### PR TITLE
lpc11uxx: Clean up SVD file

### DIFF
--- a/lpc11uxx/README.md
+++ b/lpc11uxx/README.md
@@ -5,5 +5,7 @@ microcontrollers. The code is generated automatically from the [SVD
 file](http://ds.arm.com/media/resources/db/chip/nxp/lpc11u24fbd48_301/LPC11Uxx.svd)
 using [svd2rust](https://crates.io/crates/svd2rust) 0.14.
 
+LPC11U3x/2x/1x user manual: [https://gab.wallawalla.edu/~curt.nelson/engr355/datasheets/lpc11u24/user%20manual.pdf](https://gab.wallawalla.edu/~curt.nelson/engr355/datasheets/lpc11u24/user%20manual.pdf)
+
 This crate is part of the [lpc-pac](https://github.com/lpc-rs/lpc-pac/)
 project.

--- a/lpc11uxx/lpc11uxx.svd
+++ b/lpc11uxx/lpc11uxx.svd
@@ -283,12 +283,12 @@ v7 updates:
 							<enumeratedValues>
 								<name>ENUM</name>
 								<enumeratedValue>
-									<name>MONITOR_MODE_DISABLE</name>
+									<name>DISABLED</name>
 									<description>Monitor mode disabled.</description>
 									<value>0</value>
 								</enumeratedValue>
 								<enumeratedValue>
-									<name>THE_I2C_MODULE_WILL_</name>
+									<name>ENABLED</name>
 									<description>The I2C module will enter monitor mode. In this mode the SDA output will be forced high. This will prevent the I2C module from outputting data of any kind (including ACK) onto the I 2C data bus. Depending on the state of the ENA_SCL bit, the output may be also forced high, preventing the module from having control over the I2C clock line.</description>
 									<value>1</value>
 								</enumeratedValue>
@@ -599,7 +599,7 @@ v7 updates:
 									<value>0</value>
 								</enumeratedValue>
 								<enumeratedValue>
-									<name>WATCHDOG_OSCILLATOR_</name>
+									<name>WATCHDOG_OSCILLATOR</name>
 									<description>Watchdog oscillator (WDOSC)</description>
 									<value>1</value>
 								</enumeratedValue>
@@ -854,12 +854,12 @@ v7 updates:
 							<enumeratedValues>
 								<name>ENUM</name>
 								<enumeratedValue>
-									<name>DISABLE_END_OF_AUTO_</name>
+									<name>DISABLED</name>
 									<description>Disable end of auto-baud Interrupt.</description>
 									<value>0</value>
 								</enumeratedValue>
 								<enumeratedValue>
-									<name>ENABLE_END_OF_AUTO_B</name>
+									<name>ENABLED</name>
 									<description>Enable end of auto-baud Interrupt.</description>
 									<value>1</value>
 								</enumeratedValue>
@@ -872,12 +872,12 @@ v7 updates:
 							<enumeratedValues>
 								<name>ENUM</name>
 								<enumeratedValue>
-									<name>DISABLE_AUTO_BAUD_TI</name>
+									<name>DISABLED</name>
 									<description>Disable auto-baud time-out Interrupt.</description>
 									<value>0</value>
 								</enumeratedValue>
 								<enumeratedValue>
-									<name>ENABLE_AUTO_BAUD_TIM</name>
+									<name>ENABLED</name>
 									<description>Enable auto-baud time-out Interrupt.</description>
 									<value>1</value>
 								</enumeratedValue>
@@ -906,12 +906,12 @@ v7 updates:
 							<enumeratedValues>
 								<name>ENUM</name>
 								<enumeratedValue>
-									<name>AT_LEAST_ONE_INTERRU</name>
+									<name>PENDING</name>
 									<description>At least one interrupt is pending.</description>
 									<value>0</value>
 								</enumeratedValue>
 								<enumeratedValue>
-									<name>NO_INTERRUPT_IS_PEND</name>
+									<name>NONE</name>
 									<description>No interrupt is pending.</description>
 									<value>1</value>
 								</enumeratedValue>
@@ -924,27 +924,27 @@ v7 updates:
 							<enumeratedValues>
 								<name>ENUM</name>
 								<enumeratedValue>
-									<name>1_RECEIVE_LINE_S</name>
+									<name>RECEIVE_LINE_STATUS</name>
 									<description>1   - Receive Line Status (RLS).</description>
 									<value>0x3</value>
 								</enumeratedValue>
 								<enumeratedValue>
-									<name>2A_RECEIVE_DATA_AV</name>
+									<name>RECEIVE_DATA_AVAILABLE</name>
 									<description>2a - Receive Data Available (RDA).</description>
 									<value>0x2</value>
 								</enumeratedValue>
 								<enumeratedValue>
-									<name>2B_CHARACTER_TIME_</name>
+									<name>CHARACTER_TIMEOUT_INDICATOR</name>
 									<description>2b - Character Time-out Indicator (CTI).</description>
 									<value>0x6</value>
 								</enumeratedValue>
 								<enumeratedValue>
-									<name>3_THRE_INTERRUPT</name>
+									<name>THRE_INTERRUPT</name>
 									<description>3   - THRE Interrupt.</description>
 									<value>0x1</value>
 								</enumeratedValue>
 								<enumeratedValue>
-									<name>4_MODEM_STATUS</name>
+									<name>MODEM_STATUS</name>
 									<description>4   - Modem status</description>
 									<value>0x0</value>
 								</enumeratedValue>
@@ -1063,22 +1063,22 @@ v7 updates:
 							<enumeratedValues>
 								<name>ENUM</name>
 								<enumeratedValue>
-									<name>TRIGGER_LEVEL_0_1_C</name>
+									<name>LEVEL0</name>
 									<description>Trigger level 0 (1 character or 0x01).</description>
 									<value>0x0</value>
 								</enumeratedValue>
 								<enumeratedValue>
-									<name>TRIGGER_LEVEL_1_4_C</name>
+									<name>LEVEL1</name>
 									<description>Trigger level 1 (4 characters or 0x04).</description>
 									<value>0x1</value>
 								</enumeratedValue>
 								<enumeratedValue>
-									<name>TRIGGER_LEVEL_2_8_C</name>
+									<name>LEVEL2</name>
 									<description>Trigger level 2 (8 characters or 0x08).</description>
 									<value>0x2</value>
 								</enumeratedValue>
 								<enumeratedValue>
-									<name>TRIGGER_LEVEL_3_14_</name>
+									<name>LEVEL3</name>
 									<description>Trigger level 3 (14 characters or 0x0E).</description>
 									<value>0x3</value>
 								</enumeratedValue>
@@ -1135,12 +1135,12 @@ v7 updates:
 							<enumeratedValues>
 								<name>ENUM</name>
 								<enumeratedValue>
-									<name>1_STOP_BIT_</name>
+									<name>1_STOP_BIT</name>
 									<description>1 stop bit.</description>
 									<value>0</value>
 								</enumeratedValue>
 								<enumeratedValue>
-									<name>2_STOP_BITS_1_5_IF_</name>
+									<name>2_STOP_BITS_1_5_IF</name>
 									<description>2 stop bits (1.5 if LCR[1:0]=00).</description>
 									<value>1</value>
 								</enumeratedValue>
@@ -1153,12 +1153,12 @@ v7 updates:
 							<enumeratedValues>
 								<name>ENUM</name>
 								<enumeratedValue>
-									<name>DISABLE_PARITY_GENER</name>
+									<name>DISABLED</name>
 									<description>Disable parity generation and checking.</description>
 									<value>0</value>
 								</enumeratedValue>
 								<enumeratedValue>
-									<name>ENABLE_PARITY_GENERA</name>
+									<name>ENABLED</name>
 									<description>Enable parity generation and checking.</description>
 									<value>1</value>
 								</enumeratedValue>
@@ -1171,22 +1171,22 @@ v7 updates:
 							<enumeratedValues>
 								<name>ENUM</name>
 								<enumeratedValue>
-									<name>ODD_PARITY_NUMBER_O</name>
+									<name>ODD</name>
 									<description>Odd parity. Number of 1s in the transmitted character and the attached parity bit will be odd.</description>
 									<value>0x0</value>
 								</enumeratedValue>
 								<enumeratedValue>
-									<name>EVEN_PARITY_NUMBER_</name>
+									<name>EVEN</name>
 									<description>Even Parity. Number of 1s in the transmitted character and the attached parity bit will be even.</description>
 									<value>0x1</value>
 								</enumeratedValue>
 								<enumeratedValue>
-									<name>FORCED_1_STICK_PARIT</name>
+									<name>FORCED_1_STICK</name>
 									<description>Forced 1 stick parity.</description>
 									<value>0x2</value>
 								</enumeratedValue>
 								<enumeratedValue>
-									<name>FORCED_0_STICK_PARIT</name>
+									<name>FORCED_0_STICK</name>
 									<description>Forced 0 stick parity.</description>
 									<value>0x3</value>
 								</enumeratedValue>
@@ -1346,12 +1346,12 @@ v7 updates:
 							<enumeratedValues>
 								<name>ENUM</name>
 								<enumeratedValue>
-									<name>RBR_IS_EMPTY_</name>
+									<name>EMPTY</name>
 									<description>RBR is empty.</description>
 									<value>0</value>
 								</enumeratedValue>
 								<enumeratedValue>
-									<name>RBR_CONTAINS_VALID_D</name>
+									<name>VALID</name>
 									<description>RBR contains valid data.</description>
 									<value>1</value>
 								</enumeratedValue>
@@ -1436,12 +1436,12 @@ v7 updates:
 							<enumeratedValues>
 								<name>ENUM</name>
 								<enumeratedValue>
-									<name>THR_CONTAINS_VALID_D</name>
+									<name>VALID</name>
 									<description>THR contains valid data.</description>
 									<value>0</value>
 								</enumeratedValue>
 								<enumeratedValue>
-									<name>THR_IS_EMPTY_</name>
+									<name>EMPTY</name>
 									<description>THR is empty.</description>
 									<value>1</value>
 								</enumeratedValue>
@@ -1454,7 +1454,7 @@ v7 updates:
 							<enumeratedValues>
 								<name>ENUM</name>
 								<enumeratedValue>
-									<name>VALID_D</name>
+									<name>VALID</name>
 									<description>THR and/or the TSR contains valid data.</description>
 									<value>0</value>
 								</enumeratedValue>
@@ -1663,12 +1663,12 @@ v7 updates:
 							<enumeratedValues>
 								<name>ENUM</name>
 								<enumeratedValue>
-									<name>MODE_0_</name>
+									<name>MODE0</name>
 									<description>Mode 0.</description>
 									<value>0</value>
 								</enumeratedValue>
 								<enumeratedValue>
-									<name>MODE_1_</name>
+									<name>MODE1</name>
 									<description>Mode 1.</description>
 									<value>1</value>
 								</enumeratedValue>
@@ -1757,12 +1757,12 @@ v7 updates:
 							<enumeratedValues>
 								<name>ENUM</name>
 								<enumeratedValue>
-									<name>IRDA_MODE_IS_DISABLE</name>
+									<name>DISABLED</name>
 									<description>IrDA mode is disabled, USARTn acts as a standard USART.</description>
 									<value>0</value>
 								</enumeratedValue>
 								<enumeratedValue>
-									<name>IRDA_MODE_IS_ENABLED</name>
+									<name>ENABLED</name>
 									<description>IrDA mode is enabled.</description>
 									<value>1</value>
 								</enumeratedValue>
@@ -1960,12 +1960,12 @@ v7 updates:
 							<enumeratedValues>
 								<name>ENUM</name>
 								<enumeratedValue>
-									<name>DISABLE_HALF_DUPLEX_</name>
+									<name>DISABLED</name>
 									<description>Disable half-duplex mode.</description>
 									<value>0</value>
 								</enumeratedValue>
 								<enumeratedValue>
-									<name>ENABLE_HALF_DUPLEX_M</name>
+									<name>ENABLED</name>
 									<description>Enable half-duplex mode.</description>
 									<value>1</value>
 								</enumeratedValue>
@@ -2100,12 +2100,12 @@ v7 updates:
 							<enumeratedValues>
 								<name>ENUM</name>
 								<enumeratedValue>
-									<name>THE_RECEIVER_IS_ENAB</name>
+									<name>ENABLED</name>
 									<description>The receiver is enabled.</description>
 									<value>0</value>
 								</enumeratedValue>
 								<enumeratedValue>
-									<name>THE_RECEIVER_IS_DISA</name>
+									<name>DISABLED</name>
 									<description>The receiver is disabled.</description>
 									<value>1</value>
 								</enumeratedValue>
@@ -2118,12 +2118,12 @@ v7 updates:
 							<enumeratedValues>
 								<name>ENUM</name>
 								<enumeratedValue>
-									<name>AUTO_ADDRESS_DETECT_DISABLE</name>
+									<name>DISABLED</name>
 									<description>Auto Address Detect (AAD) is disabled.</description>
 									<value>0</value>
 								</enumeratedValue>
 								<enumeratedValue>
-									<name>AUTO_ADDRESS_DETECT_ENABLE</name>
+									<name>ENABLED</name>
 									<description>Auto Address Detect (AAD) is enabled.</description>
 									<value>1</value>
 								</enumeratedValue>
@@ -2336,12 +2336,12 @@ v7 updates:
 							<enumeratedValues>
 								<name>ENUM</name>
 								<enumeratedValue>
-									<name>SEND_START_AND_STOP_</name>
+									<name>SEND_START_STOP</name>
 									<description>Send start and stop bits as in other modes.</description>
 									<value>0</value>
 								</enumeratedValue>
 								<enumeratedValue>
-									<name>DO_NOT_SEND_STARTSTOP</name>
+									<name>DONT_SEND_START_STOP</name>
 									<description>Do not send start/stop bits.</description>
 									<value>1</value>
 								</enumeratedValue>
@@ -2354,12 +2354,12 @@ v7 updates:
 							<enumeratedValues>
 								<name>ENUM</name>
 								<enumeratedValue>
-									<name>CSCEN_IS_UNDER_SOFTW</name>
+									<name>SOFTWARE</name>
 									<description>CSCEN is under software control.</description>
 									<value>0</value>
 								</enumeratedValue>
 								<enumeratedValue>
-									<name>HARDWARE_CLEARS_CSCE</name>
+									<name>HARDWARE</name>
 									<description>Hardware clears CSCEN after each character is received.</description>
 									<value>1</value>
 								</enumeratedValue>
@@ -2473,12 +2473,12 @@ v7 updates:
 				<enumeratedValues>		
 				<name>ENUM</name>		
 					<enumeratedValue>	
-						<name>DO_NOTHING_</name>
+						<name>DO_NOTHING</name>
 						<description>Do nothing.</description>
 						<value>0</value>
 					</enumeratedValue>	
 					<enumeratedValue>	
-						<name>THE_TIMER_COUNTER_AN</name>
+						<name>RESET</name>
 						<description>The Timer Counter and the Prescale Counter are synchronously reset on the next positive edge of PCLK. The counters remain reset until TCR[1] is returned to zero.</description>
 						<value>1</value>
 					</enumeratedValue>	
@@ -2822,12 +2822,12 @@ v7 updates:
 				<enumeratedValues>		
 				<name>ENUM</name>		
 					<enumeratedValue>	
-						<name>ENABLED_</name>
+						<name>ENABLED</name>
 						<description>Enabled.</description>
 						<value>1</value>
 					</enumeratedValue>	
 					<enumeratedValue>	
-						<name>DISABLED_</name>
+						<name>DISABLED</name>
 						<description>Disabled.</description>
 						<value>0</value>
 					</enumeratedValue>	
@@ -2840,12 +2840,12 @@ v7 updates:
 				<enumeratedValues>		
 				<name>ENUM</name>		
 					<enumeratedValue>	
-						<name>ENABLED_</name>
+						<name>ENABLED</name>
 						<description>Enabled.</description>
 						<value>1</value>
 					</enumeratedValue>	
 					<enumeratedValue>	
-						<name>DISABLED_</name>
+						<name>DISABLED</name>
 						<description>Disabled.</description>
 						<value>0</value>
 					</enumeratedValue>	
@@ -2858,12 +2858,12 @@ v7 updates:
 				<enumeratedValues>		
 				<name>ENUM</name>		
 					<enumeratedValue>	
-						<name>ENABLED_</name>
+						<name>ENABLED</name>
 						<description>Enabled.</description>
 						<value>1</value>
 					</enumeratedValue>	
 					<enumeratedValue>	
-						<name>DISABLED_</name>
+						<name>DISABLED</name>
 						<description>Disabled.</description>
 						<value>0</value>
 					</enumeratedValue>	
@@ -2894,12 +2894,12 @@ v7 updates:
 				<enumeratedValues>		
 				<name>ENUM</name>		
 					<enumeratedValue>	
-						<name>ENABLED_</name>
+						<name>ENABLED</name>
 						<description>Enabled.</description>
 						<value>1</value>
 					</enumeratedValue>	
 					<enumeratedValue>	
-						<name>DISABLED_</name>
+						<name>DISABLED</name>
 						<description>Disabled.</description>
 						<value>0</value>
 					</enumeratedValue>	
@@ -2912,12 +2912,12 @@ v7 updates:
 				<enumeratedValues>		
 				<name>ENUM</name>		
 					<enumeratedValue>	
-						<name>ENABLED_</name>
+						<name>ENABLED</name>
 						<description>Enabled.</description>
 						<value>1</value>
 					</enumeratedValue>	
 					<enumeratedValue>	
-						<name>DISABLED_</name>
+						<name>DISABLED</name>
 						<description>Disabled.</description>
 						<value>0</value>
 					</enumeratedValue>	
@@ -2930,12 +2930,12 @@ v7 updates:
 				<enumeratedValues>		
 				<name>ENUM</name>		
 					<enumeratedValue>	
-						<name>ENABLED_</name>
+						<name>ENABLED</name>
 						<description>Enabled.</description>
 						<value>1</value>
 					</enumeratedValue>	
 					<enumeratedValue>	
-						<name>DISABLED_</name>
+						<name>DISABLED</name>
 						<description>Disabled.</description>
 						<value>0</value>
 					</enumeratedValue>	
@@ -3028,22 +3028,22 @@ v7 updates:
 				<enumeratedValues>		
 				<name>ENUM</name>		
 					<enumeratedValue>	
-						<name>DO_NOTHING_</name>
+						<name>DO_NOTHING</name>
 						<description>Do Nothing.</description>
 						<value>0x0</value>
 					</enumeratedValue>	
 					<enumeratedValue>	
-						<name>CLEAR_THE_CORRESPOND</name>
+						<name>CLEAR</name>
 						<description>Clear the corresponding External Match bit/output to 0 (CT16Bn_MAT0 pin is LOW if pinned out).</description>
 						<value>0x1</value>
 					</enumeratedValue>	
 					<enumeratedValue>	
-						<name>SET_THE_CORRESPONDIN</name>
+						<name>SET</name>
 						<description>Set the corresponding External Match bit/output to 1 (CT16Bn_MAT0 pin is HIGH if pinned out).</description>
 						<value>0x2</value>
 					</enumeratedValue>	
 					<enumeratedValue>	
-						<name>TOGGLE_THE_CORRESPON</name>
+						<name>TOGGLE</name>
 						<description>Toggle the corresponding External Match bit/output.</description>
 						<value>0x3</value>
 					</enumeratedValue>	
@@ -3056,22 +3056,22 @@ v7 updates:
 				<enumeratedValues>		
 				<name>ENUM</name>		
 					<enumeratedValue>	
-						<name>DO_NOTHING_</name>
+						<name>DO_NOTHING</name>
 						<description>Do Nothing.</description>
 						<value>0x0</value>
 					</enumeratedValue>	
 					<enumeratedValue>	
-						<name>CLEAR_THE_CORRESPOND</name>
+						<name>CLEAR</name>
 						<description>Clear the corresponding External Match bit/output to 0 (CT16Bn_MAT1 pin is LOW if pinned out).</description>
 						<value>0x1</value>
 					</enumeratedValue>	
 					<enumeratedValue>	
-						<name>SET_THE_CORRESPONDIN</name>
+						<name>SET</name>
 						<description>Set the corresponding External Match bit/output to 1 (CT16Bn_MAT1 pin is HIGH if pinned out).</description>
 						<value>0x2</value>
 					</enumeratedValue>	
 					<enumeratedValue>	
-						<name>TOGGLE_THE_CORRESPON</name>
+						<name>TOGGLE</name>
 						<description>Toggle the corresponding External Match bit/output.</description>
 						<value>0x3</value>
 					</enumeratedValue>	
@@ -3084,22 +3084,22 @@ v7 updates:
 				<enumeratedValues>		
 				<name>ENUM</name>		
 					<enumeratedValue>	
-						<name>DO_NOTHING_</name>
+						<name>DO_NOTHING</name>
 						<description>Do Nothing.</description>
 						<value>0x0</value>
 					</enumeratedValue>	
 					<enumeratedValue>	
-						<name>CLEAR_THE_CORRESPOND</name>
+						<name>CLEAR</name>
 						<description>Clear the corresponding External Match bit/output to 0 (CT16Bn_MAT2 pin is LOW if pinned out).</description>
 						<value>0x1</value>
 					</enumeratedValue>	
 					<enumeratedValue>	
-						<name>SET_THE_CORRESPONDIN</name>
+						<name>SET</name>
 						<description>Set the corresponding External Match bit/output to 1 (CT16Bn_MAT2 pin is HIGH if pinned out).</description>
 						<value>0x2</value>
 					</enumeratedValue>	
 					<enumeratedValue>	
-						<name>TOGGLE_THE_CORRESPON</name>
+						<name>TOGGLE</name>
 						<description>Toggle the corresponding External Match bit/output.</description>
 						<value>0x3</value>
 					</enumeratedValue>	
@@ -3112,22 +3112,22 @@ v7 updates:
 				<enumeratedValues>		
 				<name>ENUM</name>		
 					<enumeratedValue>	
-						<name>DO_NOTHING_</name>
+						<name>DO_NOTHING</name>
 						<description>Do Nothing.</description>
 						<value>0x0</value>
 					</enumeratedValue>	
 					<enumeratedValue>	
-						<name>CLEAR_THE_CORRESPOND</name>
+						<name>CLEAR</name>
 						<description>Clear the corresponding External Match bit/output to 0 (CT16Bn_MAT3 pin is LOW if pinned out).</description>
 						<value>0x1</value>
 					</enumeratedValue>	
 					<enumeratedValue>	
-						<name>SET_THE_CORRESPONDIN</name>
+						<name>SET</name>
 						<description>Set the corresponding External Match bit/output to 1 (CT16Bn_MAT3 pin is HIGH if pinned out).</description>
 						<value>0x2</value>
 					</enumeratedValue>	
 					<enumeratedValue>	
-						<name>TOGGLE_THE_CORRESPON</name>
+						<name>TOGGLE</name>
 						<description>Toggle the corresponding External Match bit/output.</description>
 						<value>0x3</value>
 					</enumeratedValue>	
@@ -3161,17 +3161,17 @@ v7 updates:
 						<value>0x0</value>
 					</enumeratedValue>	
 					<enumeratedValue>	
-						<name>COUNTER_MODE_TC_IS_RISING</name>
+						<name>RISING</name>
 						<description>Counter Mode: TC is incremented on rising edges on the CAP input selected by bits 3:2.</description>
 						<value>0x1</value>
 					</enumeratedValue>	
 					<enumeratedValue>	
-						<name>COUNTER_MODE_TC_IS_FALLING</name>
+						<name>FALLING</name>
 						<description>Counter Mode: TC is incremented on falling edges on the CAP input selected by bits 3:2.</description>
 						<value>0x2</value>
 					</enumeratedValue>	
 					<enumeratedValue>	
-						<name>COUNTER_MODE_TC_IS_BOTH</name>
+						<name>BOTH</name>
 						<description>Counter Mode: TC is incremented on both edges on the CAP input selected by bits 3:2.</description>
 						<value>0x3</value>
 					</enumeratedValue>	
@@ -3184,7 +3184,7 @@ v7 updates:
 				<enumeratedValues>		
 				<name>ENUM</name>		
 					<enumeratedValue>	
-						<name>CT16B0_CAP0_</name>
+						<name>CT16B0_CAP0</name>
 						<description>CT16B0_CAP0.</description>
 						<value>0x0</value>
 					</enumeratedValue>	
@@ -3194,7 +3194,7 @@ v7 updates:
 						<value>0x1</value>
 					</enumeratedValue>	
 					<enumeratedValue>	
-						<name>CT16B0_CAP1_</name>
+						<name>CT16B0_CAP1</name>
 						<description>CT16B0_CAP1.</description>
 						<value>0x2</value>
 					</enumeratedValue>	
@@ -3267,12 +3267,12 @@ v7 updates:
 				<enumeratedValues>		
 				<name>ENUM</name>		
 					<enumeratedValue>	
-						<name>CT16BN_MAT0_IS_CONTR</name>
+						<name>EM0</name>
 						<description>CT16Bn_MAT0 is controlled by EM0.</description>
 						<value>0</value>
 					</enumeratedValue>	
 					<enumeratedValue>	
-						<name>PWM_MODE_IS_ENABLED_</name>
+						<name>ENABLED</name>
 						<description>PWM mode is enabled for CT16Bn_MAT0.</description>
 						<value>1</value>
 					</enumeratedValue>	
@@ -3285,12 +3285,12 @@ v7 updates:
 				<enumeratedValues>		
 				<name>ENUM</name>		
 					<enumeratedValue>	
-						<name>CT16BN_MAT01_IS_CONT</name>
+						<name>EM1</name>
 						<description>CT16Bn_MAT01 is controlled by EM1.</description>
 						<value>0</value>
 					</enumeratedValue>	
 					<enumeratedValue>	
-						<name>PWM_MODE_IS_ENABLED_</name>
+						<name>ENABLED</name>
 						<description>PWM mode is enabled for CT16Bn_MAT1.</description>
 						<value>1</value>
 					</enumeratedValue>	
@@ -3303,12 +3303,12 @@ v7 updates:
 				<enumeratedValues>		
 				<name>ENUM</name>		
 					<enumeratedValue>	
-						<name>CT16BN_MAT2_IS_CONTR</name>
+						<name>EM2</name>
 						<description>CT16Bn_MAT2 is controlled by EM2.</description>
 						<value>0</value>
 					</enumeratedValue>	
 					<enumeratedValue>	
-						<name>PWM_MODE_IS_ENABLED_</name>
+						<name>ENABLED</name>
 						<description>PWM mode is enabled for CT16Bn_MAT2.</description>
 						<value>1</value>
 					</enumeratedValue>	
@@ -3321,12 +3321,12 @@ v7 updates:
 				<enumeratedValues>		
 				<name>ENUM</name>		
 					<enumeratedValue>	
-						<name>CT16BN_MAT3_IS_CONTR</name>
+						<name>EM3</name>
 						<description>CT16Bn_MAT3 is controlled by EM3.</description>
 						<value>0</value>
 					</enumeratedValue>	
 					<enumeratedValue>	
-						<name>PWM_MODE_IS_ENABLED_</name>
+						<name>ENABLED</name>
 						<description>PWM mode is enabled for CT16Bn_MAT3.</description>
 						<value>1</value>
 					</enumeratedValue>	
@@ -3441,12 +3441,12 @@ v7 updates:
 				<enumeratedValues>		
 				<name>ENUM</name>		
 					<enumeratedValue>	
-						<name>DO_NOTHING_</name>
+						<name>DO_NOTHING</name>
 						<description>Do nothing.</description>
 						<value>0</value>
 					</enumeratedValue>	
 					<enumeratedValue>	
-						<name>THE_TIMER_COUNTER_AN</name>
+						<name>RESET</name>
 						<description>The Timer Counter and the Prescale Counter are synchronously reset on the next positive edge of PCLK. The counters remain reset until TCR[1] is returned to zero.</description>
 						<value>1</value>
 					</enumeratedValue>	
@@ -3790,12 +3790,12 @@ v7 updates:
 				<enumeratedValues>		
 				<name>ENUM</name>		
 					<enumeratedValue>	
-						<name>ENABLED_</name>
+						<name>ENABLED</name>
 						<description>Enabled.</description>
 						<value>1</value>
 					</enumeratedValue>	
 					<enumeratedValue>	
-						<name>DISABLED_</name>
+						<name>DISABLED</name>
 						<description>Disabled.</description>
 						<value>0</value>
 					</enumeratedValue>	
@@ -3808,12 +3808,12 @@ v7 updates:
 				<enumeratedValues>		
 				<name>ENUM</name>		
 					<enumeratedValue>	
-						<name>ENABLED_</name>
+						<name>ENABLED</name>
 						<description>Enabled.</description>
 						<value>1</value>
 					</enumeratedValue>	
 					<enumeratedValue>	
-						<name>DISABLED_</name>
+						<name>DISABLED</name>
 						<description>Disabled.</description>
 						<value>0</value>
 					</enumeratedValue>	
@@ -3826,12 +3826,12 @@ v7 updates:
 				<enumeratedValues>		
 				<name>ENUM</name>		
 					<enumeratedValue>	
-						<name>ENABLED_</name>
+						<name>ENABLED</name>
 						<description>Enabled.</description>
 						<value>1</value>
 					</enumeratedValue>	
 					<enumeratedValue>	
-						<name>DISABLED_</name>
+						<name>DISABLED</name>
 						<description>Disabled.</description>
 						<value>0</value>
 					</enumeratedValue>	
@@ -3844,12 +3844,12 @@ v7 updates:
 				<enumeratedValues>		
 				<name>ENUM</name>		
 					<enumeratedValue>	
-						<name>ENABLED_</name>
+						<name>ENABLED</name>
 						<description>Enabled.</description>
 						<value>1</value>
 					</enumeratedValue>	
 					<enumeratedValue>	
-						<name>DISABLED_</name>
+						<name>DISABLED</name>
 						<description>Disabled.</description>
 						<value>0</value>
 					</enumeratedValue>	
@@ -3862,12 +3862,12 @@ v7 updates:
 				<enumeratedValues>		
 				<name>ENUM</name>		
 					<enumeratedValue>	
-						<name>ENABLED_</name>
+						<name>ENABLED</name>
 						<description>Enabled.</description>
 						<value>1</value>
 					</enumeratedValue>	
 					<enumeratedValue>	
-						<name>DISABLED_</name>
+						<name>DISABLED</name>
 						<description>Disabled.</description>
 						<value>0</value>
 					</enumeratedValue>	
@@ -3880,12 +3880,12 @@ v7 updates:
 				<enumeratedValues>		
 				<name>ENUM</name>		
 					<enumeratedValue>	
-						<name>ENABLED_</name>
+						<name>ENABLED</name>
 						<description>Enabled.</description>
 						<value>1</value>
 					</enumeratedValue>	
 					<enumeratedValue>	
-						<name>DISABLED_</name>
+						<name>DISABLED</name>
 						<description>Disabled.</description>
 						<value>0</value>
 					</enumeratedValue>	
@@ -3978,22 +3978,22 @@ v7 updates:
 				<enumeratedValues>		
 				<name>ENUM</name>		
 					<enumeratedValue>	
-						<name>DO_NOTHING_</name>
+						<name>DO_NOTHING</name>
 						<description>Do Nothing.</description>
 						<value>0x0</value>
 					</enumeratedValue>	
 					<enumeratedValue>	
-						<name>CLEAR_THE_CORRESPOND</name>
+						<name>CLEAR</name>
 						<description>Clear the corresponding External Match bit/output to 0 (CT16Bn_MAT0 pin is LOW if pinned out).</description>
 						<value>0x1</value>
 					</enumeratedValue>	
 					<enumeratedValue>	
-						<name>SET_THE_CORRESPONDIN</name>
+						<name>SET</name>
 						<description>Set the corresponding External Match bit/output to 1 (CT16Bn_MAT0 pin is HIGH if pinned out).</description>
 						<value>0x2</value>
 					</enumeratedValue>	
 					<enumeratedValue>	
-						<name>TOGGLE_THE_CORRESPON</name>
+						<name>TOGGLE</name>
 						<description>Toggle the corresponding External Match bit/output.</description>
 						<value>0x3</value>
 					</enumeratedValue>	
@@ -4006,22 +4006,22 @@ v7 updates:
 				<enumeratedValues>		
 				<name>ENUM</name>		
 					<enumeratedValue>	
-						<name>DO_NOTHING_</name>
+						<name>DO_NOTHING</name>
 						<description>Do Nothing.</description>
 						<value>0x0</value>
 					</enumeratedValue>	
 					<enumeratedValue>	
-						<name>CLEAR_THE_CORRESPOND</name>
+						<name>CLEAR</name>
 						<description>Clear the corresponding External Match bit/output to 0 (CT16Bn_MAT1 pin is LOW if pinned out).</description>
 						<value>0x1</value>
 					</enumeratedValue>	
 					<enumeratedValue>	
-						<name>SET_THE_CORRESPONDIN</name>
+						<name>SET</name>
 						<description>Set the corresponding External Match bit/output to 1 (CT16Bn_MAT1 pin is HIGH if pinned out).</description>
 						<value>0x2</value>
 					</enumeratedValue>	
 					<enumeratedValue>	
-						<name>TOGGLE_THE_CORRESPON</name>
+						<name>TOGGLE</name>
 						<description>Toggle the corresponding External Match bit/output.</description>
 						<value>0x3</value>
 					</enumeratedValue>	
@@ -4034,22 +4034,22 @@ v7 updates:
 				<enumeratedValues>		
 				<name>ENUM</name>		
 					<enumeratedValue>	
-						<name>DO_NOTHING_</name>
+						<name>DO_NOTHING</name>
 						<description>Do Nothing.</description>
 						<value>0x0</value>
 					</enumeratedValue>	
 					<enumeratedValue>	
-						<name>CLEAR_THE_CORRESPOND</name>
+						<name>CLEAR</name>
 						<description>Clear the corresponding External Match bit/output to 0 (CT16Bn_MAT2 pin is LOW if pinned out).</description>
 						<value>0x1</value>
 					</enumeratedValue>	
 					<enumeratedValue>	
-						<name>SET_THE_CORRESPONDIN</name>
+						<name>SET</name>
 						<description>Set the corresponding External Match bit/output to 1 (CT16Bn_MAT2 pin is HIGH if pinned out).</description>
 						<value>0x2</value>
 					</enumeratedValue>	
 					<enumeratedValue>	
-						<name>TOGGLE_THE_CORRESPON</name>
+						<name>TOGGLE</name>
 						<description>Toggle the corresponding External Match bit/output.</description>
 						<value>0x3</value>
 					</enumeratedValue>	
@@ -4062,22 +4062,22 @@ v7 updates:
 				<enumeratedValues>		
 				<name>ENUM</name>		
 					<enumeratedValue>	
-						<name>DO_NOTHING_</name>
+						<name>DO_NOTHING</name>
 						<description>Do Nothing.</description>
 						<value>0x0</value>
 					</enumeratedValue>	
 					<enumeratedValue>	
-						<name>CLEAR_THE_CORRESPOND</name>
+						<name>CLEAR</name>
 						<description>Clear the corresponding External Match bit/output to 0 (CT16Bn_MAT3 pin is LOW if pinned out).</description>
 						<value>0x1</value>
 					</enumeratedValue>	
 					<enumeratedValue>	
-						<name>SET_THE_CORRESPONDIN</name>
+						<name>SET</name>
 						<description>Set the corresponding External Match bit/output to 1 (CT16Bn_MAT3 pin is HIGH if pinned out).</description>
 						<value>0x2</value>
 					</enumeratedValue>	
 					<enumeratedValue>	
-						<name>TOGGLE_THE_CORRESPON</name>
+						<name>TOGGLE</name>
 						<description>Toggle the corresponding External Match bit/output.</description>
 						<value>0x3</value>
 					</enumeratedValue>	
@@ -4111,17 +4111,17 @@ v7 updates:
 						<value>0x0</value>
 					</enumeratedValue>	
 					<enumeratedValue>	
-						<name>COUNTER_MODE_TC_IS_RISING</name>
+						<name>RISING</name>
 						<description>Counter Mode: TC is incremented on rising edges on the CAP input selected by bits 3:2.</description>
 						<value>0x1</value>
 					</enumeratedValue>	
 					<enumeratedValue>	
-						<name>COUNTER_MODE_TC_IS_FALLING</name>
+						<name>FALLING</name>
 						<description>Counter Mode: TC is incremented on falling edges on the CAP input selected by bits 3:2.</description>
 						<value>0x2</value>
 					</enumeratedValue>	
 					<enumeratedValue>	
-						<name>COUNTER_MODE_TC_IS_BOTH</name>
+						<name>BOTH</name>
 						<description>Counter Mode: TC is incremented on both edges on the CAP input selected by bits 3:2.</description>
 						<value>0x3</value>
 					</enumeratedValue>	
@@ -4134,12 +4134,12 @@ v7 updates:
 				<enumeratedValues>		
 				<name>ENUM</name>		
 					<enumeratedValue>	
-						<name>CT16B1_CAP0_</name>
+						<name>CT16B1_CAP0</name>
 						<description>CT16B1_CAP0.</description>
 						<value>0x0</value>
 					</enumeratedValue>	
 					<enumeratedValue>	
-						<name>CT16B1_CAP1_</name>
+						<name>CT16B1_CAP1</name>
 						<description>CT16B1_CAP1.</description>
 						<value>0x1</value>
 					</enumeratedValue>	
@@ -4212,12 +4212,12 @@ v7 updates:
 				<enumeratedValues>		
 				<name>ENUM</name>		
 					<enumeratedValue>	
-						<name>CT16BN_MAT0_IS_CONTR</name>
+						<name>EM0</name>
 						<description>CT16Bn_MAT0 is controlled by EM0.</description>
 						<value>0</value>
 					</enumeratedValue>	
 					<enumeratedValue>	
-						<name>PWM_MODE_IS_ENABLED_</name>
+						<name>ENABLED</name>
 						<description>PWM mode is enabled for CT16Bn_MAT0.</description>
 						<value>1</value>
 					</enumeratedValue>	
@@ -4230,12 +4230,12 @@ v7 updates:
 				<enumeratedValues>		
 				<name>ENUM</name>		
 					<enumeratedValue>	
-						<name>CT16BN_MAT01_IS_CONT</name>
+						<name>EM1</name>
 						<description>CT16Bn_MAT01 is controlled by EM1.</description>
 						<value>0</value>
 					</enumeratedValue>	
 					<enumeratedValue>	
-						<name>PWM_MODE_IS_ENABLED_</name>
+						<name>ENABLED</name>
 						<description>PWM mode is enabled for CT16Bn_MAT1.</description>
 						<value>1</value>
 					</enumeratedValue>	
@@ -4248,12 +4248,12 @@ v7 updates:
 				<enumeratedValues>		
 				<name>ENUM</name>		
 					<enumeratedValue>	
-						<name>CT16BN_MAT2_IS_CONTR</name>
+						<name>EM2</name>
 						<description>CT16Bn_MAT2 is controlled by EM2.</description>
 						<value>0</value>
 					</enumeratedValue>	
 					<enumeratedValue>	
-						<name>PWM_MODE_IS_ENABLED_</name>
+						<name>ENABLED</name>
 						<description>PWM mode is enabled for CT16Bn_MAT2.</description>
 						<value>1</value>
 					</enumeratedValue>	
@@ -4266,12 +4266,12 @@ v7 updates:
 				<enumeratedValues>		
 				<name>ENUM</name>		
 					<enumeratedValue>	
-						<name>CT16BN_MAT3_IS_CONTR</name>
+						<name>EM3</name>
 						<description>CT16Bn_MAT3 is controlled by EM3.</description>
 						<value>0</value>
 					</enumeratedValue>	
 					<enumeratedValue>	
-						<name>PWM_MODE_IS_ENABLED_</name>
+						<name>ENABLED</name>
 						<description>PWM mode is enabled for CT16Bn_MAT3.</description>
 						<value>1</value>
 					</enumeratedValue>	
@@ -4387,12 +4387,12 @@ v7 updates:
 				<enumeratedValues>																			
 				<name>ENUM</name>																			
 					<enumeratedValue>																		
-						<name>DO_NOTHING_</name>																	
+						<name>DO_NOTHING</name>																	
 						<description>Do nothing.</description>																	
 						<value>0</value>																	
 					</enumeratedValue>																		
 					<enumeratedValue>																		
-						<name>THE_TIMER_COUNTER_AN</name>																	
+						<name>RESET</name>																	
 						<description>The Timer Counter and the Prescale Counter are synchronously reset on the next positive edge of PCLK. The counters remain reset until TCR[1] is returned to zero.</description>																	
 						<value>1</value>																	
 					</enumeratedValue>																		
@@ -4716,12 +4716,12 @@ v7 updates:
 				<enumeratedValues>																			
 				<name>ENUM</name>																			
 					<enumeratedValue>																		
-						<name>ENABLED_</name>																	
+						<name>ENABLED</name>																	
 						<description>Enabled.</description>																	
 						<value>1</value>																	
 					</enumeratedValue>																		
 					<enumeratedValue>																		
-						<name>DISABLED_</name>																	
+						<name>DISABLED</name>																	
 						<description>Disabled.</description>																	
 						<value>0</value>																	
 					</enumeratedValue>																		
@@ -4734,12 +4734,12 @@ v7 updates:
 				<enumeratedValues>																			
 				<name>ENUM</name>																			
 					<enumeratedValue>																		
-						<name>ENABLED_</name>																	
+						<name>ENABLED</name>																	
 						<description>Enabled.</description>																	
 						<value>1</value>																	
 					</enumeratedValue>																		
 					<enumeratedValue>																		
-						<name>DISABLED_</name>																	
+						<name>DISABLED</name>																	
 						<description>Disabled.</description>																	
 						<value>0</value>																	
 					</enumeratedValue>																		
@@ -4752,12 +4752,12 @@ v7 updates:
 				<enumeratedValues>																			
 				<name>ENUM</name>																			
 					<enumeratedValue>																		
-						<name>ENABLED_</name>																	
+						<name>ENABLED</name>																	
 						<description>Enabled.</description>																	
 						<value>1</value>																	
 					</enumeratedValue>																		
 					<enumeratedValue>																		
-						<name>DISABLED_</name>																	
+						<name>DISABLED</name>																	
 						<description>Disabled.</description>																	
 						<value>0</value>																	
 					</enumeratedValue>																		
@@ -4776,12 +4776,12 @@ v7 updates:
 				<enumeratedValues>																			
 				<name>ENUM</name>																			
 					<enumeratedValue>																		
-						<name>ENABLED_</name>																	
+						<name>ENABLED</name>																	
 						<description>Enabled.</description>																	
 						<value>1</value>																	
 					</enumeratedValue>																		
 					<enumeratedValue>																		
-						<name>DISABLED_</name>																	
+						<name>DISABLED</name>																	
 						<description>Disabled.</description>																	
 						<value>0</value>																	
 					</enumeratedValue>																		
@@ -4794,12 +4794,12 @@ v7 updates:
 				<enumeratedValues>																			
 				<name>ENUM</name>																			
 					<enumeratedValue>																		
-						<name>ENABLED_</name>																	
+						<name>ENABLED</name>																	
 						<description>Enabled.</description>																	
 						<value>1</value>																	
 					</enumeratedValue>																		
 					<enumeratedValue>																		
-						<name>DISABLED_</name>																	
+						<name>DISABLED</name>																	
 						<description>Disabled.</description>																	
 						<value>0</value>																	
 					</enumeratedValue>																		
@@ -4812,12 +4812,12 @@ v7 updates:
 				<enumeratedValues>																			
 				<name>ENUM</name>																			
 					<enumeratedValue>																		
-						<name>ENABLED_</name>																	
+						<name>ENABLED</name>																	
 						<description>Enabled.</description>																	
 						<value>1</value>																	
 					</enumeratedValue>																		
 					<enumeratedValue>																		
-						<name>DISABLED_</name>																	
+						<name>DISABLED</name>																	
 						<description>Disabled.</description>																	
 						<value>0</value>																	
 					</enumeratedValue>																		
@@ -4902,22 +4902,22 @@ v7 updates:
 				<enumeratedValues>																			
 				<name>ENUM</name>																			
 					<enumeratedValue>																		
-						<name>DO_NOTHING_</name>																	
+						<name>DO_NOTHING</name>																	
 						<description>Do Nothing.</description>																	
 						<value>0x0</value>																	
 					</enumeratedValue>																		
 					<enumeratedValue>																		
-						<name>CLEAR_THE_CORRESPOND</name>																	
+						<name>CLEAR</name>																	
 						<description>Clear the corresponding External Match bit/output to 0 (CT32Bi_MAT0 pin is LOW if pinned out).</description>																	
 						<value>0x1</value>																	
 					</enumeratedValue>																		
 					<enumeratedValue>																		
-						<name>SET_THE_CORRESPONDIN</name>																	
+						<name>SET</name>																	
 						<description>Set the corresponding External Match bit/output to 1 (CT32Bi_MAT0 pin is HIGH if pinned out).</description>																	
 						<value>0x2</value>																	
 					</enumeratedValue>																		
 					<enumeratedValue>																		
-						<name>TOGGLE_THE_CORRESPON</name>																	
+						<name>TOGGLE</name>																	
 						<description>Toggle the corresponding External Match bit/output.</description>																	
 						<value>0x3</value>																	
 					</enumeratedValue>																		
@@ -4930,22 +4930,22 @@ v7 updates:
 				<enumeratedValues>																			
 				<name>ENUM</name>																			
 					<enumeratedValue>																		
-						<name>DO_NOTHING_</name>																	
+						<name>DO_NOTHING</name>																	
 						<description>Do Nothing.</description>																	
 						<value>0x0</value>																	
 					</enumeratedValue>																		
 					<enumeratedValue>																		
-						<name>CLEAR_THE_CORRESPOND</name>																	
+						<name>CLEAR</name>																	
 						<description>Clear the corresponding External Match bit/output to 0 (CT32Bi_MAT1 pin is LOW if pinned out).</description>																	
 						<value>0x1</value>																	
 					</enumeratedValue>																		
 					<enumeratedValue>																		
-						<name>SET_THE_CORRESPONDIN</name>																	
+						<name>SET</name>																	
 						<description>Set the corresponding External Match bit/output to 1 (CT32Bi_MAT1 pin is HIGH if pinned out).</description>																	
 						<value>0x2</value>																	
 					</enumeratedValue>																		
 					<enumeratedValue>																		
-						<name>TOGGLE_THE_CORRESPON</name>																	
+						<name>TOGGLE</name>																	
 						<description>Toggle the corresponding External Match bit/output.</description>																	
 						<value>0x3</value>																	
 					</enumeratedValue>																		
@@ -4958,22 +4958,22 @@ v7 updates:
 				<enumeratedValues>																			
 				<name>ENUM</name>																			
 					<enumeratedValue>																		
-						<name>DO_NOTHING_</name>																	
+						<name>DO_NOTHING</name>																	
 						<description>Do Nothing.</description>																	
 						<value>0x0</value>																	
 					</enumeratedValue>																		
 					<enumeratedValue>																		
-						<name>CLEAR_THE_CORRESPOND</name>																	
+						<name>CLEAR</name>																	
 						<description>Clear the corresponding External Match bit/output to 0 (CT32Bi_MAT2 pin is LOW if pinned out).</description>																	
 						<value>0x1</value>																	
 					</enumeratedValue>																		
 					<enumeratedValue>																		
-						<name>SET_THE_CORRESPONDIN</name>																	
+						<name>SET</name>																	
 						<description>Set the corresponding External Match bit/output to 1 (CT32Bi_MAT2 pin is HIGH if pinned out).</description>																	
 						<value>0x2</value>																	
 					</enumeratedValue>																		
 					<enumeratedValue>																		
-						<name>TOGGLE_THE_CORRESPON</name>																	
+						<name>TOGGLE</name>																	
 						<description>Toggle the corresponding External Match bit/output.</description>																	
 						<value>0x3</value>																	
 					</enumeratedValue>																		
@@ -4986,22 +4986,22 @@ v7 updates:
 				<enumeratedValues>																			
 				<name>ENUM</name>																			
 					<enumeratedValue>																		
-						<name>DO_NOTHING_</name>																	
+						<name>DO_NOTHING</name>																	
 						<description>Do Nothing.</description>																	
 						<value>0x0</value>																	
 					</enumeratedValue>																		
 					<enumeratedValue>																		
-						<name>CLEAR_THE_CORRESPOND</name>																	
+						<name>CLEAR</name>																	
 						<description>Clear the corresponding External Match bit/output to 0 (CT32Bi_MAT3 pin is LOW if pinned out).</description>																	
 						<value>0x1</value>																	
 					</enumeratedValue>																		
 					<enumeratedValue>																		
-						<name>SET_THE_CORRESPONDIN</name>																	
+						<name>SET</name>																	
 						<description>Set the corresponding External Match bit/output to 1 (CT32Bi_MAT3 pin is HIGH if pinned out).</description>																	
 						<value>0x2</value>																	
 					</enumeratedValue>																		
 					<enumeratedValue>																		
-						<name>TOGGLE_THE_CORRESPON</name>																	
+						<name>TOGGLE</name>																	
 						<description>Toggle the corresponding External Match bit/output.</description>																	
 						<value>0x3</value>																	
 					</enumeratedValue>																		
@@ -5035,17 +5035,17 @@ v7 updates:
 						<value>0x0</value>																	
 					</enumeratedValue>																		
 					<enumeratedValue>																		
-						<name>COUNTER_MODE_TC_IS_RISING</name>
+						<name>RISING</name>
 						<description>Counter Mode: TC is incremented on rising edges on the CAP input selected by bits 3:2.</description>																	
 						<value>0x1</value>																	
 					</enumeratedValue>																		
 					<enumeratedValue>																		
-						<name>COUNTER_MODE_TC_IS_FALLING</name>
+						<name>FALLING</name>
 						<description>Counter Mode: TC is incremented on falling edges on the CAP input selected by bits 3:2.</description>																	
 						<value>0x2</value>																	
 					</enumeratedValue>																		
 					<enumeratedValue>																		
-						<name>COUNTER_MODE_TC_IS_BOTH</name>
+						<name>BOTH</name>
 						<description>Counter Mode: TC is incremented on both edges on the CAP input selected by bits 3:2.</description>																	
 						<value>0x3</value>																	
 					</enumeratedValue>																		
@@ -5142,12 +5142,12 @@ v7 updates:
 				<enumeratedValues>																			
 				<name>ENUM</name>																			
 					<enumeratedValue>																		
-						<name>CT32BN_MAT0_IS_CONTR</name>																	
+						<name>EM0</name>																	
 						<description>CT32Bn_MAT0 is controlled by EM0.</description>																	
 						<value>0</value>																	
 					</enumeratedValue>																		
 					<enumeratedValue>																		
-						<name>PWM_MODE_IS_ENABLED_</name>																	
+						<name>ENABLED</name>																	
 						<description>PWM mode is enabled for CT32Bn_MAT0.</description>																	
 						<value>1</value>																	
 					</enumeratedValue>																		
@@ -5160,12 +5160,12 @@ v7 updates:
 				<enumeratedValues>																			
 				<name>ENUM</name>																			
 					<enumeratedValue>																		
-						<name>CT32BN_MAT01_IS_CONT</name>																	
+						<name>EM1</name>																	
 						<description>CT32Bn_MAT01 is controlled by EM1.</description>																	
 						<value>0</value>																	
 					</enumeratedValue>																		
 					<enumeratedValue>																		
-						<name>PWM_MODE_IS_ENABLED_</name>																	
+						<name>ENABLED</name>																	
 						<description>PWM mode is enabled for CT32Bn_MAT1.</description>																	
 						<value>1</value>																	
 					</enumeratedValue>																		
@@ -5178,12 +5178,12 @@ v7 updates:
 				<enumeratedValues>																			
 				<name>ENUM</name>																			
 					<enumeratedValue>																		
-						<name>CT32BN_MAT2_IS_CONTR</name>																	
+						<name>EM2</name>																	
 						<description>CT32Bn_MAT2 is controlled by EM2.</description>																	
 						<value>0</value>																	
 					</enumeratedValue>																		
 					<enumeratedValue>																		
-						<name>PWM_MODE_IS_ENABLED_</name>																	
+						<name>ENABLED</name>																	
 						<description>PWM mode is enabled for CT32Bn_MAT2.</description>																	
 						<value>1</value>																	
 					</enumeratedValue>																		
@@ -5196,12 +5196,12 @@ v7 updates:
 				<enumeratedValues>																			
 				<name>ENUM</name>																			
 					<enumeratedValue>																		
-						<name>CT32BN_MAT3_IS_CONTR</name>																	
+						<name>EM3</name>																	
 						<description>CT32Bn_MAT3 is controlled by EM3.</description>																	
 						<value>0</value>																	
 					</enumeratedValue>																		
 					<enumeratedValue>																		
-						<name>PWM_MODE_IS_ENABLED_</name>																	
+						<name>ENABLED</name>																	
 						<description>PWM mode is enabled for CT132Bn_MAT3.</description>																	
 						<value>1</value>																	
 					</enumeratedValue>																		
@@ -5311,12 +5311,12 @@ v7 updates:
 				<enumeratedValues>																			
 				<name>ENUM</name>																			
 					<enumeratedValue>																		
-						<name>DO_NOTHING_</name>																	
+						<name>DO_NOTHING</name>																	
 						<description>Do nothing.</description>																	
 						<value>0</value>																	
 					</enumeratedValue>																		
 					<enumeratedValue>																		
-						<name>THE_TIMER_COUNTER_AN</name>																	
+						<name>RESET</name>																	
 						<description>The Timer Counter and the Prescale Counter are synchronously reset on the next positive edge of PCLK. The counters remain reset until TCR[1] is returned to zero.</description>																	
 						<value>1</value>																	
 					</enumeratedValue>																		
@@ -5641,12 +5641,12 @@ v7 updates:
 				<enumeratedValues>																			
 				<name>ENUM</name>																			
 					<enumeratedValue>																		
-						<name>ENABLED_</name>																	
+						<name>ENABLED</name>																	
 						<description>Enabled.</description>																	
 						<value>1</value>																	
 					</enumeratedValue>																		
 					<enumeratedValue>																		
-						<name>DISABLED_</name>																	
+						<name>DISABLED</name>																	
 						<description>Disabled.</description>																	
 						<value>0</value>																	
 					</enumeratedValue>																		
@@ -5659,12 +5659,12 @@ v7 updates:
 				<enumeratedValues>																			
 				<name>ENUM</name>																			
 					<enumeratedValue>																		
-						<name>ENABLED_</name>																	
+						<name>ENABLED</name>																	
 						<description>Enabled.</description>																	
 						<value>1</value>																	
 					</enumeratedValue>																		
 					<enumeratedValue>																		
-						<name>DISABLED_</name>																	
+						<name>DISABLED</name>																	
 						<description>Disabled.</description>																	
 						<value>0</value>																	
 					</enumeratedValue>																		
@@ -5677,12 +5677,12 @@ v7 updates:
 				<enumeratedValues>																			
 				<name>ENUM</name>																			
 					<enumeratedValue>																		
-						<name>ENABLED_</name>																	
+						<name>ENABLED</name>																	
 						<description>Enabled.</description>																	
 						<value>1</value>																	
 					</enumeratedValue>																		
 					<enumeratedValue>																		
-						<name>DISABLED_</name>																	
+						<name>DISABLED</name>																	
 						<description>Disabled.</description>																	
 						<value>0</value>																	
 					</enumeratedValue>																		
@@ -5695,12 +5695,12 @@ v7 updates:
 				<enumeratedValues>																			
 				<name>ENUM</name>																			
 					<enumeratedValue>																		
-						<name>ENABLED_</name>																	
+						<name>ENABLED</name>																	
 						<description>Enabled.</description>																	
 						<value>1</value>																	
 					</enumeratedValue>																		
 					<enumeratedValue>																		
-						<name>DISABLED_</name>																	
+						<name>DISABLED</name>																	
 						<description>Disabled.</description>																	
 						<value>0</value>																	
 					</enumeratedValue>																		
@@ -5713,12 +5713,12 @@ v7 updates:
 				<enumeratedValues>																			
 				<name>ENUM</name>																			
 					<enumeratedValue>																		
-						<name>ENABLED_</name>																	
+						<name>ENABLED</name>																	
 						<description>Enabled.</description>																	
 						<value>1</value>																	
 					</enumeratedValue>																		
 					<enumeratedValue>																		
-						<name>DISABLED_</name>																	
+						<name>DISABLED</name>																	
 						<description>Disabled.</description>																	
 						<value>0</value>																	
 					</enumeratedValue>																		
@@ -5731,12 +5731,12 @@ v7 updates:
 				<enumeratedValues>																			
 				<name>ENUM</name>																			
 					<enumeratedValue>																		
-						<name>ENABLED_</name>																	
+						<name>ENABLED</name>																	
 						<description>Enabled.</description>																	
 						<value>1</value>																	
 					</enumeratedValue>																		
 					<enumeratedValue>																		
-						<name>DISABLED_</name>																	
+						<name>DISABLED</name>																	
 						<description>Disabled.</description>																	
 						<value>0</value>																	
 					</enumeratedValue>																		
@@ -5820,22 +5820,22 @@ v7 updates:
 				<enumeratedValues>																			
 				<name>ENUM</name>																			
 					<enumeratedValue>																		
-						<name>DO_NOTHING_</name>																	
+						<name>DO_NOTHING</name>																	
 						<description>Do Nothing.</description>																	
 						<value>0x0</value>																	
 					</enumeratedValue>																		
 					<enumeratedValue>																		
-						<name>CLEAR_THE_CORRESPOND</name>																	
+						<name>CLEAR</name>																	
 						<description>Clear the corresponding External Match bit/output to 0 (CT32Bi_MAT0 pin is LOW if pinned out).</description>																	
 						<value>0x1</value>																	
 					</enumeratedValue>																		
 					<enumeratedValue>																		
-						<name>SET_THE_CORRESPONDIN</name>																	
+						<name>SET</name>																	
 						<description>Set the corresponding External Match bit/output to 1 (CT32Bi_MAT0 pin is HIGH if pinned out).</description>																	
 						<value>0x2</value>																	
 					</enumeratedValue>																		
 					<enumeratedValue>																		
-						<name>TOGGLE_THE_CORRESPON</name>																	
+						<name>TOGGLE</name>																	
 						<description>Toggle the corresponding External Match bit/output.</description>																	
 						<value>0x3</value>																	
 					</enumeratedValue>																		
@@ -5848,22 +5848,22 @@ v7 updates:
 				<enumeratedValues>																			
 				<name>ENUM</name>																			
 					<enumeratedValue>																		
-						<name>DO_NOTHING_</name>																	
+						<name>DO_NOTHING</name>																	
 						<description>Do Nothing.</description>																	
 						<value>0x0</value>																	
 					</enumeratedValue>																		
 					<enumeratedValue>																		
-						<name>CLEAR_THE_CORRESPOND</name>																	
+						<name>CLEAR</name>																	
 						<description>Clear the corresponding External Match bit/output to 0 (CT32Bi_MAT1 pin is LOW if pinned out).</description>																	
 						<value>0x1</value>																	
 					</enumeratedValue>																		
 					<enumeratedValue>																		
-						<name>SET_THE_CORRESPONDIN</name>																	
+						<name>SET</name>																	
 						<description>Set the corresponding External Match bit/output to 1 (CT32Bi_MAT1 pin is HIGH if pinned out).</description>																	
 						<value>0x2</value>																	
 					</enumeratedValue>																		
 					<enumeratedValue>																		
-						<name>TOGGLE_THE_CORRESPON</name>																	
+						<name>TOGGLE</name>																	
 						<description>Toggle the corresponding External Match bit/output.</description>																	
 						<value>0x3</value>																	
 					</enumeratedValue>																		
@@ -5876,22 +5876,22 @@ v7 updates:
 				<enumeratedValues>																			
 				<name>ENUM</name>																			
 					<enumeratedValue>																		
-						<name>DO_NOTHING_</name>																	
+						<name>DO_NOTHING</name>																	
 						<description>Do Nothing.</description>																	
 						<value>0x0</value>																	
 					</enumeratedValue>																		
 					<enumeratedValue>																		
-						<name>CLEAR_THE_CORRESPOND</name>																	
+						<name>CLEAR</name>																	
 						<description>Clear the corresponding External Match bit/output to 0 (CT32Bi_MAT2 pin is LOW if pinned out).</description>																	
 						<value>0x1</value>																	
 					</enumeratedValue>																		
 					<enumeratedValue>																		
-						<name>SET_THE_CORRESPONDIN</name>																	
+						<name>SET</name>																	
 						<description>Set the corresponding External Match bit/output to 1 (CT32Bi_MAT2 pin is HIGH if pinned out).</description>																	
 						<value>0x2</value>																	
 					</enumeratedValue>																		
 					<enumeratedValue>																		
-						<name>TOGGLE_THE_CORRESPON</name>																	
+						<name>TOGGLE</name>																	
 						<description>Toggle the corresponding External Match bit/output.</description>																	
 						<value>0x3</value>																	
 					</enumeratedValue>																		
@@ -5904,22 +5904,22 @@ v7 updates:
 				<enumeratedValues>																			
 				<name>ENUM</name>																			
 					<enumeratedValue>																		
-						<name>DO_NOTHING_</name>																	
+						<name>DO_NOTHING</name>																	
 						<description>Do Nothing.</description>																	
 						<value>0x0</value>																	
 					</enumeratedValue>																		
 					<enumeratedValue>																		
-						<name>CLEAR_THE_CORRESPOND</name>																	
+						<name>CLEAR</name>																	
 						<description>Clear the corresponding External Match bit/output to 0 (CT32Bi_MAT3 pin is LOW if pinned out).</description>																	
 						<value>0x1</value>																	
 					</enumeratedValue>																		
 					<enumeratedValue>																		
-						<name>SET_THE_CORRESPONDIN</name>																	
+						<name>SET</name>																	
 						<description>Set the corresponding External Match bit/output to 1 (CT32Bi_MAT3 pin is HIGH if pinned out).</description>																	
 						<value>0x2</value>																	
 					</enumeratedValue>																		
 					<enumeratedValue>																		
-						<name>TOGGLE_THE_CORRESPON</name>																	
+						<name>TOGGLE</name>																	
 						<description>Toggle the corresponding External Match bit/output.</description>																	
 						<value>0x3</value>																	
 					</enumeratedValue>																		
@@ -5954,17 +5954,17 @@ v7 updates:
 						<value>0x0</value>																	
 					</enumeratedValue>																		
 					<enumeratedValue>																		
-						<name>COUNTER_MODE_TC_IS_RISING</name>
+						<name>RISING</name>
 						<description>Counter Mode: TC is incremented on rising edges on the CAP input selected by bits 3:2.</description>																	
 						<value>0x1</value>																	
 					</enumeratedValue>																		
 					<enumeratedValue>																		
-						<name>COUNTER_MODE_TC_IS_FALLING</name>
+						<name>FALLING</name>
 						<description>Counter Mode: TC is incremented on falling edges on the CAP input selected by bits 3:2.</description>																	
 						<value>0x2</value>																	
 					</enumeratedValue>																		
 					<enumeratedValue>																		
-						<name>COUNTER_MODE_TC_IS_BOTH</name>
+						<name>BOTH</name>
 						<description>Counter Mode: TC is incremented on both edges on the CAP input selected by bits 3:2.</description>																	
 						<value>0x3</value>																	
 					</enumeratedValue>																		
@@ -6045,12 +6045,12 @@ v7 updates:
 				<enumeratedValues>																			
 				<name>ENUM</name>																			
 					<enumeratedValue>																		
-						<name>CT32BN_MAT0_IS_CONTR</name>																	
+						<name>EM0</name>																	
 						<description>CT32Bn_MAT0 is controlled by EM0.</description>																	
 						<value>0</value>																	
 					</enumeratedValue>																		
 					<enumeratedValue>																		
-						<name>PWM_MODE_IS_ENABLED_</name>																	
+						<name>ENABLED</name>																	
 						<description>PWM mode is enabled for CT32Bn_MAT0.</description>																	
 						<value>1</value>																	
 					</enumeratedValue>																		
@@ -6063,12 +6063,12 @@ v7 updates:
 				<enumeratedValues>																			
 				<name>ENUM</name>																			
 					<enumeratedValue>																		
-						<name>CT32BN_MAT01_IS_CONT</name>																	
+						<name>EM1</name>																	
 						<description>CT32Bn_MAT01 is controlled by EM1.</description>																	
 						<value>0</value>																	
 					</enumeratedValue>																		
 					<enumeratedValue>																		
-						<name>PWM_MODE_IS_ENABLED_</name>																	
+						<name>ENABLED</name>																	
 						<description>PWM mode is enabled for CT32Bn_MAT1.</description>																	
 						<value>1</value>																	
 					</enumeratedValue>																		
@@ -6081,12 +6081,12 @@ v7 updates:
 				<enumeratedValues>																			
 				<name>ENUM</name>																			
 					<enumeratedValue>																		
-						<name>CT32BN_MAT2_IS_CONTR</name>																	
+						<name>EM2</name>																	
 						<description>CT32Bn_MAT2 is controlled by EM2.</description>																	
 						<value>0</value>																	
 					</enumeratedValue>																		
 					<enumeratedValue>																		
-						<name>PWM_MODE_IS_ENABLED_</name>																	
+						<name>ENABLED</name>																	
 						<description>PWM mode is enabled for CT32Bn_MAT2.</description>																	
 						<value>1</value>																	
 					</enumeratedValue>																		
@@ -6099,12 +6099,12 @@ v7 updates:
 				<enumeratedValues>																			
 				<name>ENUM</name>																			
 					<enumeratedValue>																		
-						<name>CT32BN_MAT3_IS_CONTR</name>																	
+						<name>EM3</name>																	
 						<description>CT32Bn_MAT3 is controlled by EM3.</description>																	
 						<value>0</value>																	
 					</enumeratedValue>																		
 					<enumeratedValue>																		
-						<name>PWM_MODE_IS_ENABLED_</name>																	
+						<name>ENABLED</name>																	
 						<description>PWM mode is enabled for CT132Bn_MAT3.</description>																	
 						<value>1</value>																	
 					</enumeratedValue>																		
@@ -6162,12 +6162,12 @@ v7 updates:
 							<enumeratedValues>
 								<name>ENUM</name>
 								<enumeratedValue>
-									<name>SOFTWARE_CONTROLLED_</name>
+									<name>SOFTWARE_CONTROLLED</name>
 									<description>Software-controlled mode: Conversions are software-controlled and require 11 clocks.</description>
 									<value>0</value>
 								</enumeratedValue>
 								<enumeratedValue>
-									<name>HARDWARE_SCAN_MODE_</name>
+									<name>HARDWARE_SCAN</name>
 									<description>Hardware scan mode: The AD converter does repeated conversions at the rate selected by the CLKS field, scanning (if necessary) through the pins selected by 1s in the SEL field. The first conversion after the start corresponds to the least-significant bit set to 1 in the SEL field, then the next higher  bits (pins) set to 1 are scanned if applicable. Repeated conversions can be terminated by clearing this bit, but the conversion in progress when this bit is cleared will be completed. Important: START bits must be 000 when BURST = 1 or conversions will not start.</description>
 									<value>1</value>
 								</enumeratedValue>
@@ -6180,42 +6180,42 @@ v7 updates:
 							<enumeratedValues>
 								<name>ENUM</name>
 								<enumeratedValue>
-									<name>11_CLOCKS</name>
+									<name>11_CLOCKS_10_BITS</name>
 									<description>11 clocks / 10 bits</description>
 									<value>0x0</value>
 								</enumeratedValue>
 								<enumeratedValue>
-									<name>10_CLOCKS</name>
+									<name>10_CLOCKS_9_BITS</name>
 									<description>10 clocks / 9 bits</description>
 									<value>0x1</value>
 								</enumeratedValue>
 								<enumeratedValue>
-									<name>9_CLOCKS</name>
+									<name>9_CLOCKS_8_BITS</name>
 									<description>9 clocks / 8 bits</description>
 									<value>0x2</value>
 								</enumeratedValue>
 								<enumeratedValue>
-									<name>8_CLOCKS</name>
+									<name>8_CLOCKS_7_BITS</name>
 									<description>8 clocks / 7 bits</description>
 									<value>0x3</value>
 								</enumeratedValue>
 								<enumeratedValue>
-									<name>7_CLOCKS</name>
+									<name>7_CLOCKS_6_BITS</name>
 									<description>7 clocks / 6 bits</description>
 									<value>0x4</value>
 								</enumeratedValue>
 								<enumeratedValue>
-									<name>6_CLOCKS</name>
+									<name>6_CLOCKS_5_BITS</name>
 									<description>6 clocks / 5 bits</description>
 									<value>0x5</value>
 								</enumeratedValue>
 								<enumeratedValue>
-									<name>5_CLOCKS</name>
+									<name>5_CLOCKS_4_BITS</name>
 									<description>5 clocks / 4 bits</description>
 									<value>0x6</value>
 								</enumeratedValue>
 								<enumeratedValue>
-									<name>4_CLOCKS</name>
+									<name>4_CLOCKS_3_BITS</name>
 									<description>4 clocks / 3 bits</description>
 									<value>0x7</value>
 								</enumeratedValue>
@@ -7099,12 +7099,12 @@ controller </description>
 							<enumeratedValues>
 								<name>ENUM</name>
 								<enumeratedValue>
-									<name>DURING_NORMAL_OPERAT</name>
+									<name>NORMAL_OPERATION</name>
 									<description>During normal operation.</description>
 									<value>0</value>
 								</enumeratedValue>
 								<enumeratedValue>
-									<name>SERIAL_INPUT_IS_TAKE</name>
+									<name>SERIAL_OUTPUT</name>
 									<description>Serial input is taken from the serial output (MOSI or MISO) rather than the serial input pin (MISO or MOSI respectively).</description>
 									<value>1</value>
 								</enumeratedValue>
@@ -7399,12 +7399,12 @@ controller </description>
 				<enumeratedValues>																			
 				<name>ENUM</name>																			
 					<enumeratedValue>																		
-						<name>RESET_</name>																	
+						<name>RESET</name>																	
 						<description>RESET.</description>																	
 						<value>0x0</value>																	
 					</enumeratedValue>																		
 					<enumeratedValue>																		
-						<name>PIO0_0_</name>																	
+						<name>PIO0_0</name>																	
 						<description>PIO0_0.</description>																	
 						<value>0x1</value>																	
 					</enumeratedValue>																		
@@ -7417,22 +7417,22 @@ controller </description>
 				<enumeratedValues>																			
 				<name>ENUM</name>																			
 					<enumeratedValue>																		
-						<name>INACTIVE_NO_PULL_DO</name>																	
+						<name>INACTIVE</name>																	
 						<description>Inactive (no pull-down/pull-up resistor enabled).</description>																	
 						<value>0x0</value>																	
 					</enumeratedValue>																		
 					<enumeratedValue>																		
-						<name>PULL_DOWN_RESISTOR_E</name>																	
+						<name>PULL_DOWN</name>																	
 						<description>Pull-down resistor enabled.</description>																	
 						<value>0x1</value>																	
 					</enumeratedValue>																		
 					<enumeratedValue>																		
-						<name>PULL_UP_RESISTOR_ENA</name>																	
+						<name>PULL_UP</name>																	
 						<description>Pull-up resistor enabled.</description>																	
 						<value>0x2</value>																	
 					</enumeratedValue>																		
 					<enumeratedValue>																		
-						<name>REPEATER_MODE_</name>																	
+						<name>REPEATER</name>																	
 						<description>Repeater mode.</description>																	
 						<value>0x3</value>																	
 					</enumeratedValue>																		
@@ -7445,12 +7445,12 @@ controller </description>
 				<enumeratedValues>																			
 				<name>ENUM</name>																			
 					<enumeratedValue>																		
-						<name>DISABLE_</name>																	
+						<name>DISABLED</name>																	
 						<description>Disable.</description>																	
 						<value>0</value>																	
 					</enumeratedValue>																		
 					<enumeratedValue>																		
-						<name>ENABLE_</name>																	
+						<name>ENABLED</name>																	
 						<description>Enable.</description>																	
 						<value>1</value>																	
 					</enumeratedValue>																		
@@ -7463,12 +7463,12 @@ controller </description>
 				<enumeratedValues>																			
 				<name>ENUM</name>																			
 					<enumeratedValue>																		
-						<name>INPUT_NOT_INVERTED_</name>																	
+						<name>NOT_INVERTED</name>																	
 						<description>Input not inverted (HIGH on pin reads as 1, LOW on pin reads as 0).</description>																	
 						<value>0</value>																	
 					</enumeratedValue>																		
 					<enumeratedValue>																		
-						<name>INPUT_INVERTED_HIGH</name>																	
+						<name>INVERTED</name>																	
 						<description>Input inverted (HIGH on pin reads as 0, LOW on pin reads as 1).</description>																	
 						<value>1</value>																	
 					</enumeratedValue>																		
@@ -7487,12 +7487,12 @@ controller </description>
 				<enumeratedValues>																			
 				<name>ENUM</name>																			
 					<enumeratedValue>																		
-						<name>DISABLE_</name>																	
+						<name>DISABLED</name>																	
 						<description>Disable.</description>																	
 						<value>0</value>																	
 					</enumeratedValue>																		
 					<enumeratedValue>																		
-						<name>OPEN_DRAIN_MODE_ENAB</name>																	
+						<name>OPEN_DRAIN</name>																	
 						<description>Open-drain mode enabled.  This is not a true open-drain mode.</description>																	
 						<value>1</value>																	
 					</enumeratedValue>																		
@@ -7521,22 +7521,22 @@ controller </description>
 				<enumeratedValues>																			
 				<name>ENUM</name>																			
 					<enumeratedValue>																		
-						<name>PIO0_1_</name>																	
+						<name>PIO0_1</name>																	
 						<description>PIO0_1.</description>																	
 						<value>0x0</value>																	
 					</enumeratedValue>																		
 					<enumeratedValue>																		
-						<name>CLKOUT_</name>																	
+						<name>CLKOUT</name>																	
 						<description>CLKOUT.</description>																	
 						<value>0x1</value>																	
 					</enumeratedValue>																		
 					<enumeratedValue>																		
-						<name>CT32B0_MAT2_</name>																	
+						<name>CT32B0_MAT2</name>																	
 						<description>CT32B0_MAT2.</description>																	
 						<value>0x2</value>																	
 					</enumeratedValue>																		
 					<enumeratedValue>																		
-						<name>USB_FTOGGLE_</name>																	
+						<name>USB_FTOGGLE</name>																	
 						<description>USB_FTOGGLE.</description>																	
 						<value>0x3</value>																	
 					</enumeratedValue>																		
@@ -7549,22 +7549,22 @@ controller </description>
 				<enumeratedValues>																			
 				<name>ENUM</name>																			
 					<enumeratedValue>																		
-						<name>INACTIVE_NO_PULL_DO</name>																	
+						<name>INACTIVE</name>																	
 						<description>Inactive (no pull-down/pull-up resistor enabled).</description>																	
 						<value>0x0</value>																	
 					</enumeratedValue>																		
 					<enumeratedValue>																		
-						<name>PULL_DOWN_RESISTOR_E</name>																	
+						<name>PULL_DOWN</name>																	
 						<description>Pull-down resistor enabled.</description>																	
 						<value>0x1</value>																	
 					</enumeratedValue>																		
 					<enumeratedValue>																		
-						<name>PULL_UP_RESISTOR_ENA</name>																	
+						<name>PULL_UP</name>																	
 						<description>Pull-up resistor enabled.</description>																	
 						<value>0x2</value>																	
 					</enumeratedValue>																		
 					<enumeratedValue>																		
-						<name>REPEATER_MODE_</name>																	
+						<name>REPEATER</name>																	
 						<description>Repeater mode.</description>																	
 						<value>0x3</value>																	
 					</enumeratedValue>																		
@@ -7577,12 +7577,12 @@ controller </description>
 				<enumeratedValues>																			
 				<name>ENUM</name>																			
 					<enumeratedValue>																		
-						<name>DISABLE_</name>																	
+						<name>DISABLED</name>																	
 						<description>Disable.</description>																	
 						<value>0</value>																	
 					</enumeratedValue>																		
 					<enumeratedValue>																		
-						<name>ENABLE_</name>																	
+						<name>ENABLED</name>																	
 						<description>Enable.</description>																	
 						<value>1</value>																	
 					</enumeratedValue>																		
@@ -7595,12 +7595,12 @@ controller </description>
 				<enumeratedValues>																			
 				<name>ENUM</name>																			
 					<enumeratedValue>																		
-						<name>INPUT_NOT_INVERTED_</name>																	
+						<name>NOT_INVERTED</name>																	
 						<description>Input not inverted (HIGH on pin reads as 1, LOW on pin reads as 0).</description>																	
 						<value>0</value>																	
 					</enumeratedValue>																		
 					<enumeratedValue>																		
-						<name>INPUT_INVERTED_HIGH</name>																	
+						<name>INVERTED</name>																	
 						<description>Input inverted (HIGH on pin reads as 0, LOW on pin reads as 1).</description>																	
 						<value>1</value>																	
 					</enumeratedValue>																		
@@ -7619,12 +7619,12 @@ controller </description>
 				<enumeratedValues>																			
 				<name>ENUM</name>																			
 					<enumeratedValue>																		
-						<name>DISABLE_</name>																	
+						<name>DISABLED</name>																	
 						<description>Disable.</description>																	
 						<value>0</value>																	
 					</enumeratedValue>																		
 					<enumeratedValue>																		
-						<name>OPEN_DRAIN_MODE_ENAB</name>																	
+						<name>OPEN_DRAIN</name>																	
 						<description>Open-drain mode enabled.  This is not a true open-drain mode.</description>																	
 						<value>1</value>																	
 					</enumeratedValue>																		
@@ -7653,17 +7653,17 @@ controller </description>
 				<enumeratedValues>																			
 				<name>ENUM</name>																			
 					<enumeratedValue>																		
-						<name>PIO0_2_</name>																	
+						<name>PIO0_2</name>																	
 						<description>PIO0_2.</description>																	
 						<value>0x0</value>																	
 					</enumeratedValue>																		
 					<enumeratedValue>																		
-						<name>SSEL0_</name>																	
+						<name>SSEL0</name>																	
 						<description>SSEL0.</description>																	
 						<value>0x1</value>																	
 					</enumeratedValue>																		
 					<enumeratedValue>																		
-						<name>CT16B0_CAP0_</name>																	
+						<name>CT16B0_CAP0</name>																	
 						<description>CT16B0_CAP0.</description>																	
 						<value>0x2</value>																	
 					</enumeratedValue>																		
@@ -7676,22 +7676,22 @@ controller </description>
 				<enumeratedValues>																			
 				<name>ENUM</name>																			
 					<enumeratedValue>																		
-						<name>INACTIVE_NO_PULL_DO</name>																	
+						<name>INACTIVE</name>																	
 						<description>Inactive (no pull-down/pull-up resistor enabled).</description>																	
 						<value>0x0</value>																	
 					</enumeratedValue>																		
 					<enumeratedValue>																		
-						<name>PULL_DOWN_RESISTOR_E</name>																	
+						<name>PULL_DOWN</name>																	
 						<description>Pull-down resistor enabled.</description>																	
 						<value>0x1</value>																	
 					</enumeratedValue>																		
 					<enumeratedValue>																		
-						<name>PULL_UP_RESISTOR_ENA</name>																	
+						<name>PULL_UP</name>																	
 						<description>Pull-up resistor enabled.</description>																	
 						<value>0x2</value>																	
 					</enumeratedValue>																		
 					<enumeratedValue>																		
-						<name>REPEATER_MODE_</name>																	
+						<name>REPEATER</name>																	
 						<description>Repeater mode.</description>																	
 						<value>0x3</value>																	
 					</enumeratedValue>																		
@@ -7704,12 +7704,12 @@ controller </description>
 				<enumeratedValues>																			
 				<name>ENUM</name>																			
 					<enumeratedValue>																		
-						<name>DISABLE_</name>																	
+						<name>DISABLED</name>																	
 						<description>Disable.</description>																	
 						<value>0</value>																	
 					</enumeratedValue>																		
 					<enumeratedValue>																		
-						<name>ENABLE_</name>																	
+						<name>ENABLED</name>																	
 						<description>Enable.</description>																	
 						<value>1</value>																	
 					</enumeratedValue>																		
@@ -7722,12 +7722,12 @@ controller </description>
 				<enumeratedValues>																			
 				<name>ENUM</name>																			
 					<enumeratedValue>																		
-						<name>INPUT_NOT_INVERTED_</name>																	
+						<name>NOT_INVERTED</name>																	
 						<description>Input not inverted (HIGH on pin reads as 1, LOW on pin reads as 0).</description>																	
 						<value>0</value>																	
 					</enumeratedValue>																		
 					<enumeratedValue>																		
-						<name>INPUT_INVERTED_HIGH</name>																	
+						<name>INVERTED</name>																	
 						<description>Input inverted (HIGH on pin reads as 0, LOW on pin reads as 1).</description>																	
 						<value>1</value>																	
 					</enumeratedValue>																		
@@ -7746,12 +7746,12 @@ controller </description>
 				<enumeratedValues>																			
 				<name>ENUM</name>																			
 					<enumeratedValue>																		
-						<name>DISABLE_</name>																	
+						<name>DISABLED</name>																	
 						<description>Disable.</description>																	
 						<value>0</value>																	
 					</enumeratedValue>																		
 					<enumeratedValue>																		
-						<name>OPEN_DRAIN_MODE_ENAB</name>																	
+						<name>OPEN_DRAIN</name>																	
 						<description>Open-drain mode enabled.  This is not a true open-drain mode.</description>																	
 						<value>1</value>																	
 					</enumeratedValue>																		
@@ -7780,12 +7780,12 @@ controller </description>
 				<enumeratedValues>																			
 				<name>ENUM</name>																			
 					<enumeratedValue>																		
-						<name>PIO0_3_</name>																	
+						<name>PIO0_3</name>																	
 						<description>PIO0_3.</description>																	
 						<value>0x0</value>																	
 					</enumeratedValue>																		
 					<enumeratedValue>																		
-						<name>USB_VBUS_</name>																	
+						<name>USB_VBUS</name>																	
 						<description>USB_VBUS.</description>																	
 						<value>0x1</value>																	
 					</enumeratedValue>																		
@@ -7798,22 +7798,22 @@ controller </description>
 				<enumeratedValues>																			
 				<name>ENUM</name>																			
 					<enumeratedValue>																		
-						<name>INACTIVE_NO_PULL_DO</name>																	
+						<name>INACTIVE</name>																	
 						<description>Inactive (no pull-down/pull-up resistor enabled).</description>																	
 						<value>0x0</value>																	
 					</enumeratedValue>																		
 					<enumeratedValue>																		
-						<name>PULL_DOWN_RESISTOR_E</name>																	
+						<name>PULL_DOWN</name>																	
 						<description>Pull-down resistor enabled.</description>																	
 						<value>0x1</value>																	
 					</enumeratedValue>																		
 					<enumeratedValue>																		
-						<name>PULL_UP_RESISTOR_ENA</name>																	
+						<name>PULL_UP</name>																	
 						<description>Pull-up resistor enabled.</description>																	
 						<value>0x2</value>																	
 					</enumeratedValue>																		
 					<enumeratedValue>																		
-						<name>REPEATER_MODE_</name>																	
+						<name>REPEATER</name>																	
 						<description>Repeater mode.</description>																	
 						<value>0x3</value>																	
 					</enumeratedValue>																		
@@ -7826,12 +7826,12 @@ controller </description>
 				<enumeratedValues>																			
 				<name>ENUM</name>																			
 					<enumeratedValue>																		
-						<name>DISABLE_</name>																	
+						<name>DISABLED</name>																	
 						<description>Disable.</description>																	
 						<value>0</value>																	
 					</enumeratedValue>																		
 					<enumeratedValue>																		
-						<name>ENABLE_</name>																	
+						<name>ENABLED</name>																	
 						<description>Enable.</description>																	
 						<value>1</value>																	
 					</enumeratedValue>																		
@@ -7844,12 +7844,12 @@ controller </description>
 				<enumeratedValues>																			
 				<name>ENUM</name>																			
 					<enumeratedValue>																		
-						<name>INPUT_NOT_INVERTED_</name>																	
+						<name>NOT_INVERTED</name>																	
 						<description>Input not inverted (HIGH on pin reads as 1, LOW on pin reads as 0).</description>																	
 						<value>0</value>																	
 					</enumeratedValue>																		
 					<enumeratedValue>																		
-						<name>INPUT_INVERTED_HIGH</name>																	
+						<name>INVERTED</name>																	
 						<description>Input inverted (HIGH on pin reads as 0, LOW on pin reads as 1).</description>																	
 						<value>1</value>																	
 					</enumeratedValue>																		
@@ -7868,12 +7868,12 @@ controller </description>
 				<enumeratedValues>																			
 				<name>ENUM</name>																			
 					<enumeratedValue>																		
-						<name>DISABLE_</name>																	
+						<name>DISABLED</name>																	
 						<description>Disable.</description>																	
 						<value>0</value>																	
 					</enumeratedValue>																		
 					<enumeratedValue>																		
-						<name>OPEN_DRAIN_MODE_ENAB</name>																	
+						<name>OPEN_DRAIN</name>																	
 						<description>Open-drain mode enabled.  This is not a true open-drain mode.</description>																	
 						<value>1</value>																	
 					</enumeratedValue>																		
@@ -7902,12 +7902,12 @@ controller </description>
 				<enumeratedValues>																			
 				<name>ENUM</name>																			
 					<enumeratedValue>																		
-						<name>PIO0_4_OPEN_DRAIN_P</name>																	
+						<name>PIO0_4</name>																	
 						<description>PIO0_4 (open-drain pin).</description>																	
 						<value>0x0</value>																	
 					</enumeratedValue>																		
 					<enumeratedValue>																		
-						<name>I2C_SCL_OPEN_DRAIN_</name>																	
+						<name>I2C_SCL</name>																	
 						<description>I2C SCL (open-drain pin).</description>																	
 						<value>0x1</value>																	
 					</enumeratedValue>																		
@@ -7926,22 +7926,22 @@ controller </description>
 				<enumeratedValues>																			
 				<name>ENUM</name>																			
 					<enumeratedValue>																		
-						<name>STANDARD_MODE_FAST_</name>																	
+						<name>STANDARD_MODE</name>																	
 						<description>Standard mode/ Fast-mode I2C.</description>																	
 						<value>0x0</value>																	
 					</enumeratedValue>																		
 					<enumeratedValue>																		
-						<name>STANDARD_IO_FUNCTIO</name>																	
+						<name>STANDARD_IO</name>																	
 						<description>Standard I/O functionality</description>																	
 						<value>0x1</value>																	
 					</enumeratedValue>																		
 					<enumeratedValue>																		
-						<name>FAST_MODE_PLUS_I2C</name>																	
+						<name>FAST_MODE_PLUS</name>																	
 						<description>Fast-mode Plus I2C</description>																	
 						<value>0x2</value>																	
 					</enumeratedValue>																		
 					<enumeratedValue>																		
-						<name>RESERVED_3</name>
+						<name>RESERVED</name>
 						<description>Reserved.</description>																	
 						<value>0x3</value>																	
 					</enumeratedValue>																		
@@ -7970,12 +7970,12 @@ controller </description>
 				<enumeratedValues>																			
 				<name>ENUM</name>																			
 					<enumeratedValue>																		
-						<name>PIO0_5_OPEN_DRAIN_P</name>																	
+						<name>PIO0_5</name>																	
 						<description>PIO0_5 (open-drain pin).</description>																	
 						<value>0x0</value>																	
 					</enumeratedValue>																		
 					<enumeratedValue>																		
-						<name>I2C_SDA_OPEN_DRAIN_</name>																	
+						<name>I2C_SDA</name>																	
 						<description>I2C SDA (open-drain pin).</description>																	
 						<value>0x1</value>																	
 					</enumeratedValue>																		
@@ -7994,22 +7994,22 @@ controller </description>
 				<enumeratedValues>																			
 				<name>ENUM</name>																			
 					<enumeratedValue>																		
-						<name>STANDARD_MODE_FAST_</name>																	
+						<name>STANDARD_MODE</name>																	
 						<description>Standard mode/ Fast-mode I2C.</description>																	
 						<value>0x0</value>																	
 					</enumeratedValue>																		
 					<enumeratedValue>																		
-						<name>STANDARD_IO_FUNCTIO</name>																	
+						<name>STANDARD_IO</name>																	
 						<description>Standard I/O functionality</description>																	
 						<value>0x1</value>																	
 					</enumeratedValue>																		
 					<enumeratedValue>																		
-						<name>FAST_MODE_PLUS_I2C</name>																	
+						<name>FAST_MODE_PLUS</name>																	
 						<description>Fast-mode Plus I2C</description>																	
 						<value>0x2</value>																	
 					</enumeratedValue>																		
 					<enumeratedValue>																		
-						<name>RESERVED_3</name>
+						<name>RESERVED</name>
 						<description>Reserved.</description>																	
 						<value>0x3</value>																	
 					</enumeratedValue>																		
@@ -8038,17 +8038,17 @@ controller </description>
 				<enumeratedValues>																			
 				<name>ENUM</name>																			
 					<enumeratedValue>																		
-						<name>PIO0_6_</name>																	
+						<name>PIO0_6</name>																	
 						<description>PIO0_6.</description>																	
 						<value>0x0</value>																	
 					</enumeratedValue>																		
 					<enumeratedValue>																		
-						<name>USB_CONNECT_</name>																	
+						<name>USB_CONNECT</name>																	
 						<description>USB_CONNECT.</description>																	
 						<value>0x1</value>																	
 					</enumeratedValue>																		
 					<enumeratedValue>																		
-						<name>SCK0_</name>																	
+						<name>SCK0</name>																	
 						<description>SCK0.</description>																	
 						<value>0x2</value>																	
 					</enumeratedValue>																		
@@ -8061,22 +8061,22 @@ controller </description>
 				<enumeratedValues>																			
 				<name>ENUM</name>																			
 					<enumeratedValue>																		
-						<name>INACTIVE_NO_PULL_DO</name>																	
+						<name>INACTIVE</name>																	
 						<description>Inactive (no pull-down/pull-up resistor enabled).</description>																	
 						<value>0x0</value>																	
 					</enumeratedValue>																		
 					<enumeratedValue>																		
-						<name>PULL_DOWN_RESISTOR_E</name>																	
+						<name>PULL_DOWN</name>																	
 						<description>Pull-down resistor enabled.</description>																	
 						<value>0x1</value>																	
 					</enumeratedValue>																		
 					<enumeratedValue>																		
-						<name>PULL_UP_RESISTOR_ENA</name>																	
+						<name>PULL_UP</name>																	
 						<description>Pull-up resistor enabled.</description>																	
 						<value>0x2</value>																	
 					</enumeratedValue>																		
 					<enumeratedValue>																		
-						<name>REPEATER_MODE_</name>																	
+						<name>REPEATER</name>																	
 						<description>Repeater mode.</description>																	
 						<value>0x3</value>																	
 					</enumeratedValue>																		
@@ -8089,12 +8089,12 @@ controller </description>
 				<enumeratedValues>																			
 				<name>ENUM</name>																			
 					<enumeratedValue>																		
-						<name>DISABLE_</name>																	
+						<name>DISABLED</name>																	
 						<description>Disable.</description>																	
 						<value>0</value>																	
 					</enumeratedValue>																		
 					<enumeratedValue>																		
-						<name>ENABLE_</name>																	
+						<name>ENABLED</name>																	
 						<description>Enable.</description>																	
 						<value>1</value>																	
 					</enumeratedValue>																		
@@ -8107,12 +8107,12 @@ controller </description>
 				<enumeratedValues>																			
 				<name>ENUM</name>																			
 					<enumeratedValue>																		
-						<name>INPUT_NOT_INVERTED_</name>																	
+						<name>NOT_INVERTED</name>																	
 						<description>Input not inverted (HIGH on pin reads as 1, LOW on pin reads as 0).</description>																	
 						<value>0</value>																	
 					</enumeratedValue>																		
 					<enumeratedValue>																		
-						<name>INPUT_INVERTED_HIGH</name>																	
+						<name>INVERTED</name>																	
 						<description>Input inverted (HIGH on pin reads as 0, LOW on pin reads as 1).</description>																	
 						<value>1</value>																	
 					</enumeratedValue>																		
@@ -8131,12 +8131,12 @@ controller </description>
 				<enumeratedValues>																			
 				<name>ENUM</name>																			
 					<enumeratedValue>																		
-						<name>DISABLE_</name>																	
+						<name>DISABLED</name>																	
 						<description>Disable.</description>																	
 						<value>0</value>																	
 					</enumeratedValue>																		
 					<enumeratedValue>																		
-						<name>OPEN_DRAIN_MODE_ENAB</name>																	
+						<name>OPEN_DRAIN</name>																	
 						<description>Open-drain mode enabled.  This is not a true open-drain mode.</description>																	
 						<value>1</value>																	
 					</enumeratedValue>																		
@@ -8165,12 +8165,12 @@ controller </description>
 				<enumeratedValues>																			
 				<name>ENUM</name>																			
 					<enumeratedValue>																		
-						<name>PIO0_7_</name>																	
+						<name>PIO0_7</name>																	
 						<description>PIO0_7.</description>																	
 						<value>0x0</value>																	
 					</enumeratedValue>																		
 					<enumeratedValue>																		
-						<name>CTS_</name>																	
+						<name>CTS</name>																	
 						<description>CTS.</description>																	
 						<value>0x1</value>																	
 					</enumeratedValue>																		
@@ -8183,22 +8183,22 @@ controller </description>
 				<enumeratedValues>																			
 				<name>ENUM</name>																			
 					<enumeratedValue>																		
-						<name>INACTIVE_NO_PULL_DO</name>																	
+						<name>INACTIVE</name>																	
 						<description>Inactive (no pull-down/pull-up resistor enabled).</description>																	
 						<value>0x0</value>																	
 					</enumeratedValue>																		
 					<enumeratedValue>																		
-						<name>PULL_DOWN_RESISTOR_E</name>																	
+						<name>PULL_DOWN</name>																	
 						<description>Pull-down resistor enabled.</description>																	
 						<value>0x1</value>																	
 					</enumeratedValue>																		
 					<enumeratedValue>																		
-						<name>PULL_UP_RESISTOR_ENA</name>																	
+						<name>PULL_UP</name>																	
 						<description>Pull-up resistor enabled.</description>																	
 						<value>0x2</value>																	
 					</enumeratedValue>																		
 					<enumeratedValue>																		
-						<name>REPEATER_MODE_</name>																	
+						<name>REPEATER</name>																	
 						<description>Repeater mode.</description>																	
 						<value>0x3</value>																	
 					</enumeratedValue>																		
@@ -8211,12 +8211,12 @@ controller </description>
 				<enumeratedValues>																			
 				<name>ENUM</name>																			
 					<enumeratedValue>																		
-						<name>DISABLE_</name>																	
+						<name>DISABLED</name>																	
 						<description>Disable.</description>																	
 						<value>0</value>																	
 					</enumeratedValue>																		
 					<enumeratedValue>																		
-						<name>ENABLE_</name>																	
+						<name>ENABLED</name>																	
 						<description>Enable.</description>																	
 						<value>1</value>																	
 					</enumeratedValue>																		
@@ -8229,12 +8229,12 @@ controller </description>
 				<enumeratedValues>																			
 				<name>ENUM</name>																			
 					<enumeratedValue>																		
-						<name>INPUT_NOT_INVERTED_</name>																	
+						<name>NOT_INVERTED</name>																	
 						<description>Input not inverted (HIGH on pin reads as 1, LOW on pin reads as 0).</description>																	
 						<value>0</value>																	
 					</enumeratedValue>																		
 					<enumeratedValue>																		
-						<name>INPUT_INVERTED_HIGH</name>																	
+						<name>INVERTED</name>																	
 						<description>Input inverted (HIGH on pin reads as 0, LOW on pin reads as 1).</description>																	
 						<value>1</value>																	
 					</enumeratedValue>																		
@@ -8253,12 +8253,12 @@ controller </description>
 				<enumeratedValues>																			
 				<name>ENUM</name>																			
 					<enumeratedValue>																		
-						<name>DISABLE_</name>																	
+						<name>DISABLED</name>																	
 						<description>Disable.</description>																	
 						<value>0</value>																	
 					</enumeratedValue>																		
 					<enumeratedValue>																		
-						<name>OPEN_DRAIN_MODE_ENAB</name>																	
+						<name>OPEN_DRAIN</name>																	
 						<description>Open-drain mode enabled.  This is not a true open-drain mode.</description>																	
 						<value>1</value>																	
 					</enumeratedValue>																		
@@ -8287,17 +8287,17 @@ controller </description>
 				<enumeratedValues>																			
 				<name>ENUM</name>																			
 					<enumeratedValue>																		
-						<name>PIO0_8_</name>																	
+						<name>PIO0_8</name>																	
 						<description>PIO0_8.</description>																	
 						<value>0x0</value>																	
 					</enumeratedValue>																		
 					<enumeratedValue>																		
-						<name>MISO0_</name>																	
+						<name>MISO0</name>																	
 						<description>MISO0.</description>																	
 						<value>0x1</value>																	
 					</enumeratedValue>																		
 					<enumeratedValue>																		
-						<name>CT16B0_MAT0_</name>																	
+						<name>CT16B0_MAT0</name>																	
 						<description>CT16B0_MAT0.</description>																	
 						<value>0x2</value>																	
 					</enumeratedValue>																		
@@ -8310,22 +8310,22 @@ controller </description>
 				<enumeratedValues>																			
 				<name>ENUM</name>																			
 					<enumeratedValue>																		
-						<name>INACTIVE_NO_PULL_DO</name>																	
+						<name>INACTIVE</name>																	
 						<description>Inactive (no pull-down/pull-up resistor enabled).</description>																	
 						<value>0x0</value>																	
 					</enumeratedValue>																		
 					<enumeratedValue>																		
-						<name>PULL_DOWN_RESISTOR_E</name>																	
+						<name>PULL_DOWN</name>																	
 						<description>Pull-down resistor enabled.</description>																	
 						<value>0x1</value>																	
 					</enumeratedValue>																		
 					<enumeratedValue>																		
-						<name>PULL_UP_RESISTOR_ENA</name>																	
+						<name>PULL_UP</name>																	
 						<description>Pull-up resistor enabled.</description>																	
 						<value>0x2</value>																	
 					</enumeratedValue>																		
 					<enumeratedValue>																		
-						<name>REPEATER_MODE_</name>																	
+						<name>REPEATER</name>																	
 						<description>Repeater mode.</description>																	
 						<value>0x3</value>																	
 					</enumeratedValue>																		
@@ -8338,12 +8338,12 @@ controller </description>
 				<enumeratedValues>																			
 				<name>ENUM</name>																			
 					<enumeratedValue>																		
-						<name>DISABLE_</name>																	
+						<name>DISABLED</name>																	
 						<description>Disable.</description>																	
 						<value>0</value>																	
 					</enumeratedValue>																		
 					<enumeratedValue>																		
-						<name>ENABLE_</name>																	
+						<name>ENABLED</name>																	
 						<description>Enable.</description>																	
 						<value>1</value>																	
 					</enumeratedValue>																		
@@ -8356,12 +8356,12 @@ controller </description>
 				<enumeratedValues>																			
 				<name>ENUM</name>																			
 					<enumeratedValue>																		
-						<name>INPUT_NOT_INVERTED_</name>																	
+						<name>NOT_INVERTED</name>																	
 						<description>Input not inverted (HIGH on pin reads as 1, LOW on pin reads as 0).</description>																	
 						<value>0</value>																	
 					</enumeratedValue>																		
 					<enumeratedValue>																		
-						<name>INPUT_INVERTED_HIGH</name>																	
+						<name>INVERTED</name>																	
 						<description>Input inverted (HIGH on pin reads as 0, LOW on pin reads as 1).</description>																	
 						<value>1</value>																	
 					</enumeratedValue>																		
@@ -8380,12 +8380,12 @@ controller </description>
 				<enumeratedValues>																			
 				<name>ENUM</name>																			
 					<enumeratedValue>																		
-						<name>DISABLE_</name>																	
+						<name>DISABLED</name>																	
 						<description>Disable.</description>																	
 						<value>0</value>																	
 					</enumeratedValue>																		
 					<enumeratedValue>																		
-						<name>OPEN_DRAIN_MODE_ENAB</name>																	
+						<name>OPEN_DRAIN</name>																	
 						<description>Open-drain mode enabled.  This is not a true open-drain mode.</description>																	
 						<value>1</value>																	
 					</enumeratedValue>																		
@@ -8414,17 +8414,17 @@ controller </description>
 				<enumeratedValues>																			
 				<name>ENUM</name>																			
 					<enumeratedValue>																		
-						<name>PIO0_9_</name>																	
+						<name>PIO0_9</name>																	
 						<description>PIO0_9.</description>																	
 						<value>0x0</value>																	
 					</enumeratedValue>																		
 					<enumeratedValue>																		
-						<name>MOSI0_</name>																	
+						<name>MOSI0</name>																	
 						<description>MOSI0.</description>																	
 						<value>0x1</value>																	
 					</enumeratedValue>																		
 					<enumeratedValue>																		
-						<name>CT16B0_MAT1_</name>																	
+						<name>CT16B0_MAT1</name>																	
 						<description>CT16B0_MAT1.</description>																	
 						<value>0x2</value>																	
 					</enumeratedValue>																		
@@ -8437,22 +8437,22 @@ controller </description>
 				<enumeratedValues>																			
 				<name>ENUM</name>																			
 					<enumeratedValue>																		
-						<name>INACTIVE_NO_PULL_DO</name>																	
+						<name>INACTIVE</name>																	
 						<description>Inactive (no pull-down/pull-up resistor enabled).</description>																	
 						<value>0x0</value>																	
 					</enumeratedValue>																		
 					<enumeratedValue>																		
-						<name>PULL_DOWN_RESISTOR_E</name>																	
+						<name>PULL_DOWN</name>																	
 						<description>Pull-down resistor enabled.</description>																	
 						<value>0x1</value>																	
 					</enumeratedValue>																		
 					<enumeratedValue>																		
-						<name>PULL_UP_RESISTOR_ENA</name>																	
+						<name>PULL_UP</name>																	
 						<description>Pull-up resistor enabled.</description>																	
 						<value>0x2</value>																	
 					</enumeratedValue>																		
 					<enumeratedValue>																		
-						<name>REPEATER_MODE_</name>																	
+						<name>REPEATER</name>																	
 						<description>Repeater mode.</description>																	
 						<value>0x3</value>																	
 					</enumeratedValue>																		
@@ -8465,12 +8465,12 @@ controller </description>
 				<enumeratedValues>																			
 				<name>ENUM</name>																			
 					<enumeratedValue>																		
-						<name>DISABLE_</name>																	
+						<name>DISABLED</name>																	
 						<description>Disable.</description>																	
 						<value>0</value>																	
 					</enumeratedValue>																		
 					<enumeratedValue>																		
-						<name>ENABLE_</name>																	
+						<name>ENABLED</name>																	
 						<description>Enable.</description>																	
 						<value>1</value>																	
 					</enumeratedValue>																		
@@ -8483,12 +8483,12 @@ controller </description>
 				<enumeratedValues>																			
 				<name>ENUM</name>																			
 					<enumeratedValue>																		
-						<name>INPUT_NOT_INVERTED_</name>																	
+						<name>NOT_INVERTED</name>																	
 						<description>Input not inverted (HIGH on pin reads as 1, LOW on pin reads as 0).</description>																	
 						<value>0</value>																	
 					</enumeratedValue>																		
 					<enumeratedValue>																		
-						<name>INPUT_INVERTED_HIGH</name>																	
+						<name>INVERTED</name>																	
 						<description>Input inverted (HIGH on pin reads as 0, LOW on pin reads as 1).</description>																	
 						<value>1</value>																	
 					</enumeratedValue>																		
@@ -8507,12 +8507,12 @@ controller </description>
 				<enumeratedValues>																			
 				<name>ENUM</name>																			
 					<enumeratedValue>																		
-						<name>DISABLE_</name>																	
+						<name>DISABLED</name>																	
 						<description>Disable.</description>																	
 						<value>0</value>																	
 					</enumeratedValue>																		
 					<enumeratedValue>																		
-						<name>OPEN_DRAIN_MODE_ENAB</name>																	
+						<name>OPEN_DRAIN</name>																	
 						<description>Open-drain mode enabled.  This is not a true open-drain mode.</description>																	
 						<value>1</value>																	
 					</enumeratedValue>																		
@@ -8541,22 +8541,22 @@ controller </description>
 				<enumeratedValues>																			
 				<name>ENUM</name>																			
 					<enumeratedValue>																		
-						<name>SWCLK_</name>																	
+						<name>SWCLK</name>																	
 						<description>SWCLK.</description>																	
 						<value>0x0</value>																	
 					</enumeratedValue>																		
 					<enumeratedValue>																		
-						<name>PIO0_10_</name>																	
+						<name>PIO0_10</name>																	
 						<description>PIO0_10.</description>																	
 						<value>0x1</value>																	
 					</enumeratedValue>																		
 					<enumeratedValue>																		
-						<name>SCK0_</name>																	
+						<name>SCK0</name>																	
 						<description>SCK0.</description>																	
 						<value>0x2</value>																	
 					</enumeratedValue>																		
 					<enumeratedValue>																		
-						<name>CT16B0_MAT2_</name>																	
+						<name>CT16B0_MAT2</name>																	
 						<description>CT16B0_MAT2.</description>																	
 						<value>0x3</value>																	
 					</enumeratedValue>																		
@@ -8569,22 +8569,22 @@ controller </description>
 				<enumeratedValues>																			
 				<name>ENUM</name>																			
 					<enumeratedValue>																		
-						<name>INACTIVE_NO_PULL_DO</name>																	
+						<name>INACTIVE</name>																	
 						<description>Inactive (no pull-down/pull-up resistor enabled).</description>																	
 						<value>0x0</value>																	
 					</enumeratedValue>																		
 					<enumeratedValue>																		
-						<name>PULL_DOWN_RESISTOR_E</name>																	
+						<name>PULL_DOWN</name>																	
 						<description>Pull-down resistor enabled.</description>																	
 						<value>0x1</value>																	
 					</enumeratedValue>																		
 					<enumeratedValue>																		
-						<name>PULL_UP_RESISTOR_ENA</name>																	
+						<name>PULL_UP</name>																	
 						<description>Pull-up resistor enabled.</description>																	
 						<value>0x2</value>																	
 					</enumeratedValue>																		
 					<enumeratedValue>																		
-						<name>REPEATER_MODE_</name>																	
+						<name>REPEATER</name>																	
 						<description>Repeater mode.</description>																	
 						<value>0x3</value>																	
 					</enumeratedValue>																		
@@ -8597,12 +8597,12 @@ controller </description>
 				<enumeratedValues>																			
 				<name>ENUM</name>																			
 					<enumeratedValue>																		
-						<name>DISABLE_</name>																	
+						<name>DISABLED</name>																	
 						<description>Disable.</description>																	
 						<value>0</value>																	
 					</enumeratedValue>																		
 					<enumeratedValue>																		
-						<name>ENABLE_</name>																	
+						<name>ENABLED</name>																	
 						<description>Enable.</description>																	
 						<value>1</value>																	
 					</enumeratedValue>																		
@@ -8615,12 +8615,12 @@ controller </description>
 				<enumeratedValues>																			
 				<name>ENUM</name>																			
 					<enumeratedValue>																		
-						<name>INPUT_NOT_INVERTED_</name>																	
+						<name>NOT_INVERTED</name>																	
 						<description>Input not inverted (HIGH on pin reads as 1, LOW on pin reads as 0).</description>																	
 						<value>0</value>																	
 					</enumeratedValue>																		
 					<enumeratedValue>																		
-						<name>INPUT_INVERTED_HIGH</name>																	
+						<name>INVERTED</name>																	
 						<description>Input inverted (HIGH on pin reads as 0, LOW on pin reads as 1).</description>																	
 						<value>1</value>																	
 					</enumeratedValue>																		
@@ -8639,12 +8639,12 @@ controller </description>
 				<enumeratedValues>																			
 				<name>ENUM</name>																			
 					<enumeratedValue>																		
-						<name>DISABLE_</name>																	
+						<name>DISABLED</name>																	
 						<description>Disable.</description>																	
 						<value>0</value>																	
 					</enumeratedValue>																		
 					<enumeratedValue>																		
-						<name>OPEN_DRAIN_MODE_ENAB</name>																	
+						<name>OPEN_DRAIN</name>																	
 						<description>Open-drain mode enabled.  This is not a true open-drain mode.</description>																	
 						<value>1</value>																	
 					</enumeratedValue>																		
@@ -8673,22 +8673,22 @@ controller </description>
 				<enumeratedValues>																			
 				<name>ENUM</name>																			
 					<enumeratedValue>																		
-						<name>TDI_</name>																	
+						<name>TDI</name>																	
 						<description>TDI.</description>																	
 						<value>0x0</value>																	
 					</enumeratedValue>																		
 					<enumeratedValue>																		
-						<name>PIO0_11_</name>																	
+						<name>PIO0_11</name>																	
 						<description>PIO0_11.</description>																	
 						<value>0x1</value>																	
 					</enumeratedValue>																		
 					<enumeratedValue>																		
-						<name>AD0_</name>																	
+						<name>AD0</name>																	
 						<description>AD0.</description>																	
 						<value>0x2</value>																	
 					</enumeratedValue>																		
 					<enumeratedValue>																		
-						<name>CT32B0_MAT3_</name>																	
+						<name>CT32B0_MAT3</name>																	
 						<description>CT32B0_MAT3.</description>																	
 						<value>0x3</value>																	
 					</enumeratedValue>																		
@@ -8701,22 +8701,22 @@ controller </description>
 				<enumeratedValues>																			
 				<name>ENUM</name>																			
 					<enumeratedValue>																		
-						<name>INACTIVE_NO_PULL_DO</name>																	
+						<name>INACTIVE</name>																	
 						<description>Inactive (no pull-down/pull-up resistor enabled).</description>																	
 						<value>0x0</value>																	
 					</enumeratedValue>																		
 					<enumeratedValue>																		
-						<name>PULL_DOWN_RESISTOR_E</name>																	
+						<name>PULL_DOWN</name>																	
 						<description>Pull-down resistor enabled.</description>																	
 						<value>0x1</value>																	
 					</enumeratedValue>																		
 					<enumeratedValue>																		
-						<name>PULL_UP_RESISTOR_ENA</name>																	
+						<name>PULL_UP</name>																	
 						<description>Pull-up resistor enabled.</description>																	
 						<value>0x2</value>																	
 					</enumeratedValue>																		
 					<enumeratedValue>																		
-						<name>REPEATER_MODE_</name>																	
+						<name>REPEATER</name>																	
 						<description>Repeater mode.</description>																	
 						<value>0x3</value>																	
 					</enumeratedValue>																		
@@ -8729,12 +8729,12 @@ controller </description>
 				<enumeratedValues>																			
 				<name>ENUM</name>																			
 					<enumeratedValue>																		
-						<name>DISABLE_</name>																	
+						<name>DISABLED</name>																	
 						<description>Disable.</description>																	
 						<value>0</value>																	
 					</enumeratedValue>																		
 					<enumeratedValue>																		
-						<name>ENABLE_</name>																	
+						<name>ENABLED</name>																	
 						<description>Enable.</description>																	
 						<value>1</value>																	
 					</enumeratedValue>																		
@@ -8747,12 +8747,12 @@ controller </description>
 				<enumeratedValues>																			
 				<name>ENUM</name>																			
 					<enumeratedValue>																		
-						<name>INPUT_NOT_INVERTED_</name>																	
+						<name>NOT_INVERTED</name>																	
 						<description>Input not inverted (HIGH on pin reads as 1, LOW on pin reads as 0).</description>																	
 						<value>0</value>																	
 					</enumeratedValue>																		
 					<enumeratedValue>																		
-						<name>INPUT_INVERTED_HIGH</name>																	
+						<name>INVERTED</name>																	
 						<description>Input inverted (HIGH on pin reads as 0, LOW on pin reads as 1).</description>																	
 						<value>1</value>																	
 					</enumeratedValue>																		
@@ -8765,12 +8765,12 @@ controller </description>
 				<enumeratedValues>																			
 				<name>ENUM</name>																			
 					<enumeratedValue>																		
-						<name>ANALOG_INPUT_MODE_</name>																	
+						<name>ANALOG</name>																	
 						<description>Analog input mode.</description>																	
 						<value>0</value>																	
 					</enumeratedValue>																		
 					<enumeratedValue>																		
-						<name>DIGITAL_FUNCTIONAL_M</name>																	
+						<name>DIGITAL</name>																	
 						<description>Digital functional mode.</description>																	
 						<value>1</value>																	
 					</enumeratedValue>																		
@@ -8783,12 +8783,12 @@ controller </description>
 				<enumeratedValues>																			
 				<name>ENUM</name>																			
 					<enumeratedValue>																		
-						<name>FILTER_ENABLED_</name>																	
+						<name>ENABLED</name>																	
 						<description>Filter enabled.</description>																	
 						<value>0</value>																	
 					</enumeratedValue>																		
 					<enumeratedValue>																		
-						<name>FILTER_DISABLED_</name>																	
+						<name>DISABLED</name>																	
 						<description>Filter disabled.</description>																	
 						<value>1</value>																	
 					</enumeratedValue>																		
@@ -8807,12 +8807,12 @@ controller </description>
 				<enumeratedValues>																			
 				<name>ENUM</name>																			
 					<enumeratedValue>																		
-						<name>DISABLE_</name>																	
+						<name>DISABLED</name>																	
 						<description>Disable.</description>																	
 						<value>0</value>																	
 					</enumeratedValue>																		
 					<enumeratedValue>																		
-						<name>OPEN_DRAIN_MODE_ENAB</name>																	
+						<name>OPEN_DRAIN</name>																	
 						<description>Open-drain mode enabled.  This is not a true open-drain mode.</description>																	
 						<value>1</value>																	
 					</enumeratedValue>																		
@@ -8841,22 +8841,22 @@ controller </description>
 				<enumeratedValues>																			
 				<name>ENUM</name>																			
 					<enumeratedValue>																		
-						<name>TMS_</name>																	
+						<name>TMS</name>																	
 						<description>TMS.</description>																	
 						<value>0x0</value>																	
 					</enumeratedValue>																		
 					<enumeratedValue>																		
-						<name>PIO0_12_</name>																	
+						<name>PIO0_12</name>																	
 						<description>PIO0_12.</description>																	
 						<value>0x1</value>																	
 					</enumeratedValue>																		
 					<enumeratedValue>																		
-						<name>AD1_</name>																	
+						<name>AD1</name>																	
 						<description>AD1.</description>																	
 						<value>0x2</value>																	
 					</enumeratedValue>																		
 					<enumeratedValue>																		
-						<name>CT32B1_CAP0_</name>																	
+						<name>CT32B1_CAP0</name>																	
 						<description>CT32B1_CAP0.</description>																	
 						<value>0x3</value>																	
 					</enumeratedValue>																		
@@ -8869,22 +8869,22 @@ controller </description>
 				<enumeratedValues>																			
 				<name>ENUM</name>																			
 					<enumeratedValue>																		
-						<name>INACTIVE_NO_PULL_DO</name>																	
+						<name>INACTIVE</name>																	
 						<description>Inactive (no pull-down/pull-up resistor enabled).</description>																	
 						<value>0x0</value>																	
 					</enumeratedValue>																		
 					<enumeratedValue>																		
-						<name>PULL_DOWN_RESISTOR_E</name>																	
+						<name>PULL_DOWN</name>																	
 						<description>Pull-down resistor enabled.</description>																	
 						<value>0x1</value>																	
 					</enumeratedValue>																		
 					<enumeratedValue>																		
-						<name>PULL_UP_RESISTOR_ENA</name>																	
+						<name>PULL_UP</name>																	
 						<description>Pull-up resistor enabled.</description>																	
 						<value>0x2</value>																	
 					</enumeratedValue>																		
 					<enumeratedValue>																		
-						<name>REPEATER_MODE_</name>																	
+						<name>REPEATER</name>																	
 						<description>Repeater mode.</description>																	
 						<value>0x3</value>																	
 					</enumeratedValue>																		
@@ -8897,12 +8897,12 @@ controller </description>
 				<enumeratedValues>																			
 				<name>ENUM</name>																			
 					<enumeratedValue>																		
-						<name>DISABLE_</name>																	
+						<name>DISABLED</name>																	
 						<description>Disable.</description>																	
 						<value>0</value>																	
 					</enumeratedValue>																		
 					<enumeratedValue>																		
-						<name>ENABLE_</name>																	
+						<name>ENABLED</name>																	
 						<description>Enable.</description>																	
 						<value>1</value>																	
 					</enumeratedValue>																		
@@ -8915,12 +8915,12 @@ controller </description>
 				<enumeratedValues>																			
 				<name>ENUM</name>																			
 					<enumeratedValue>																		
-						<name>INPUT_NOT_INVERTED_</name>																	
+						<name>NOT_INVERTED</name>																	
 						<description>Input not inverted (HIGH on pin reads as 1, LOW on pin reads as 0).</description>																	
 						<value>0</value>																	
 					</enumeratedValue>																		
 					<enumeratedValue>																		
-						<name>INPUT_INVERTED_HIGH</name>																	
+						<name>INVERTED</name>																	
 						<description>Input inverted (HIGH on pin reads as 0, LOW on pin reads as 1).</description>																	
 						<value>1</value>																	
 					</enumeratedValue>																		
@@ -8933,12 +8933,12 @@ controller </description>
 				<enumeratedValues>																			
 				<name>ENUM</name>																			
 					<enumeratedValue>																		
-						<name>ANALOG_INPUT_MODE_</name>																	
+						<name>ANALOG</name>																	
 						<description>Analog input mode.</description>																	
 						<value>0</value>																	
 					</enumeratedValue>																		
 					<enumeratedValue>																		
-						<name>DIGITAL_FUNCTIONAL_M</name>																	
+						<name>DIGITAL</name>																	
 						<description>Digital functional mode.</description>																	
 						<value>1</value>																	
 					</enumeratedValue>																		
@@ -8951,12 +8951,12 @@ controller </description>
 				<enumeratedValues>																			
 				<name>ENUM</name>																			
 					<enumeratedValue>																		
-						<name>FILTER_ENABLED_</name>																	
+						<name>ENABLED</name>																	
 						<description>Filter enabled.</description>																	
 						<value>0</value>																	
 					</enumeratedValue>																		
 					<enumeratedValue>																		
-						<name>FILTER_DISABLED_</name>																	
+						<name>DISABLED</name>																	
 						<description>Filter disabled.</description>																	
 						<value>1</value>																	
 					</enumeratedValue>																		
@@ -8975,12 +8975,12 @@ controller </description>
 				<enumeratedValues>																			
 				<name>ENUM</name>																			
 					<enumeratedValue>																		
-						<name>DISABLE_</name>																	
+						<name>DISABLED</name>																	
 						<description>Disable.</description>																	
 						<value>0</value>																	
 					</enumeratedValue>																		
 					<enumeratedValue>																		
-						<name>OPEN_DRAIN_MODE_ENAB</name>																	
+						<name>OPEN_DRAIN</name>																	
 						<description>Open-drain mode enabled.  This is not a true open-drain mode.</description>																	
 						<value>1</value>																	
 					</enumeratedValue>																		
@@ -9009,22 +9009,22 @@ controller </description>
 				<enumeratedValues>																			
 				<name>ENUM</name>																			
 					<enumeratedValue>																		
-						<name>TDO_</name>																	
+						<name>TDO</name>																	
 						<description>TDO.</description>																	
 						<value>0x0</value>																	
 					</enumeratedValue>																		
 					<enumeratedValue>																		
-						<name>PIO0_13_</name>																	
+						<name>PIO0_13</name>																	
 						<description>PIO0_13.</description>																	
 						<value>0x1</value>																	
 					</enumeratedValue>																		
 					<enumeratedValue>																		
-						<name>AD2_</name>																	
+						<name>AD2</name>																	
 						<description>AD2.</description>																	
 						<value>0x2</value>																	
 					</enumeratedValue>																		
 					<enumeratedValue>																		
-						<name>CT32B1_MAT0_</name>																	
+						<name>CT32B1_MAT0</name>																	
 						<description>CT32B1_MAT0.</description>																	
 						<value>0x3</value>																	
 					</enumeratedValue>																		
@@ -9037,22 +9037,22 @@ controller </description>
 				<enumeratedValues>																			
 				<name>ENUM</name>																			
 					<enumeratedValue>																		
-						<name>INACTIVE_NO_PULL_DO</name>																	
+						<name>INACTIVE</name>																	
 						<description>Inactive (no pull-down/pull-up resistor enabled).</description>																	
 						<value>0x0</value>																	
 					</enumeratedValue>																		
 					<enumeratedValue>																		
-						<name>PULL_DOWN_RESISTOR_E</name>																	
+						<name>PULL_DOWN</name>																	
 						<description>Pull-down resistor enabled.</description>																	
 						<value>0x1</value>																	
 					</enumeratedValue>																		
 					<enumeratedValue>																		
-						<name>PULL_UP_RESISTOR_ENA</name>																	
+						<name>PULL_UP</name>																	
 						<description>Pull-up resistor enabled.</description>																	
 						<value>0x2</value>																	
 					</enumeratedValue>																		
 					<enumeratedValue>																		
-						<name>REPEATER_MODE_</name>																	
+						<name>REPEATER</name>																	
 						<description>Repeater mode.</description>																	
 						<value>0x3</value>																	
 					</enumeratedValue>																		
@@ -9065,12 +9065,12 @@ controller </description>
 				<enumeratedValues>																			
 				<name>ENUM</name>																			
 					<enumeratedValue>																		
-						<name>DISABLE_</name>																	
+						<name>DISABLED</name>																	
 						<description>Disable.</description>																	
 						<value>0</value>																	
 					</enumeratedValue>																		
 					<enumeratedValue>																		
-						<name>ENABLE_</name>																	
+						<name>ENABLED</name>																	
 						<description>Enable.</description>																	
 						<value>1</value>																	
 					</enumeratedValue>																		
@@ -9083,12 +9083,12 @@ controller </description>
 				<enumeratedValues>																			
 				<name>ENUM</name>																			
 					<enumeratedValue>																		
-						<name>INPUT_NOT_INVERTED_</name>																	
+						<name>NOT_INVERTED</name>																	
 						<description>Input not inverted (HIGH on pin reads as 1, LOW on pin reads as 0).</description>																	
 						<value>0</value>																	
 					</enumeratedValue>																		
 					<enumeratedValue>																		
-						<name>INPUT_INVERTED_HIGH</name>																	
+						<name>INVERTED</name>																	
 						<description>Input inverted (HIGH on pin reads as 0, LOW on pin reads as 1).</description>																	
 						<value>1</value>																	
 					</enumeratedValue>																		
@@ -9101,12 +9101,12 @@ controller </description>
 				<enumeratedValues>																			
 				<name>ENUM</name>																			
 					<enumeratedValue>																		
-						<name>ANALOG_INPUT_MODE_</name>																	
+						<name>ANALOG</name>																	
 						<description>Analog input mode.</description>																	
 						<value>0</value>																	
 					</enumeratedValue>																		
 					<enumeratedValue>																		
-						<name>DIGITAL_FUNCTIONAL_M</name>																	
+						<name>DIGITAL</name>																	
 						<description>Digital functional mode.</description>																	
 						<value>1</value>																	
 					</enumeratedValue>																		
@@ -9119,12 +9119,12 @@ controller </description>
 				<enumeratedValues>																			
 				<name>ENUM</name>																			
 					<enumeratedValue>																		
-						<name>FILTER_ENABLED_</name>																	
+						<name>ENABLED</name>																	
 						<description>Filter enabled.</description>																	
 						<value>0</value>																	
 					</enumeratedValue>																		
 					<enumeratedValue>																		
-						<name>FILTER_DISABLED_</name>																	
+						<name>DISABLED</name>																	
 						<description>Filter disabled.</description>																	
 						<value>1</value>																	
 					</enumeratedValue>																		
@@ -9143,12 +9143,12 @@ controller </description>
 				<enumeratedValues>																			
 				<name>ENUM</name>																			
 					<enumeratedValue>																		
-						<name>DISABLE_</name>																	
+						<name>DISABLED</name>																	
 						<description>Disable.</description>																	
 						<value>0</value>																	
 					</enumeratedValue>																		
 					<enumeratedValue>																		
-						<name>OPEN_DRAIN_MODE_ENAB</name>																	
+						<name>OPEN_DRAIN</name>																	
 						<description>Open-drain mode enabled.  This is not a true open-drain mode.</description>																	
 						<value>1</value>																	
 					</enumeratedValue>																		
@@ -9177,22 +9177,22 @@ controller </description>
 				<enumeratedValues>																			
 				<name>ENUM</name>																			
 					<enumeratedValue>																		
-						<name>TRST_</name>																	
+						<name>TRST</name>																	
 						<description>TRST.</description>																	
 						<value>0x0</value>																	
 					</enumeratedValue>																		
 					<enumeratedValue>																		
-						<name>PIO0_14_</name>																	
+						<name>PIO0_14</name>																	
 						<description>PIO0_14.</description>																	
 						<value>0x1</value>																	
 					</enumeratedValue>																		
 					<enumeratedValue>																		
-						<name>AD3_</name>																	
+						<name>AD3</name>																	
 						<description>AD3.</description>																	
 						<value>0x2</value>																	
 					</enumeratedValue>																		
 					<enumeratedValue>																		
-						<name>CT32B1_MAT1_</name>																	
+						<name>CT32B1_MAT1</name>																	
 						<description>CT32B1_MAT1.</description>																	
 						<value>0x3</value>																	
 					</enumeratedValue>																		
@@ -9205,22 +9205,22 @@ controller </description>
 				<enumeratedValues>																			
 				<name>ENUM</name>																			
 					<enumeratedValue>																		
-						<name>INACTIVE_NO_PULL_DO</name>																	
+						<name>INACTIVE</name>																	
 						<description>Inactive (no pull-down/pull-up resistor enabled).</description>																	
 						<value>0x0</value>																	
 					</enumeratedValue>																		
 					<enumeratedValue>																		
-						<name>PULL_DOWN_RESISTOR_E</name>																	
+						<name>PULL_DOWN</name>																	
 						<description>Pull-down resistor enabled.</description>																	
 						<value>0x1</value>																	
 					</enumeratedValue>																		
 					<enumeratedValue>																		
-						<name>PULL_UP_RESISTOR_ENA</name>																	
+						<name>PULL_UP</name>																	
 						<description>Pull-up resistor enabled.</description>																	
 						<value>0x2</value>																	
 					</enumeratedValue>																		
 					<enumeratedValue>																		
-						<name>REPEATER_MODE_</name>																	
+						<name>REPEATER</name>																	
 						<description>Repeater mode.</description>																	
 						<value>0x3</value>																	
 					</enumeratedValue>																		
@@ -9233,12 +9233,12 @@ controller </description>
 				<enumeratedValues>																			
 				<name>ENUM</name>																			
 					<enumeratedValue>																		
-						<name>DISABLE_</name>																	
+						<name>DISABLED</name>																	
 						<description>Disable.</description>																	
 						<value>0</value>																	
 					</enumeratedValue>																		
 					<enumeratedValue>																		
-						<name>ENABLE_</name>																	
+						<name>ENABLED</name>																	
 						<description>Enable.</description>																	
 						<value>1</value>																	
 					</enumeratedValue>																		
@@ -9251,12 +9251,12 @@ controller </description>
 				<enumeratedValues>																			
 				<name>ENUM</name>																			
 					<enumeratedValue>																		
-						<name>INPUT_NOT_INVERTED_</name>																	
+						<name>NOT_INVERTED</name>																	
 						<description>Input not inverted (HIGH on pin reads as 1, LOW on pin reads as 0).</description>																	
 						<value>0</value>																	
 					</enumeratedValue>																		
 					<enumeratedValue>																		
-						<name>INPUT_INVERTED_HIGH</name>																	
+						<name>INVERTED</name>																	
 						<description>Input inverted (HIGH on pin reads as 0, LOW on pin reads as 1).</description>																	
 						<value>1</value>																	
 					</enumeratedValue>																		
@@ -9269,12 +9269,12 @@ controller </description>
 				<enumeratedValues>																			
 				<name>ENUM</name>																			
 					<enumeratedValue>																		
-						<name>ANALOG_INPUT_MODE_</name>																	
+						<name>ANALOG</name>																	
 						<description>Analog input mode.</description>																	
 						<value>0</value>																	
 					</enumeratedValue>																		
 					<enumeratedValue>																		
-						<name>DIGITAL_FUNCTIONAL_M</name>																	
+						<name>DIGITAL</name>																	
 						<description>Digital functional mode.</description>																	
 						<value>1</value>																	
 					</enumeratedValue>																		
@@ -9287,12 +9287,12 @@ controller </description>
 				<enumeratedValues>																			
 				<name>ENUM</name>																			
 					<enumeratedValue>																		
-						<name>FILTER_ENABLED_</name>																	
+						<name>ENABLED</name>																	
 						<description>Filter enabled.</description>																	
 						<value>0</value>																	
 					</enumeratedValue>																		
 					<enumeratedValue>																		
-						<name>FILTER_DISABLED_</name>																	
+						<name>DISABLED</name>																	
 						<description>Filter disabled.</description>																	
 						<value>1</value>																	
 					</enumeratedValue>																		
@@ -9311,12 +9311,12 @@ controller </description>
 				<enumeratedValues>																			
 				<name>ENUM</name>																			
 					<enumeratedValue>																		
-						<name>DISABLE_</name>																	
+						<name>DISABLED</name>																	
 						<description>Disable.</description>																	
 						<value>0</value>																	
 					</enumeratedValue>																		
 					<enumeratedValue>																		
-						<name>OPEN_DRAIN_MODE_ENAB</name>																	
+						<name>OPEN_DRAIN</name>																	
 						<description>Open-drain mode enabled.  This is not a true open-drain mode.</description>																	
 						<value>1</value>																	
 					</enumeratedValue>																		
@@ -9345,22 +9345,22 @@ controller </description>
 				<enumeratedValues>																			
 				<name>ENUM</name>																			
 					<enumeratedValue>																		
-						<name>SWDIO_</name>																	
+						<name>SWDIO</name>																	
 						<description>SWDIO.</description>																	
 						<value>0x0</value>																	
 					</enumeratedValue>																		
 					<enumeratedValue>																		
-						<name>PIO0_15_</name>																	
+						<name>PIO0_15</name>																	
 						<description>PIO0_15.</description>																	
 						<value>0x1</value>																	
 					</enumeratedValue>																		
 					<enumeratedValue>																		
-						<name>AD4_</name>																	
+						<name>AD4</name>																	
 						<description>AD4.</description>																	
 						<value>0x2</value>																	
 					</enumeratedValue>																		
 					<enumeratedValue>																		
-						<name>CT32B1_MAT2_</name>																	
+						<name>CT32B1_MAT2</name>																	
 						<description>CT32B1_MAT2.</description>																	
 						<value>0x3</value>																	
 					</enumeratedValue>																		
@@ -9373,22 +9373,22 @@ controller </description>
 				<enumeratedValues>																			
 				<name>ENUM</name>																			
 					<enumeratedValue>																		
-						<name>INACTIVE_NO_PULL_DO</name>																	
+						<name>INACTIVE</name>																	
 						<description>Inactive (no pull-down/pull-up resistor enabled).</description>																	
 						<value>0x0</value>																	
 					</enumeratedValue>																		
 					<enumeratedValue>																		
-						<name>PULL_DOWN_RESISTOR_E</name>																	
+						<name>PULL_DOWN</name>																	
 						<description>Pull-down resistor enabled.</description>																	
 						<value>0x1</value>																	
 					</enumeratedValue>																		
 					<enumeratedValue>																		
-						<name>PULL_UP_RESISTOR_ENA</name>																	
+						<name>PULL_UP</name>																	
 						<description>Pull-up resistor enabled.</description>																	
 						<value>0x2</value>																	
 					</enumeratedValue>																		
 					<enumeratedValue>																		
-						<name>REPEATER_MODE_</name>																	
+						<name>REPEATER</name>																	
 						<description>Repeater mode.</description>																	
 						<value>0x3</value>																	
 					</enumeratedValue>																		
@@ -9401,12 +9401,12 @@ controller </description>
 				<enumeratedValues>																			
 				<name>ENUM</name>																			
 					<enumeratedValue>																		
-						<name>DISABLE_</name>																	
+						<name>DISABLED</name>																	
 						<description>Disable.</description>																	
 						<value>0</value>																	
 					</enumeratedValue>																		
 					<enumeratedValue>																		
-						<name>ENABLE_</name>																	
+						<name>ENABLED</name>																	
 						<description>Enable.</description>																	
 						<value>1</value>																	
 					</enumeratedValue>																		
@@ -9419,12 +9419,12 @@ controller </description>
 				<enumeratedValues>																			
 				<name>ENUM</name>																			
 					<enumeratedValue>																		
-						<name>INPUT_NOT_INVERTED_</name>																	
+						<name>NOT_INVERTED</name>																	
 						<description>Input not inverted (HIGH on pin reads as 1, LOW on pin reads as 0).</description>																	
 						<value>0</value>																	
 					</enumeratedValue>																		
 					<enumeratedValue>																		
-						<name>INPUT_INVERTED_HIGH</name>																	
+						<name>INVERTED</name>																	
 						<description>Input inverted (HIGH on pin reads as 0, LOW on pin reads as 1).</description>																	
 						<value>1</value>																	
 					</enumeratedValue>																		
@@ -9437,12 +9437,12 @@ controller </description>
 				<enumeratedValues>																			
 				<name>ENUM</name>																			
 					<enumeratedValue>																		
-						<name>ANALOG_INPUT_MODE_</name>																	
+						<name>ANALOG</name>																	
 						<description>Analog input mode.</description>																	
 						<value>0</value>																	
 					</enumeratedValue>																		
 					<enumeratedValue>																		
-						<name>DIGITAL_FUNCTIONAL_M</name>																	
+						<name>DIGITAL</name>																	
 						<description>Digital functional mode.</description>																	
 						<value>1</value>																	
 					</enumeratedValue>																		
@@ -9455,12 +9455,12 @@ controller </description>
 				<enumeratedValues>																			
 				<name>ENUM</name>																			
 					<enumeratedValue>																		
-						<name>FILTER_ENABLED_</name>																	
+						<name>ENABLED</name>																	
 						<description>Filter enabled.</description>																	
 						<value>0</value>																	
 					</enumeratedValue>																		
 					<enumeratedValue>																		
-						<name>FILTER_DISABLED_</name>																	
+						<name>DISABLED</name>																	
 						<description>Filter disabled.</description>																	
 						<value>1</value>																	
 					</enumeratedValue>																		
@@ -9479,12 +9479,12 @@ controller </description>
 				<enumeratedValues>																			
 				<name>ENUM</name>																			
 					<enumeratedValue>																		
-						<name>DISABLE_</name>																	
+						<name>DISABLED</name>																	
 						<description>Disable.</description>																	
 						<value>0</value>																	
 					</enumeratedValue>																		
 					<enumeratedValue>																		
-						<name>OPEN_DRAIN_MODE_ENAB</name>																	
+						<name>OPEN_DRAIN</name>																	
 						<description>Open-drain mode enabled.  This is not a true open-drain mode.</description>																	
 						<value>1</value>																	
 					</enumeratedValue>																		
@@ -9513,17 +9513,17 @@ controller </description>
 				<enumeratedValues>																			
 				<name>ENUM</name>																			
 					<enumeratedValue>																		
-						<name>PIO0_16_</name>																	
+						<name>PIO0_16</name>																	
 						<description>PIO0_16.</description>																	
 						<value>0x0</value>																	
 					</enumeratedValue>																		
 					<enumeratedValue>																		
-						<name>AD5_</name>																	
+						<name>AD5</name>																	
 						<description>AD5.</description>																	
 						<value>0x1</value>																	
 					</enumeratedValue>																		
 					<enumeratedValue>																		
-						<name>CT32B1_MAT3_</name>																	
+						<name>CT32B1_MAT3</name>																	
 						<description>CT32B1_MAT3.</description>																	
 						<value>0x2</value>																	
 					</enumeratedValue>																		
@@ -9536,22 +9536,22 @@ controller </description>
 				<enumeratedValues>																			
 				<name>ENUM</name>																			
 					<enumeratedValue>																		
-						<name>INACTIVE_NO_PULL_DO</name>																	
+						<name>INACTIVE</name>																	
 						<description>Inactive (no pull-down/pull-up resistor enabled).</description>																	
 						<value>0x0</value>																	
 					</enumeratedValue>																		
 					<enumeratedValue>																		
-						<name>PULL_DOWN_RESISTOR_E</name>																	
+						<name>PULL_DOWN</name>																	
 						<description>Pull-down resistor enabled.</description>																	
 						<value>0x1</value>																	
 					</enumeratedValue>																		
 					<enumeratedValue>																		
-						<name>PULL_UP_RESISTOR_ENA</name>																	
+						<name>PULL_UP</name>																	
 						<description>Pull-up resistor enabled.</description>																	
 						<value>0x2</value>																	
 					</enumeratedValue>																		
 					<enumeratedValue>																		
-						<name>REPEATER_MODE_</name>																	
+						<name>REPEATER</name>																	
 						<description>Repeater mode.</description>																	
 						<value>0x3</value>																	
 					</enumeratedValue>																		
@@ -9564,12 +9564,12 @@ controller </description>
 				<enumeratedValues>																			
 				<name>ENUM</name>																			
 					<enumeratedValue>																		
-						<name>DISABLE_</name>																	
+						<name>DISABLED</name>																	
 						<description>Disable.</description>																	
 						<value>0</value>																	
 					</enumeratedValue>																		
 					<enumeratedValue>																		
-						<name>ENABLE_</name>																	
+						<name>ENABLED</name>																	
 						<description>Enable.</description>																	
 						<value>1</value>																	
 					</enumeratedValue>																		
@@ -9582,12 +9582,12 @@ controller </description>
 				<enumeratedValues>																			
 				<name>ENUM</name>																			
 					<enumeratedValue>																		
-						<name>INPUT_NOT_INVERTED_</name>																	
+						<name>NOT_INVERTED</name>																	
 						<description>Input not inverted (HIGH on pin reads as 1, LOW on pin reads as 0).</description>																	
 						<value>0</value>																	
 					</enumeratedValue>																		
 					<enumeratedValue>																		
-						<name>INPUT_INVERTED_HIGH</name>																	
+						<name>INVERTED</name>																	
 						<description>Input inverted (HIGH on pin reads as 0, LOW on pin reads as 1).</description>																	
 						<value>1</value>																	
 					</enumeratedValue>																		
@@ -9600,12 +9600,12 @@ controller </description>
 				<enumeratedValues>																			
 				<name>ENUM</name>																			
 					<enumeratedValue>																		
-						<name>ANALOG_INPUT_MODE_</name>																	
+						<name>ANALOG</name>																	
 						<description>Analog input mode.</description>																	
 						<value>0</value>																	
 					</enumeratedValue>																		
 					<enumeratedValue>																		
-						<name>DIGITAL_FUNCTIONAL_M</name>																	
+						<name>DIGITAL</name>																	
 						<description>Digital functional mode.</description>																	
 						<value>1</value>																	
 					</enumeratedValue>																		
@@ -9618,12 +9618,12 @@ controller </description>
 				<enumeratedValues>																			
 				<name>ENUM</name>																			
 					<enumeratedValue>																		
-						<name>FILTER_ENABLED_</name>																	
+						<name>ENABLED</name>																	
 						<description>Filter enabled.</description>																	
 						<value>0</value>																	
 					</enumeratedValue>																		
 					<enumeratedValue>																		
-						<name>FILTER_DISABLED_</name>																	
+						<name>DISABLED</name>																	
 						<description>Filter disabled.</description>																	
 						<value>1</value>																	
 					</enumeratedValue>																		
@@ -9642,12 +9642,12 @@ controller </description>
 				<enumeratedValues>																			
 				<name>ENUM</name>																			
 					<enumeratedValue>																		
-						<name>DISABLE_</name>																	
+						<name>DISABLED</name>																	
 						<description>Disable.</description>																	
 						<value>0</value>																	
 					</enumeratedValue>																		
 					<enumeratedValue>																		
-						<name>OPEN_DRAIN_MODE_ENAB</name>																	
+						<name>OPEN_DRAIN</name>																	
 						<description>Open-drain mode enabled.  This is not a true open-drain mode.</description>																	
 						<value>1</value>																	
 					</enumeratedValue>																		
@@ -9676,17 +9676,17 @@ controller </description>
 				<enumeratedValues>																			
 				<name>ENUM</name>																			
 					<enumeratedValue>																		
-						<name>PIO0_17_</name>																	
+						<name>PIO0_17</name>																	
 						<description>PIO0_17.</description>																	
 						<value>0x0</value>																	
 					</enumeratedValue>																		
 					<enumeratedValue>																		
-						<name>RTS_</name>																	
+						<name>RTS</name>																	
 						<description>RTS.</description>																	
 						<value>0x1</value>																	
 					</enumeratedValue>																		
 					<enumeratedValue>																		
-						<name>CT32B0_CAP0_</name>																	
+						<name>CT32B0_CAP0</name>																	
 						<description>CT32B0_CAP0.</description>																	
 						<value>0x2</value>																	
 					</enumeratedValue>																		
@@ -9704,22 +9704,22 @@ controller </description>
 				<enumeratedValues>																			
 				<name>ENUM</name>																			
 					<enumeratedValue>																		
-						<name>INACTIVE_NO_PULL_DO</name>																	
+						<name>INACTIVE</name>																	
 						<description>Inactive (no pull-down/pull-up resistor enabled).</description>																	
 						<value>0x0</value>																	
 					</enumeratedValue>																		
 					<enumeratedValue>																		
-						<name>PULL_DOWN_RESISTOR_E</name>																	
+						<name>PULL_DOWN</name>																	
 						<description>Pull-down resistor enabled.</description>																	
 						<value>0x1</value>																	
 					</enumeratedValue>																		
 					<enumeratedValue>																		
-						<name>PULL_UP_RESISTOR_ENA</name>																	
+						<name>PULL_UP</name>																	
 						<description>Pull-up resistor enabled.</description>																	
 						<value>0x2</value>																	
 					</enumeratedValue>																		
 					<enumeratedValue>																		
-						<name>REPEATER_MODE_</name>																	
+						<name>REPEATER</name>																	
 						<description>Repeater mode.</description>																	
 						<value>0x3</value>																	
 					</enumeratedValue>																		
@@ -9732,12 +9732,12 @@ controller </description>
 				<enumeratedValues>																			
 				<name>ENUM</name>																			
 					<enumeratedValue>																		
-						<name>DISABLE_</name>																	
+						<name>DISABLED</name>																	
 						<description>Disable.</description>																	
 						<value>0</value>																	
 					</enumeratedValue>																		
 					<enumeratedValue>																		
-						<name>ENABLE_</name>																	
+						<name>ENABLED</name>																	
 						<description>Enable.</description>																	
 						<value>1</value>																	
 					</enumeratedValue>																		
@@ -9750,12 +9750,12 @@ controller </description>
 				<enumeratedValues>																			
 				<name>ENUM</name>																			
 					<enumeratedValue>																		
-						<name>INPUT_NOT_INVERTED_</name>																	
+						<name>NOT_INVERTED</name>																	
 						<description>Input not inverted (HIGH on pin reads as 1, LOW on pin reads as 0).</description>																	
 						<value>0</value>																	
 					</enumeratedValue>																		
 					<enumeratedValue>																		
-						<name>INPUT_INVERTED_HIGH</name>																	
+						<name>INVERTED</name>																	
 						<description>Input inverted (HIGH on pin reads as 0, LOW on pin reads as 1).</description>																	
 						<value>1</value>																	
 					</enumeratedValue>																		
@@ -9774,12 +9774,12 @@ controller </description>
 				<enumeratedValues>																			
 				<name>ENUM</name>																			
 					<enumeratedValue>																		
-						<name>DISABLE_</name>																	
+						<name>DISABLED</name>																	
 						<description>Disable.</description>																	
 						<value>0</value>																	
 					</enumeratedValue>																		
 					<enumeratedValue>																		
-						<name>OPEN_DRAIN_MODE_ENAB</name>																	
+						<name>OPEN_DRAIN</name>																	
 						<description>Open-drain mode enabled.  This is not a true open-drain mode.</description>																	
 						<value>1</value>																	
 					</enumeratedValue>																		
@@ -9808,17 +9808,17 @@ controller </description>
 				<enumeratedValues>																			
 				<name>ENUM</name>																			
 					<enumeratedValue>																		
-						<name>PIO0_18_</name>																	
+						<name>PIO0_18</name>																	
 						<description>PIO0_18.</description>																	
 						<value>0x0</value>																	
 					</enumeratedValue>																		
 					<enumeratedValue>																		
-						<name>RXD_</name>																	
+						<name>RXD</name>																	
 						<description>RXD.</description>																	
 						<value>0x1</value>																	
 					</enumeratedValue>																		
 					<enumeratedValue>																		
-						<name>CT32B0_MAT0_</name>																	
+						<name>CT32B0_MAT0</name>																	
 						<description>CT32B0_MAT0.</description>																	
 						<value>0x2</value>																	
 					</enumeratedValue>																		
@@ -9831,22 +9831,22 @@ controller </description>
 				<enumeratedValues>																			
 				<name>ENUM</name>																			
 					<enumeratedValue>																		
-						<name>INACTIVE_NO_PULL_DO</name>																	
+						<name>INACTIVE</name>																	
 						<description>Inactive (no pull-down/pull-up resistor enabled).</description>																	
 						<value>0x0</value>																	
 					</enumeratedValue>																		
 					<enumeratedValue>																		
-						<name>PULL_DOWN_RESISTOR_E</name>																	
+						<name>PULL_DOWN</name>																	
 						<description>Pull-down resistor enabled.</description>																	
 						<value>0x1</value>																	
 					</enumeratedValue>																		
 					<enumeratedValue>																		
-						<name>PULL_UP_RESISTOR_ENA</name>																	
+						<name>PULL_UP</name>																	
 						<description>Pull-up resistor enabled.</description>																	
 						<value>0x2</value>																	
 					</enumeratedValue>																		
 					<enumeratedValue>																		
-						<name>REPEATER_MODE_</name>																	
+						<name>REPEATER</name>																	
 						<description>Repeater mode.</description>																	
 						<value>0x3</value>																	
 					</enumeratedValue>																		
@@ -9859,12 +9859,12 @@ controller </description>
 				<enumeratedValues>																			
 				<name>ENUM</name>																			
 					<enumeratedValue>																		
-						<name>DISABLE_</name>																	
+						<name>DISABLED</name>																	
 						<description>Disable.</description>																	
 						<value>0</value>																	
 					</enumeratedValue>																		
 					<enumeratedValue>																		
-						<name>ENABLE_</name>																	
+						<name>ENABLED</name>																	
 						<description>Enable.</description>																	
 						<value>1</value>																	
 					</enumeratedValue>																		
@@ -9877,12 +9877,12 @@ controller </description>
 				<enumeratedValues>																			
 				<name>ENUM</name>																			
 					<enumeratedValue>																		
-						<name>INPUT_NOT_INVERTED_</name>																	
+						<name>NOT_INVERTED</name>																	
 						<description>Input not inverted (HIGH on pin reads as 1, LOW on pin reads as 0).</description>																	
 						<value>0</value>																	
 					</enumeratedValue>																		
 					<enumeratedValue>																		
-						<name>INPUT_INVERTED_HIGH</name>																	
+						<name>INVERTED</name>																	
 						<description>Input inverted (HIGH on pin reads as 0, LOW on pin reads as 1).</description>																	
 						<value>1</value>																	
 					</enumeratedValue>																		
@@ -9901,12 +9901,12 @@ controller </description>
 				<enumeratedValues>																			
 				<name>ENUM</name>																			
 					<enumeratedValue>																		
-						<name>DISABLE_</name>																	
+						<name>DISABLED</name>																	
 						<description>Disable.</description>																	
 						<value>0</value>																	
 					</enumeratedValue>																		
 					<enumeratedValue>																		
-						<name>OPEN_DRAIN_MODE_ENAB</name>																	
+						<name>OPEN_DRAIN</name>																	
 						<description>Open-drain mode enabled.  This is not a true open-drain mode.</description>																	
 						<value>1</value>																	
 					</enumeratedValue>																		
@@ -9935,17 +9935,17 @@ controller </description>
 				<enumeratedValues>																			
 				<name>ENUM</name>																			
 					<enumeratedValue>																		
-						<name>PIO0_19_</name>																	
+						<name>PIO0_19</name>																	
 						<description>PIO0_19.</description>																	
 						<value>0x0</value>																	
 					</enumeratedValue>																		
 					<enumeratedValue>																		
-						<name>TXD_</name>																	
+						<name>TXD</name>																	
 						<description>TXD.</description>																	
 						<value>0x1</value>																	
 					</enumeratedValue>																		
 					<enumeratedValue>																		
-						<name>CT32B0_MAT1_</name>																	
+						<name>CT32B0_MAT1</name>																	
 						<description>CT32B0_MAT1.</description>																	
 						<value>0x2</value>																	
 					</enumeratedValue>																		
@@ -9958,22 +9958,22 @@ controller </description>
 				<enumeratedValues>																			
 				<name>ENUM</name>																			
 					<enumeratedValue>																		
-						<name>INACTIVE_NO_PULL_DO</name>																	
+						<name>INACTIVE</name>																	
 						<description>Inactive (no pull-down/pull-up resistor enabled).</description>																	
 						<value>0x0</value>																	
 					</enumeratedValue>																		
 					<enumeratedValue>																		
-						<name>PULL_DOWN_RESISTOR_E</name>																	
+						<name>PULL_DOWN</name>																	
 						<description>Pull-down resistor enabled.</description>																	
 						<value>0x1</value>																	
 					</enumeratedValue>																		
 					<enumeratedValue>																		
-						<name>PULL_UP_RESISTOR_ENA</name>																	
+						<name>PULL_UP</name>																	
 						<description>Pull-up resistor enabled.</description>																	
 						<value>0x2</value>																	
 					</enumeratedValue>																		
 					<enumeratedValue>																		
-						<name>REPEATER_MODE_</name>																	
+						<name>REPEATER</name>																	
 						<description>Repeater mode.</description>																	
 						<value>0x3</value>																	
 					</enumeratedValue>																		
@@ -9986,12 +9986,12 @@ controller </description>
 				<enumeratedValues>																			
 				<name>ENUM</name>																			
 					<enumeratedValue>																		
-						<name>DISABLE_</name>																	
+						<name>DISABLED</name>																	
 						<description>Disable.</description>																	
 						<value>0</value>																	
 					</enumeratedValue>																		
 					<enumeratedValue>																		
-						<name>ENABLE_</name>																	
+						<name>ENABLED</name>																	
 						<description>Enable.</description>																	
 						<value>1</value>																	
 					</enumeratedValue>																		
@@ -10004,12 +10004,12 @@ controller </description>
 				<enumeratedValues>																			
 				<name>ENUM</name>																			
 					<enumeratedValue>																		
-						<name>INPUT_NOT_INVERTED_</name>																	
+						<name>NOT_INVERTED</name>																	
 						<description>Input not inverted (HIGH on pin reads as 1, LOW on pin reads as 0).</description>																	
 						<value>0</value>																	
 					</enumeratedValue>																		
 					<enumeratedValue>																		
-						<name>INPUT_INVERTED_HIGH</name>																	
+						<name>INVERTED</name>																	
 						<description>Input inverted (HIGH on pin reads as 0, LOW on pin reads as 1).</description>																	
 						<value>1</value>																	
 					</enumeratedValue>																		
@@ -10028,12 +10028,12 @@ controller </description>
 				<enumeratedValues>																			
 				<name>ENUM</name>																			
 					<enumeratedValue>																		
-						<name>DISABLE_</name>																	
+						<name>DISABLED</name>																	
 						<description>Disable.</description>																	
 						<value>0</value>																	
 					</enumeratedValue>																		
 					<enumeratedValue>																		
-						<name>OPEN_DRAIN_MODE_ENAB</name>																	
+						<name>OPEN_DRAIN</name>																	
 						<description>Open-drain mode enabled.  This is not a true open-drain mode.</description>																	
 						<value>1</value>																	
 					</enumeratedValue>																		
@@ -10062,12 +10062,12 @@ controller </description>
 				<enumeratedValues>																			
 				<name>ENUM</name>																			
 					<enumeratedValue>																		
-						<name>PIO0_20_</name>																	
+						<name>PIO0_20</name>																	
 						<description>PIO0_20.</description>																	
 						<value>0x0</value>																	
 					</enumeratedValue>																		
 					<enumeratedValue>																		
-						<name>CT16B1_CAP0_</name>																	
+						<name>CT16B1_CAP0</name>																	
 						<description>CT16B1_CAP0.</description>																	
 						<value>0x1</value>																	
 					</enumeratedValue>																		
@@ -10080,22 +10080,22 @@ controller </description>
 				<enumeratedValues>																			
 				<name>ENUM</name>																			
 					<enumeratedValue>																		
-						<name>INACTIVE_NO_PULL_DO</name>																	
+						<name>INACTIVE</name>																	
 						<description>Inactive (no pull-down/pull-up resistor enabled).</description>																	
 						<value>0x0</value>																	
 					</enumeratedValue>																		
 					<enumeratedValue>																		
-						<name>PULL_DOWN_RESISTOR_E</name>																	
+						<name>PULL_DOWN</name>																	
 						<description>Pull-down resistor enabled.</description>																	
 						<value>0x1</value>																	
 					</enumeratedValue>																		
 					<enumeratedValue>																		
-						<name>PULL_UP_RESISTOR_ENA</name>																	
+						<name>PULL_UP</name>																	
 						<description>Pull-up resistor enabled.</description>																	
 						<value>0x2</value>																	
 					</enumeratedValue>																		
 					<enumeratedValue>																		
-						<name>REPEATER_MODE_</name>																	
+						<name>REPEATER</name>																	
 						<description>Repeater mode.</description>																	
 						<value>0x3</value>																	
 					</enumeratedValue>																		
@@ -10108,12 +10108,12 @@ controller </description>
 				<enumeratedValues>																			
 				<name>ENUM</name>																			
 					<enumeratedValue>																		
-						<name>DISABLE_</name>																	
+						<name>DISABLED</name>																	
 						<description>Disable.</description>																	
 						<value>0</value>																	
 					</enumeratedValue>																		
 					<enumeratedValue>																		
-						<name>ENABLE_</name>																	
+						<name>ENABLED</name>																	
 						<description>Enable.</description>																	
 						<value>1</value>																	
 					</enumeratedValue>																		
@@ -10126,12 +10126,12 @@ controller </description>
 				<enumeratedValues>																			
 				<name>ENUM</name>																			
 					<enumeratedValue>																		
-						<name>INPUT_NOT_INVERTED_</name>																	
+						<name>NOT_INVERTED</name>																	
 						<description>Input not inverted (HIGH on pin reads as 1, LOW on pin reads as 0).</description>																	
 						<value>0</value>																	
 					</enumeratedValue>																		
 					<enumeratedValue>																		
-						<name>INPUT_INVERTED_HIGH</name>																	
+						<name>INVERTED</name>																	
 						<description>Input inverted (HIGH on pin reads as 0, LOW on pin reads as 1).</description>																	
 						<value>1</value>																	
 					</enumeratedValue>																		
@@ -10150,12 +10150,12 @@ controller </description>
 				<enumeratedValues>																			
 				<name>ENUM</name>																			
 					<enumeratedValue>																		
-						<name>DISABLE_</name>																	
+						<name>DISABLED</name>																	
 						<description>Disable.</description>																	
 						<value>0</value>																	
 					</enumeratedValue>																		
 					<enumeratedValue>																		
-						<name>OPEN_DRAIN_MODE_ENAB</name>																	
+						<name>OPEN_DRAIN</name>																	
 						<description>Open-drain mode enabled.  This is not a true open-drain mode.</description>																	
 						<value>1</value>																	
 					</enumeratedValue>																		
@@ -10184,17 +10184,17 @@ controller </description>
 				<enumeratedValues>																			
 				<name>ENUM</name>																			
 					<enumeratedValue>																		
-						<name>PIO0_21_</name>																	
+						<name>PIO0_21</name>																	
 						<description>PIO0_21.</description>																	
 						<value>0x0</value>																	
 					</enumeratedValue>																		
 					<enumeratedValue>																		
-						<name>CT16B1_MAT0_</name>																	
+						<name>CT16B1_MAT0</name>																	
 						<description>CT16B1_MAT0.</description>																	
 						<value>0x1</value>																	
 					</enumeratedValue>																		
 					<enumeratedValue>																		
-						<name>MOSI1_</name>																	
+						<name>MOSI1</name>																	
 						<description>MOSI1.</description>																	
 						<value>0x2</value>																	
 					</enumeratedValue>																		
@@ -10207,22 +10207,22 @@ controller </description>
 				<enumeratedValues>																			
 				<name>ENUM</name>																			
 					<enumeratedValue>																		
-						<name>INACTIVE_NO_PULL_DO</name>																	
+						<name>INACTIVE</name>																	
 						<description>Inactive (no pull-down/pull-up resistor enabled).</description>																	
 						<value>0x0</value>																	
 					</enumeratedValue>																		
 					<enumeratedValue>																		
-						<name>PULL_DOWN_RESISTOR_E</name>																	
+						<name>PULL_DOWN</name>																	
 						<description>Pull-down resistor enabled.</description>																	
 						<value>0x1</value>																	
 					</enumeratedValue>																		
 					<enumeratedValue>																		
-						<name>PULL_UP_RESISTOR_ENA</name>																	
+						<name>PULL_UP</name>																	
 						<description>Pull-up resistor enabled.</description>																	
 						<value>0x2</value>																	
 					</enumeratedValue>																		
 					<enumeratedValue>																		
-						<name>REPEATER_MODE_</name>																	
+						<name>REPEATER</name>																	
 						<description>Repeater mode.</description>																	
 						<value>0x3</value>																	
 					</enumeratedValue>																		
@@ -10235,12 +10235,12 @@ controller </description>
 				<enumeratedValues>																			
 				<name>ENUM</name>																			
 					<enumeratedValue>																		
-						<name>DISABLE_</name>																	
+						<name>DISABLED</name>																	
 						<description>Disable.</description>																	
 						<value>0</value>																	
 					</enumeratedValue>																		
 					<enumeratedValue>																		
-						<name>ENABLE_</name>																	
+						<name>ENABLED</name>																	
 						<description>Enable.</description>																	
 						<value>1</value>																	
 					</enumeratedValue>																		
@@ -10253,12 +10253,12 @@ controller </description>
 				<enumeratedValues>																			
 				<name>ENUM</name>																			
 					<enumeratedValue>																		
-						<name>INPUT_NOT_INVERTED_</name>																	
+						<name>NOT_INVERTED</name>																	
 						<description>Input not inverted (HIGH on pin reads as 1, LOW on pin reads as 0).</description>																	
 						<value>0</value>																	
 					</enumeratedValue>																		
 					<enumeratedValue>																		
-						<name>INPUT_INVERTED_HIGH</name>																	
+						<name>INVERTED</name>																	
 						<description>Input inverted (HIGH on pin reads as 0, LOW on pin reads as 1).</description>																	
 						<value>1</value>																	
 					</enumeratedValue>																		
@@ -10277,12 +10277,12 @@ controller </description>
 				<enumeratedValues>																			
 				<name>ENUM</name>																			
 					<enumeratedValue>																		
-						<name>DISABLE_</name>																	
+						<name>DISABLED</name>																	
 						<description>Disable.</description>																	
 						<value>0</value>																	
 					</enumeratedValue>																		
 					<enumeratedValue>																		
-						<name>OPEN_DRAIN_MODE_ENAB</name>																	
+						<name>OPEN_DRAIN</name>																	
 						<description>Open-drain mode enabled.  This is not a true open-drain mode.</description>																	
 						<value>1</value>																	
 					</enumeratedValue>																		
@@ -10313,22 +10313,22 @@ controller </description>
 				<name>ENUM</name>																			
 																							
 					<enumeratedValue>																		
-						<name>PIO0_22_</name>																	
+						<name>PIO0_22</name>																	
 						<description>PIO0_22.</description>																	
 						<value>0x0</value>																	
 					</enumeratedValue>																		
 					<enumeratedValue>																		
-						<name>AD6_</name>																	
+						<name>AD6</name>																	
 						<description>AD6.</description>																	
 						<value>0x1</value>																	
 					</enumeratedValue>																		
 					<enumeratedValue>																		
-						<name>CT16B1_MAT1_</name>																	
+						<name>CT16B1_MAT1</name>																	
 						<description>CT16B1_MAT1.</description>																	
 						<value>0x2</value>																	
 					</enumeratedValue>																		
 					<enumeratedValue>																		
-						<name>MISO1_</name>																	
+						<name>MISO1</name>																	
 						<description>MISO1.</description>																	
 						<value>0x3</value>																	
 					</enumeratedValue>																		
@@ -10343,22 +10343,22 @@ controller </description>
 				<name>ENUM</name>																			
 																							
 					<enumeratedValue>																		
-						<name>INACTIVE_NO_PULL_DO</name>																	
+						<name>INACTIVE</name>																	
 						<description>Inactive (no pull-down/pull-up resistor enabled).</description>																	
 						<value>0x0</value>																	
 					</enumeratedValue>																		
 					<enumeratedValue>																		
-						<name>PULL_DOWN_RESISTOR_E</name>																	
+						<name>PULL_DOWN</name>																	
 						<description>Pull-down resistor enabled.</description>																	
 						<value>0x1</value>																	
 					</enumeratedValue>																		
 					<enumeratedValue>																		
-						<name>PULL_UP_RESISTOR_ENA</name>																	
+						<name>PULL_UP</name>																	
 						<description>Pull-up resistor enabled.</description>																	
 						<value>0x2</value>																	
 					</enumeratedValue>																		
 					<enumeratedValue>																		
-						<name>REPEATER_MODE_</name>																	
+						<name>REPEATER</name>																	
 						<description>Repeater mode.</description>																	
 						<value>0x3</value>																	
 					</enumeratedValue>																		
@@ -10373,12 +10373,12 @@ controller </description>
 				<name>ENUM</name>																			
 																							
 					<enumeratedValue>																		
-						<name>DISABLE_</name>																	
+						<name>DISABLED</name>																	
 						<description>Disable.</description>																	
 						<value>0</value>																	
 					</enumeratedValue>																		
 					<enumeratedValue>																		
-						<name>ENABLE_</name>																	
+						<name>ENABLED</name>																	
 						<description>Enable.</description>																	
 						<value>1</value>																	
 					</enumeratedValue>																		
@@ -10393,12 +10393,12 @@ controller </description>
 				<name>ENUM</name>																			
 																							
 					<enumeratedValue>																		
-						<name>INPUT_NOT_INVERTED_</name>																	
+						<name>NOT_INVERTED</name>																	
 						<description>Input not inverted (HIGH on pin reads as 1, LOW on pin reads as 0).</description>																	
 						<value>0</value>																	
 					</enumeratedValue>																		
 					<enumeratedValue>																		
-						<name>INPUT_INVERTED_HIGH</name>																	
+						<name>INVERTED</name>																	
 						<description>Input inverted (HIGH on pin reads as 0, LOW on pin reads as 1).</description>																	
 						<value>1</value>																	
 					</enumeratedValue>																		
@@ -10413,12 +10413,12 @@ controller </description>
 				<name>ENUM</name>																			
 																							
 					<enumeratedValue>																		
-						<name>ANALOG_INPUT_MODE_</name>																	
+						<name>ANALOG</name>																	
 						<description>Analog input mode.</description>																	
 						<value>0</value>																	
 					</enumeratedValue>																		
 					<enumeratedValue>																		
-						<name>DIGITAL_FUNCTIONAL_M</name>																	
+						<name>DIGITAL</name>																	
 						<description>Digital functional mode.</description>																	
 						<value>1</value>																	
 					</enumeratedValue>																		
@@ -10433,12 +10433,12 @@ controller </description>
 				<name>ENUM</name>																			
 																							
 					<enumeratedValue>																		
-						<name>FILTER_ENABLED_</name>																	
+						<name>ENABLED</name>																	
 						<description>Filter enabled.</description>																	
 						<value>0</value>																	
 					</enumeratedValue>																		
 					<enumeratedValue>																		
-						<name>FILTER_DISABLED_</name>																	
+						<name>DISABLED</name>																	
 						<description>Filter disabled.</description>																	
 						<value>1</value>																	
 					</enumeratedValue>																		
@@ -10460,12 +10460,12 @@ controller </description>
 				<name>ENUM</name>																			
 																							
 					<enumeratedValue>																		
-						<name>DISABLE_</name>																	
+						<name>DISABLED</name>																	
 						<description>Disable.</description>																	
 						<value>0</value>																	
 					</enumeratedValue>																		
 					<enumeratedValue>																		
-						<name>OPEN_DRAIN_MODE_ENAB</name>																	
+						<name>OPEN_DRAIN</name>																	
 						<description>Open-drain mode enabled.  This is not a true open-drain mode.</description>																	
 						<value>1</value>																	
 					</enumeratedValue>																		
@@ -10497,12 +10497,12 @@ controller </description>
 				<name>ENUM</name>																			
 																							
 					<enumeratedValue>																		
-						<name>PIO0_23_</name>																	
+						<name>PIO0_23</name>																	
 						<description>PIO0_23.</description>																	
 						<value>0x0</value>																	
 					</enumeratedValue>																		
 					<enumeratedValue>																		
-						<name>AD7_</name>																	
+						<name>AD7</name>																	
 						<description>AD7.</description>																	
 						<value>0x1</value>																	
 					</enumeratedValue>																		
@@ -10517,22 +10517,22 @@ controller </description>
 				<name>ENUM</name>																			
 																							
 					<enumeratedValue>																		
-						<name>INACTIVE_NO_PULL_DO</name>																	
+						<name>INACTIVE</name>																	
 						<description>Inactive (no pull-down/pull-up resistor enabled).</description>																	
 						<value>0x0</value>																	
 					</enumeratedValue>																		
 					<enumeratedValue>																		
-						<name>PULL_DOWN_RESISTOR_E</name>																	
+						<name>PULL_DOWN</name>																	
 						<description>Pull-down resistor enabled.</description>																	
 						<value>0x1</value>																	
 					</enumeratedValue>																		
 					<enumeratedValue>																		
-						<name>PULL_UP_RESISTOR_ENA</name>																	
+						<name>PULL_UP</name>																	
 						<description>Pull-up resistor enabled.</description>																	
 						<value>0x2</value>																	
 					</enumeratedValue>																		
 					<enumeratedValue>																		
-						<name>REPEATER_MODE_</name>																	
+						<name>REPEATER</name>																	
 						<description>Repeater mode.</description>																	
 						<value>0x3</value>																	
 					</enumeratedValue>																		
@@ -10547,12 +10547,12 @@ controller </description>
 				<name>ENUM</name>																			
 																							
 					<enumeratedValue>																		
-						<name>DISABLE_</name>																	
+						<name>DISABLED</name>																	
 						<description>Disable.</description>																	
 						<value>0</value>																	
 					</enumeratedValue>																		
 					<enumeratedValue>																		
-						<name>ENABLE_</name>																	
+						<name>ENABLED</name>																	
 						<description>Enable.</description>																	
 						<value>1</value>																	
 					</enumeratedValue>																		
@@ -10567,12 +10567,12 @@ controller </description>
 				<name>ENUM</name>																			
 																							
 					<enumeratedValue>																		
-						<name>INPUT_NOT_INVERTED_</name>																	
+						<name>NOT_INVERTED</name>																	
 						<description>Input not inverted (HIGH on pin reads as 1, LOW on pin reads as 0).</description>																	
 						<value>0</value>																	
 					</enumeratedValue>																		
 					<enumeratedValue>																		
-						<name>INPUT_INVERTED_HIGH</name>																	
+						<name>INVERTED</name>																	
 						<description>Input inverted (HIGH on pin reads as 0, LOW on pin reads as 1).</description>																	
 						<value>1</value>																	
 					</enumeratedValue>																		
@@ -10587,12 +10587,12 @@ controller </description>
 				<name>ENUM</name>																			
 																							
 					<enumeratedValue>																		
-						<name>ANALOG_INPUT_MODE_</name>																	
+						<name>ANALOG</name>																	
 						<description>Analog input mode.</description>																	
 						<value>0</value>																	
 					</enumeratedValue>																		
 					<enumeratedValue>																		
-						<name>DIGITAL_FUNCTIONAL_M</name>																	
+						<name>DIGITAL</name>																	
 						<description>Digital functional mode.</description>																	
 						<value>1</value>																	
 					</enumeratedValue>																		
@@ -10607,12 +10607,12 @@ controller </description>
 				<name>ENUM</name>																			
 																							
 					<enumeratedValue>																		
-						<name>FILTER_ENABLED_</name>																	
+						<name>ENABLED</name>																	
 						<description>Filter enabled.</description>																	
 						<value>0</value>																	
 					</enumeratedValue>																		
 					<enumeratedValue>																		
-						<name>FILTER_DISABLED_</name>																	
+						<name>DISABLED</name>																	
 						<description>Filter disabled.</description>																	
 						<value>1</value>																	
 					</enumeratedValue>																		
@@ -10634,12 +10634,12 @@ controller </description>
 				<name>ENUM</name>																			
 																							
 					<enumeratedValue>																		
-						<name>DISABLE_</name>																	
+						<name>DISABLED</name>																	
 						<description>Disable.</description>																	
 						<value>0</value>																	
 					</enumeratedValue>																		
 					<enumeratedValue>																		
-						<name>OPEN_DRAIN_MODE_ENAB</name>																	
+						<name>OPEN_DRAIN</name>																	
 						<description>Open-drain mode enabled.  This is not a true open-drain mode.</description>																	
 						<value>1</value>																	
 					</enumeratedValue>																		
@@ -10671,12 +10671,12 @@ controller </description>
 				<name>ENUM</name>																			
 																							
 					<enumeratedValue>																		
-						<name>PIO1_0_</name>																	
+						<name>PIO1_0</name>																	
 						<description>PIO1_0.</description>																	
 						<value>0x0</value>																	
 					</enumeratedValue>																		
 					<enumeratedValue>																		
-						<name>CT32B1_MAT1_</name>																	
+						<name>CT32B1_MAT1</name>																	
 						<description>CT32B1_MAT1.</description>																	
 						<value>0x1</value>																	
 					</enumeratedValue>																		
@@ -10691,22 +10691,22 @@ controller </description>
 				<name>ENUM</name>																			
 																							
 					<enumeratedValue>																		
-						<name>INACTIVE_NO_PULL_DO</name>																	
+						<name>INACTIVE</name>																	
 						<description>Inactive (no pull-down/pull-up resistor enabled).</description>																	
 						<value>0x0</value>																	
 					</enumeratedValue>																		
 					<enumeratedValue>																		
-						<name>PULL_DOWN_RESISTOR_E</name>																	
+						<name>PULL_DOWN</name>																	
 						<description>Pull-down resistor enabled.</description>																	
 						<value>0x1</value>																	
 					</enumeratedValue>																		
 					<enumeratedValue>																		
-						<name>PULL_UP_RESISTOR_ENA</name>																	
+						<name>PULL_UP</name>																	
 						<description>Pull-up resistor enabled.</description>																	
 						<value>0x2</value>																	
 					</enumeratedValue>																		
 					<enumeratedValue>																		
-						<name>REPEATER_MODE_</name>																	
+						<name>REPEATER</name>																	
 						<description>Repeater mode.</description>																	
 						<value>0x3</value>																	
 					</enumeratedValue>																		
@@ -10721,12 +10721,12 @@ controller </description>
 				<name>ENUM</name>																			
 																							
 					<enumeratedValue>																		
-						<name>DISABLE_</name>																	
+						<name>DISABLED</name>																	
 						<description>Disable.</description>																	
 						<value>0</value>																	
 					</enumeratedValue>																		
 					<enumeratedValue>																		
-						<name>ENABLE_</name>																	
+						<name>ENABLED</name>																	
 						<description>Enable.</description>																	
 						<value>1</value>																	
 					</enumeratedValue>																		
@@ -10741,12 +10741,12 @@ controller </description>
 				<name>ENUM</name>																			
 																							
 					<enumeratedValue>																		
-						<name>INPUT_NOT_INVERTED_</name>																	
+						<name>NOT_INVERTED</name>																	
 						<description>Input not inverted (HIGH on pin reads as 1, LOW on pin reads as 0).</description>																	
 						<value>0</value>																	
 					</enumeratedValue>																		
 					<enumeratedValue>																		
-						<name>INPUT_INVERTED_HIGH</name>																	
+						<name>INVERTED</name>																	
 						<description>Input inverted (HIGH on pin reads as 0, LOW on pin reads as 1).</description>																	
 						<value>1</value>																	
 					</enumeratedValue>																		
@@ -10768,12 +10768,12 @@ controller </description>
 				<name>ENUM</name>																			
 																							
 					<enumeratedValue>																		
-						<name>DISABLE_</name>																	
+						<name>DISABLED</name>																	
 						<description>Disable.</description>																	
 						<value>0</value>																	
 					</enumeratedValue>																		
 					<enumeratedValue>																		
-						<name>OPEN_DRAIN_MODE_ENAB</name>																	
+						<name>OPEN_DRAIN</name>																	
 						<description>Open-drain mode enabled. This is not a true open-drain mode. Input cannot be pulled up above VDD.</description>																	
 						<value>1</value>																	
 					</enumeratedValue>																		
@@ -10805,12 +10805,12 @@ controller </description>
 				<name>ENUM</name>																			
 																							
 					<enumeratedValue>																		
-						<name>PIO1_1_</name>																	
+						<name>PIO1_1</name>																	
 						<description>PIO1_1.</description>																	
 						<value>0x0</value>																	
 					</enumeratedValue>																		
 					<enumeratedValue>																		
-						<name>CT32B1_MAT1_</name>																	
+						<name>CT32B1_MAT1</name>																	
 						<description>CT32B1_MAT1.</description>																	
 						<value>0x1</value>																	
 					</enumeratedValue>																		
@@ -10825,22 +10825,22 @@ controller </description>
 				<name>ENUM</name>																			
 																							
 					<enumeratedValue>																		
-						<name>INACTIVE_NO_PULL_DO</name>																	
+						<name>INACTIVE</name>																	
 						<description>Inactive (no pull-down/pull-up resistor enabled).</description>																	
 						<value>0x0</value>																	
 					</enumeratedValue>																		
 					<enumeratedValue>																		
-						<name>PULL_DOWN_RESISTOR_E</name>																	
+						<name>PULL_DOWN</name>																	
 						<description>Pull-down resistor enabled.</description>																	
 						<value>0x1</value>																	
 					</enumeratedValue>																		
 					<enumeratedValue>																		
-						<name>PULL_UP_RESISTOR_ENA</name>																	
+						<name>PULL_UP</name>																	
 						<description>Pull-up resistor enabled.</description>																	
 						<value>0x2</value>																	
 					</enumeratedValue>																		
 					<enumeratedValue>																		
-						<name>REPEATER_MODE_</name>																	
+						<name>REPEATER</name>																	
 						<description>Repeater mode.</description>																	
 						<value>0x3</value>																	
 					</enumeratedValue>																		
@@ -10855,12 +10855,12 @@ controller </description>
 				<name>ENUM</name>																			
 																							
 					<enumeratedValue>																		
-						<name>DISABLE_</name>																	
+						<name>DISABLED</name>																	
 						<description>Disable.</description>																	
 						<value>0</value>																	
 					</enumeratedValue>																		
 					<enumeratedValue>																		
-						<name>ENABLE_</name>																	
+						<name>ENABLED</name>																	
 						<description>Enable.</description>																	
 						<value>1</value>																	
 					</enumeratedValue>																		
@@ -10875,12 +10875,12 @@ controller </description>
 				<name>ENUM</name>																			
 																							
 					<enumeratedValue>																		
-						<name>INPUT_NOT_INVERTED_</name>																	
+						<name>NOT_INVERTED</name>																	
 						<description>Input not inverted (HIGH on pin reads as 1, LOW on pin reads as 0).</description>																	
 						<value>0</value>																	
 					</enumeratedValue>																		
 					<enumeratedValue>																		
-						<name>INPUT_INVERTED_HIGH</name>																	
+						<name>INVERTED</name>																	
 						<description>Input inverted (HIGH on pin reads as 0, LOW on pin reads as 1).</description>																	
 						<value>1</value>																	
 					</enumeratedValue>																		
@@ -10902,12 +10902,12 @@ controller </description>
 				<name>ENUM</name>																			
 																							
 					<enumeratedValue>																		
-						<name>DISABLE_</name>																	
+						<name>DISABLED</name>																	
 						<description>Disable.</description>																	
 						<value>0</value>																	
 					</enumeratedValue>																		
 					<enumeratedValue>																		
-						<name>OPEN_DRAIN_MODE_ENAB</name>																	
+						<name>OPEN_DRAIN</name>																	
 						<description>Open-drain mode enabled. This is not a true open-drain mode. Input cannot be pulled up above VDD.</description>																	
 						<value>1</value>																	
 					</enumeratedValue>																		
@@ -10939,12 +10939,12 @@ controller </description>
 				<name>ENUM</name>																			
 																							
 					<enumeratedValue>																		
-						<name>PIO1_2_</name>																	
+						<name>PIO1_2</name>																	
 						<description>PIO1_2.</description>																	
 						<value>0x0</value>																	
 					</enumeratedValue>																		
 					<enumeratedValue>																		
-						<name>CT32B1_MAT2_</name>																	
+						<name>CT32B1_MAT2</name>																	
 						<description>CT32B1_MAT2.</description>																	
 						<value>0x1</value>																	
 					</enumeratedValue>																		
@@ -10959,22 +10959,22 @@ controller </description>
 				<name>ENUM</name>																			
 																							
 					<enumeratedValue>																		
-						<name>INACTIVE_NO_PULL_DO</name>																	
+						<name>INACTIVE</name>																	
 						<description>Inactive (no pull-down/pull-up resistor enabled).</description>																	
 						<value>0x0</value>																	
 					</enumeratedValue>																		
 					<enumeratedValue>																		
-						<name>PULL_DOWN_RESISTOR_E</name>																	
+						<name>PULL_DOWN</name>																	
 						<description>Pull-down resistor enabled.</description>																	
 						<value>0x1</value>																	
 					</enumeratedValue>																		
 					<enumeratedValue>																		
-						<name>PULL_UP_RESISTOR_ENA</name>																	
+						<name>PULL_UP</name>																	
 						<description>Pull-up resistor enabled.</description>																	
 						<value>0x2</value>																	
 					</enumeratedValue>																		
 					<enumeratedValue>																		
-						<name>REPEATER_MODE_</name>																	
+						<name>REPEATER</name>																	
 						<description>Repeater mode.</description>																	
 						<value>0x3</value>																	
 					</enumeratedValue>																		
@@ -10989,12 +10989,12 @@ controller </description>
 				<name>ENUM</name>																			
 																							
 					<enumeratedValue>																		
-						<name>DISABLE_</name>																	
+						<name>DISABLED</name>																	
 						<description>Disable.</description>																	
 						<value>0</value>																	
 					</enumeratedValue>																		
 					<enumeratedValue>																		
-						<name>ENABLE_</name>																	
+						<name>ENABLED</name>																	
 						<description>Enable.</description>																	
 						<value>1</value>																	
 					</enumeratedValue>																		
@@ -11009,12 +11009,12 @@ controller </description>
 				<name>ENUM</name>																			
 																							
 					<enumeratedValue>																		
-						<name>INPUT_NOT_INVERTED_</name>																	
+						<name>NOT_INVERTED</name>																	
 						<description>Input not inverted (HIGH on pin reads as 1, LOW on pin reads as 0).</description>																	
 						<value>0</value>																	
 					</enumeratedValue>																		
 					<enumeratedValue>																		
-						<name>INPUT_INVERTED_HIGH</name>																	
+						<name>INVERTED</name>																	
 						<description>Input inverted (HIGH on pin reads as 0, LOW on pin reads as 1).</description>																	
 						<value>1</value>																	
 					</enumeratedValue>																		
@@ -11036,12 +11036,12 @@ controller </description>
 				<name>ENUM</name>																			
 																							
 					<enumeratedValue>																		
-						<name>DISABLE_</name>																	
+						<name>DISABLED</name>																	
 						<description>Disable.</description>																	
 						<value>0</value>																	
 					</enumeratedValue>																		
 					<enumeratedValue>																		
-						<name>OPEN_DRAIN_MODE_ENAB</name>																	
+						<name>OPEN_DRAIN</name>																	
 						<description>Open-drain mode enabled. This is not a true open-drain mode. Input cannot be pulled up above VDD.</description>																	
 						<value>1</value>																	
 					</enumeratedValue>																		
@@ -11073,12 +11073,12 @@ controller </description>
 				<name>ENUM</name>																			
 																							
 					<enumeratedValue>																		
-						<name>PIO1_3_</name>																	
+						<name>PIO1_3</name>																	
 						<description>PIO1_3.</description>																	
 						<value>0x0</value>																	
 					</enumeratedValue>																		
 					<enumeratedValue>																		
-						<name>CT32B1_MAT3_</name>																	
+						<name>CT32B1_MAT3</name>																	
 						<description>CT32B1_MAT3.</description>																	
 						<value>0x1</value>																	
 					</enumeratedValue>																		
@@ -11093,22 +11093,22 @@ controller </description>
 				<name>ENUM</name>																			
 																							
 					<enumeratedValue>																		
-						<name>INACTIVE_NO_PULL_DO</name>																	
+						<name>INACTIVE</name>																	
 						<description>Inactive (no pull-down/pull-up resistor enabled).</description>																	
 						<value>0x0</value>																	
 					</enumeratedValue>																		
 					<enumeratedValue>																		
-						<name>PULL_DOWN_RESISTOR_E</name>																	
+						<name>PULL_DOWN</name>																	
 						<description>Pull-down resistor enabled.</description>																	
 						<value>0x1</value>																	
 					</enumeratedValue>																		
 					<enumeratedValue>																		
-						<name>PULL_UP_RESISTOR_ENA</name>																	
+						<name>PULL_UP</name>																	
 						<description>Pull-up resistor enabled.</description>																	
 						<value>0x2</value>																	
 					</enumeratedValue>																		
 					<enumeratedValue>																		
-						<name>REPEATER_MODE_</name>																	
+						<name>REPEATER</name>																	
 						<description>Repeater mode.</description>																	
 						<value>0x3</value>																	
 					</enumeratedValue>																		
@@ -11123,12 +11123,12 @@ controller </description>
 				<name>ENUM</name>																			
 																							
 					<enumeratedValue>																		
-						<name>DISABLE_</name>																	
+						<name>DISABLED</name>																	
 						<description>Disable.</description>																	
 						<value>0</value>																	
 					</enumeratedValue>																		
 					<enumeratedValue>																		
-						<name>ENABLE_</name>																	
+						<name>ENABLED</name>																	
 						<description>Enable.</description>																	
 						<value>1</value>																	
 					</enumeratedValue>																		
@@ -11143,12 +11143,12 @@ controller </description>
 				<name>ENUM</name>																			
 																							
 					<enumeratedValue>																		
-						<name>INPUT_NOT_INVERTED_</name>																	
+						<name>NOT_INVERTED</name>																	
 						<description>Input not inverted (HIGH on pin reads as 1, LOW on pin reads as 0).</description>																	
 						<value>0</value>																	
 					</enumeratedValue>																		
 					<enumeratedValue>																		
-						<name>INPUT_INVERTED_HIGH</name>																	
+						<name>INVERTED</name>																	
 						<description>Input inverted (HIGH on pin reads as 0, LOW on pin reads as 1).</description>																	
 						<value>1</value>																	
 					</enumeratedValue>																		
@@ -11170,12 +11170,12 @@ controller </description>
 				<name>ENUM</name>																			
 																							
 					<enumeratedValue>																		
-						<name>DISABLE_</name>																	
+						<name>DISABLED</name>																	
 						<description>Disable.</description>																	
 						<value>0</value>																	
 					</enumeratedValue>																		
 					<enumeratedValue>																		
-						<name>OPEN_DRAIN_MODE_ENAB</name>																	
+						<name>OPEN_DRAIN</name>																	
 						<description>Open-drain mode enabled. This is not a true open-drain mode. Input cannot be pulled up above VDD.</description>																	
 						<value>1</value>																	
 					</enumeratedValue>																		
@@ -11207,12 +11207,12 @@ controller </description>
 				<name>ENUM</name>																			
 																							
 					<enumeratedValue>																		
-						<name>PIO1_4_</name>																	
+						<name>PIO1_4</name>																	
 						<description>PIO1_4.</description>																	
 						<value>0x0</value>																	
 					</enumeratedValue>																		
 					<enumeratedValue>																		
-						<name>CT32B1_CAP0_</name>																	
+						<name>CT32B1_CAP0</name>																	
 						<description>CT32B1_CAP0.</description>																	
 						<value>0x1</value>																	
 					</enumeratedValue>																		
@@ -11227,22 +11227,22 @@ controller </description>
 				<name>ENUM</name>																			
 																							
 					<enumeratedValue>																		
-						<name>INACTIVE_NO_PULL_DO</name>																	
+						<name>INACTIVE</name>																	
 						<description>Inactive (no pull-down/pull-up resistor enabled).</description>																	
 						<value>0x0</value>																	
 					</enumeratedValue>																		
 					<enumeratedValue>																		
-						<name>PULL_DOWN_RESISTOR_E</name>																	
+						<name>PULL_DOWN</name>																	
 						<description>Pull-down resistor enabled.</description>																	
 						<value>0x1</value>																	
 					</enumeratedValue>																		
 					<enumeratedValue>																		
-						<name>PULL_UP_RESISTOR_ENA</name>																	
+						<name>PULL_UP</name>																	
 						<description>Pull-up resistor enabled.</description>																	
 						<value>0x2</value>																	
 					</enumeratedValue>																		
 					<enumeratedValue>																		
-						<name>REPEATER_MODE_</name>																	
+						<name>REPEATER</name>																	
 						<description>Repeater mode.</description>																	
 						<value>0x3</value>																	
 					</enumeratedValue>																		
@@ -11257,12 +11257,12 @@ controller </description>
 				<name>ENUM</name>																			
 																							
 					<enumeratedValue>																		
-						<name>DISABLE_</name>																	
+						<name>DISABLED</name>																	
 						<description>Disable.</description>																	
 						<value>0</value>																	
 					</enumeratedValue>																		
 					<enumeratedValue>																		
-						<name>ENABLE_</name>																	
+						<name>ENABLED</name>																	
 						<description>Enable.</description>																	
 						<value>1</value>																	
 					</enumeratedValue>																		
@@ -11277,12 +11277,12 @@ controller </description>
 				<name>ENUM</name>																			
 																							
 					<enumeratedValue>																		
-						<name>INPUT_NOT_INVERTED_</name>																	
+						<name>NOT_INVERTED</name>																	
 						<description>Input not inverted (HIGH on pin reads as 1, LOW on pin reads as 0).</description>																	
 						<value>0</value>																	
 					</enumeratedValue>																		
 					<enumeratedValue>																		
-						<name>INPUT_INVERTED_HIGH</name>																	
+						<name>INVERTED</name>																	
 						<description>Input inverted (HIGH on pin reads as 0, LOW on pin reads as 1).</description>																	
 						<value>1</value>																	
 					</enumeratedValue>																		
@@ -11304,12 +11304,12 @@ controller </description>
 				<name>ENUM</name>																			
 																							
 					<enumeratedValue>																		
-						<name>DISABLE_</name>																	
+						<name>DISABLED</name>																	
 						<description>Disable.</description>																	
 						<value>0</value>																	
 					</enumeratedValue>																		
 					<enumeratedValue>																		
-						<name>OPEN_DRAIN_MODE_ENAB</name>																	
+						<name>OPEN_DRAIN</name>																	
 						<description>Open-drain mode enabled. This is not a true open-drain mode. Input cannot be pulled up above VDD.</description>																	
 						<value>1</value>																	
 					</enumeratedValue>																		
@@ -11341,12 +11341,12 @@ controller </description>
 				<name>ENUM</name>																			
 																							
 					<enumeratedValue>																		
-						<name>PIO1_5_</name>																	
+						<name>PIO1_5</name>																	
 						<description>PIO1_5.</description>																	
 						<value>0x0</value>																	
 					</enumeratedValue>																		
 					<enumeratedValue>																		
-						<name>CT32B1_CAP1_</name>																	
+						<name>CT32B1_CAP1</name>																	
 						<description>CT32B1_CAP1.</description>																	
 						<value>0x1</value>																	
 					</enumeratedValue>																		
@@ -11361,22 +11361,22 @@ controller </description>
 				<name>ENUM</name>																			
 																							
 					<enumeratedValue>																		
-						<name>INACTIVE_NO_PULL_DO</name>																	
+						<name>INACTIVE</name>																	
 						<description>Inactive (no pull-down/pull-up resistor enabled).</description>																	
 						<value>0x0</value>																	
 					</enumeratedValue>																		
 					<enumeratedValue>																		
-						<name>PULL_DOWN_RESISTOR_E</name>																	
+						<name>PULL_DOWN</name>																	
 						<description>Pull-down resistor enabled.</description>																	
 						<value>0x1</value>																	
 					</enumeratedValue>																		
 					<enumeratedValue>																		
-						<name>PULL_UP_RESISTOR_ENA</name>																	
+						<name>PULL_UP</name>																	
 						<description>Pull-up resistor enabled.</description>																	
 						<value>0x2</value>																	
 					</enumeratedValue>																		
 					<enumeratedValue>																		
-						<name>REPEATER_MODE_</name>																	
+						<name>REPEATER</name>																	
 						<description>Repeater mode.</description>																	
 						<value>0x3</value>																	
 					</enumeratedValue>																		
@@ -11391,12 +11391,12 @@ controller </description>
 				<name>ENUM</name>																			
 																							
 					<enumeratedValue>																		
-						<name>DISABLE_</name>																	
+						<name>DISABLED</name>																	
 						<description>Disable.</description>																	
 						<value>0</value>																	
 					</enumeratedValue>																		
 					<enumeratedValue>																		
-						<name>ENABLE_</name>																	
+						<name>ENABLED</name>																	
 						<description>Enable.</description>																	
 						<value>1</value>																	
 					</enumeratedValue>																		
@@ -11411,12 +11411,12 @@ controller </description>
 				<name>ENUM</name>																			
 																							
 					<enumeratedValue>																		
-						<name>INPUT_NOT_INVERTED_</name>																	
+						<name>NOT_INVERTED</name>																	
 						<description>Input not inverted (HIGH on pin reads as 1, LOW on pin reads as 0).</description>																	
 						<value>0</value>																	
 					</enumeratedValue>																		
 					<enumeratedValue>																		
-						<name>INPUT_INVERTED_HIGH</name>																	
+						<name>INVERTED</name>																	
 						<description>Input inverted (HIGH on pin reads as 0, LOW on pin reads as 1).</description>																	
 						<value>1</value>																	
 					</enumeratedValue>																		
@@ -11438,12 +11438,12 @@ controller </description>
 				<name>ENUM</name>																			
 																							
 					<enumeratedValue>																		
-						<name>DISABLE_</name>																	
+						<name>DISABLED</name>																	
 						<description>Disable.</description>																	
 						<value>0</value>																	
 					</enumeratedValue>																		
 					<enumeratedValue>																		
-						<name>OPEN_DRAIN_MODE_ENAB</name>																	
+						<name>OPEN_DRAIN</name>																	
 						<description>Open-drain mode enabled.  This is not a true open-drain mode.</description>																	
 						<value>1</value>																	
 					</enumeratedValue>																		
@@ -11475,7 +11475,7 @@ controller </description>
 				<name>ENUM</name>																			
 																							
 					<enumeratedValue>																		
-						<name>PIO1_6_</name>																	
+						<name>PIO1_6</name>																	
 						<description>PIO1_6.</description>																	
 						<value>0x0</value>																	
 					</enumeratedValue>																		
@@ -11490,22 +11490,22 @@ controller </description>
 				<name>ENUM</name>																			
 																							
 					<enumeratedValue>																		
-						<name>INACTIVE_NO_PULL_DO</name>																	
+						<name>INACTIVE</name>																	
 						<description>Inactive (no pull-down/pull-up resistor enabled).</description>																	
 						<value>0x0</value>																	
 					</enumeratedValue>																		
 					<enumeratedValue>																		
-						<name>PULL_DOWN_RESISTOR_E</name>																	
+						<name>PULL_DOWN</name>																	
 						<description>Pull-down resistor enabled.</description>																	
 						<value>0x1</value>																	
 					</enumeratedValue>																		
 					<enumeratedValue>																		
-						<name>PULL_UP_RESISTOR_ENA</name>																	
+						<name>PULL_UP</name>																	
 						<description>Pull-up resistor enabled.</description>																	
 						<value>0x2</value>																	
 					</enumeratedValue>																		
 					<enumeratedValue>																		
-						<name>REPEATER_MODE_</name>																	
+						<name>REPEATER</name>																	
 						<description>Repeater mode.</description>																	
 						<value>0x3</value>																	
 					</enumeratedValue>																		
@@ -11520,12 +11520,12 @@ controller </description>
 				<name>ENUM</name>																			
 																							
 					<enumeratedValue>																		
-						<name>DISABLE_</name>																	
+						<name>DISABLED</name>																	
 						<description>Disable.</description>																	
 						<value>0</value>																	
 					</enumeratedValue>																		
 					<enumeratedValue>																		
-						<name>ENABLE_</name>																	
+						<name>ENABLED</name>																	
 						<description>Enable.</description>																	
 						<value>1</value>																	
 					</enumeratedValue>																		
@@ -11540,12 +11540,12 @@ controller </description>
 				<name>ENUM</name>																			
 																							
 					<enumeratedValue>																		
-						<name>INPUT_NOT_INVERTED_</name>																	
+						<name>NOT_INVERTED</name>																	
 						<description>Input not inverted (HIGH on pin reads as 1, LOW on pin reads as 0).</description>																	
 						<value>0</value>																	
 					</enumeratedValue>																		
 					<enumeratedValue>																		
-						<name>INPUT_INVERTED_HIGH</name>																	
+						<name>INVERTED</name>																	
 						<description>Input inverted (HIGH on pin reads as 0, LOW on pin reads as 1).</description>																	
 						<value>1</value>																	
 					</enumeratedValue>																		
@@ -11567,12 +11567,12 @@ controller </description>
 				<name>ENUM</name>																			
 																							
 					<enumeratedValue>																		
-						<name>DISABLE_</name>																	
+						<name>DISABLED</name>																	
 						<description>Disable.</description>																	
 						<value>0</value>																	
 					</enumeratedValue>																		
 					<enumeratedValue>																		
-						<name>OPEN_DRAIN_MODE_ENAB</name>																	
+						<name>OPEN_DRAIN</name>																	
 						<description>Open-drain mode enabled. This is not a true open-drain mode. Input cannot be pulled up above VDD.</description>																	
 						<value>1</value>																	
 					</enumeratedValue>																		
@@ -11604,7 +11604,7 @@ controller </description>
 				<name>ENUM</name>																			
 																							
 					<enumeratedValue>																		
-						<name>PIO1_7_</name>																	
+						<name>PIO1_7</name>																	
 						<description>PIO1_7.</description>																	
 						<value>0x0</value>																	
 					</enumeratedValue>																		
@@ -11619,22 +11619,22 @@ controller </description>
 				<name>ENUM</name>																			
 																							
 					<enumeratedValue>																		
-						<name>INACTIVE_NO_PULL_DO</name>																	
+						<name>INACTIVE</name>																	
 						<description>Inactive (no pull-down/pull-up resistor enabled).</description>																	
 						<value>0x0</value>																	
 					</enumeratedValue>																		
 					<enumeratedValue>																		
-						<name>PULL_DOWN_RESISTOR_E</name>																	
+						<name>PULL_DOWN</name>																	
 						<description>Pull-down resistor enabled.</description>																	
 						<value>0x1</value>																	
 					</enumeratedValue>																		
 					<enumeratedValue>																		
-						<name>PULL_UP_RESISTOR_ENA</name>																	
+						<name>PULL_UP</name>																	
 						<description>Pull-up resistor enabled.</description>																	
 						<value>0x2</value>																	
 					</enumeratedValue>																		
 					<enumeratedValue>																		
-						<name>REPEATER_MODE_</name>																	
+						<name>REPEATER</name>																	
 						<description>Repeater mode.</description>																	
 						<value>0x3</value>																	
 					</enumeratedValue>																		
@@ -11649,12 +11649,12 @@ controller </description>
 				<name>ENUM</name>																			
 																							
 					<enumeratedValue>																		
-						<name>DISABLE_</name>																	
+						<name>DISABLED</name>																	
 						<description>Disable.</description>																	
 						<value>0</value>																	
 					</enumeratedValue>																		
 					<enumeratedValue>																		
-						<name>ENABLE_</name>																	
+						<name>ENABLED</name>																	
 						<description>Enable.</description>																	
 						<value>1</value>																	
 					</enumeratedValue>																		
@@ -11669,12 +11669,12 @@ controller </description>
 				<name>ENUM</name>																			
 																							
 					<enumeratedValue>																		
-						<name>INPUT_NOT_INVERTED_</name>																	
+						<name>NOT_INVERTED</name>																	
 						<description>Input not inverted (HIGH on pin reads as 1, LOW on pin reads as 0).</description>																	
 						<value>0</value>																	
 					</enumeratedValue>																		
 					<enumeratedValue>																		
-						<name>INPUT_INVERTED_HIGH</name>																	
+						<name>INVERTED</name>																	
 						<description>Input inverted (HIGH on pin reads as 0, LOW on pin reads as 1).</description>																	
 						<value>1</value>																	
 					</enumeratedValue>																		
@@ -11696,12 +11696,12 @@ controller </description>
 				<name>ENUM</name>																			
 																							
 					<enumeratedValue>																		
-						<name>DISABLE_</name>																	
+						<name>DISABLED</name>																	
 						<description>Disable.</description>																	
 						<value>0</value>																	
 					</enumeratedValue>																		
 					<enumeratedValue>																		
-						<name>OPEN_DRAIN_MODE_ENAB</name>																	
+						<name>OPEN_DRAIN</name>																	
 						<description>Open-drain mode enabled. This is not a true open-drain mode. Input cannot be pulled up above VDD.</description>																	
 						<value>1</value>																	
 					</enumeratedValue>																		
@@ -11733,7 +11733,7 @@ controller </description>
 				<name>ENUM</name>																			
 																							
 					<enumeratedValue>																		
-						<name>PIO1_8_</name>																	
+						<name>PIO1_8</name>																	
 						<description>PIO1_8.</description>																	
 						<value>0x0</value>																	
 					</enumeratedValue>																		
@@ -11748,22 +11748,22 @@ controller </description>
 				<name>ENUM</name>																			
 																							
 					<enumeratedValue>																		
-						<name>INACTIVE_NO_PULL_DO</name>																	
+						<name>INACTIVE</name>																	
 						<description>Inactive (no pull-down/pull-up resistor enabled).</description>																	
 						<value>0x0</value>																	
 					</enumeratedValue>																		
 					<enumeratedValue>																		
-						<name>PULL_DOWN_RESISTOR_E</name>																	
+						<name>PULL_DOWN</name>																	
 						<description>Pull-down resistor enabled.</description>																	
 						<value>0x1</value>																	
 					</enumeratedValue>																		
 					<enumeratedValue>																		
-						<name>PULL_UP_RESISTOR_ENA</name>																	
+						<name>PULL_UP</name>																	
 						<description>Pull-up resistor enabled.</description>																	
 						<value>0x2</value>																	
 					</enumeratedValue>																		
 					<enumeratedValue>																		
-						<name>REPEATER_MODE_</name>																	
+						<name>REPEATER</name>																	
 						<description>Repeater mode.</description>																	
 						<value>0x3</value>																	
 					</enumeratedValue>																		
@@ -11778,12 +11778,12 @@ controller </description>
 				<name>ENUM</name>																			
 																							
 					<enumeratedValue>																		
-						<name>DISABLE_</name>																	
+						<name>DISABLED</name>																	
 						<description>Disable.</description>																	
 						<value>0</value>																	
 					</enumeratedValue>																		
 					<enumeratedValue>																		
-						<name>ENABLE_</name>																	
+						<name>ENABLED</name>																	
 						<description>Enable.</description>																	
 						<value>1</value>																	
 					</enumeratedValue>																		
@@ -11798,12 +11798,12 @@ controller </description>
 				<name>ENUM</name>																			
 																							
 					<enumeratedValue>																		
-						<name>INPUT_NOT_INVERTED_</name>																	
+						<name>NOT_INVERTED</name>																	
 						<description>Input not inverted (HIGH on pin reads as 1, LOW on pin reads as 0).</description>																	
 						<value>0</value>																	
 					</enumeratedValue>																		
 					<enumeratedValue>																		
-						<name>INPUT_INVERTED_HIGH</name>																	
+						<name>INVERTED</name>																	
 						<description>Input inverted (HIGH on pin reads as 0, LOW on pin reads as 1).</description>																	
 						<value>1</value>																	
 					</enumeratedValue>																		
@@ -11825,12 +11825,12 @@ controller </description>
 				<name>ENUM</name>																			
 																							
 					<enumeratedValue>																		
-						<name>DISABLE_</name>																	
+						<name>DISABLED</name>																	
 						<description>Disable.</description>																	
 						<value>0</value>																	
 					</enumeratedValue>																		
 					<enumeratedValue>																		
-						<name>OPEN_DRAIN_MODE_ENAB</name>																	
+						<name>OPEN_DRAIN</name>																	
 						<description>Open-drain mode enabled. This is not a true open-drain mode. Input cannot be pulled up above VDD.</description>																	
 						<value>1</value>																	
 					</enumeratedValue>																		
@@ -11862,7 +11862,7 @@ controller </description>
 				<name>ENUM</name>																			
 																							
 					<enumeratedValue>																		
-						<name>PIO1_9_</name>																	
+						<name>PIO1_9</name>																	
 						<description>PIO1_9.</description>																	
 						<value>0x0</value>																	
 					</enumeratedValue>																		
@@ -11877,22 +11877,22 @@ controller </description>
 				<name>ENUM</name>																			
 																							
 					<enumeratedValue>																		
-						<name>INACTIVE_NO_PULL_DO</name>																	
+						<name>INACTIVE</name>																	
 						<description>Inactive (no pull-down/pull-up resistor enabled).</description>																	
 						<value>0x0</value>																	
 					</enumeratedValue>																		
 					<enumeratedValue>																		
-						<name>PULL_DOWN_RESISTOR_E</name>																	
+						<name>PULL_DOWN</name>																	
 						<description>Pull-down resistor enabled.</description>																	
 						<value>0x1</value>																	
 					</enumeratedValue>																		
 					<enumeratedValue>																		
-						<name>PULL_UP_RESISTOR_ENA</name>																	
+						<name>PULL_UP</name>																	
 						<description>Pull-up resistor enabled.</description>																	
 						<value>0x2</value>																	
 					</enumeratedValue>																		
 					<enumeratedValue>																		
-						<name>REPEATER_MODE_</name>																	
+						<name>REPEATER</name>																	
 						<description>Repeater mode.</description>																	
 						<value>0x3</value>																	
 					</enumeratedValue>																		
@@ -11907,12 +11907,12 @@ controller </description>
 				<name>ENUM</name>																			
 																							
 					<enumeratedValue>																		
-						<name>DISABLE_</name>																	
+						<name>DISABLED</name>																	
 						<description>Disable.</description>																	
 						<value>0</value>																	
 					</enumeratedValue>																		
 					<enumeratedValue>																		
-						<name>ENABLE_</name>																	
+						<name>ENABLED</name>																	
 						<description>Enable.</description>																	
 						<value>1</value>																	
 					</enumeratedValue>																		
@@ -11927,12 +11927,12 @@ controller </description>
 				<name>ENUM</name>																			
 																							
 					<enumeratedValue>																		
-						<name>INPUT_NOT_INVERTED_</name>																	
+						<name>NOT_INVERTED</name>																	
 						<description>Input not inverted (HIGH on pin reads as 1, LOW on pin reads as 0).</description>																	
 						<value>0</value>																	
 					</enumeratedValue>																		
 					<enumeratedValue>																		
-						<name>INPUT_INVERTED_HIGH</name>																	
+						<name>INVERTED</name>																	
 						<description>Input inverted (HIGH on pin reads as 0, LOW on pin reads as 1).</description>																	
 						<value>1</value>																	
 					</enumeratedValue>																		
@@ -11954,12 +11954,12 @@ controller </description>
 				<name>ENUM</name>																			
 																							
 					<enumeratedValue>																		
-						<name>DISABLE_</name>																	
+						<name>DISABLED</name>																	
 						<description>Disable.</description>																	
 						<value>0</value>																	
 					</enumeratedValue>																		
 					<enumeratedValue>																		
-						<name>OPEN_DRAIN_MODE_ENAB</name>																	
+						<name>OPEN_DRAIN</name>																	
 						<description>Open-drain mode enabled. This is not a true open-drain mode. Input cannot be pulled up above VDD.</description>																	
 						<value>1</value>																	
 					</enumeratedValue>																		
@@ -11991,7 +11991,7 @@ controller </description>
 				<name>ENUM</name>																			
 																							
 					<enumeratedValue>																		
-						<name>PIO1_10_</name>																	
+						<name>PIO1_10</name>																	
 						<description>PIO1_10.</description>																	
 						<value>0x0</value>																	
 					</enumeratedValue>																		
@@ -12006,22 +12006,22 @@ controller </description>
 				<name>ENUM</name>																			
 																							
 					<enumeratedValue>																		
-						<name>INACTIVE_NO_PULL_DO</name>																	
+						<name>INACTIVE</name>																	
 						<description>Inactive (no pull-down/pull-up resistor enabled).</description>																	
 						<value>0x0</value>																	
 					</enumeratedValue>																		
 					<enumeratedValue>																		
-						<name>PULL_DOWN_RESISTOR_E</name>																	
+						<name>PULL_DOWN</name>																	
 						<description>Pull-down resistor enabled.</description>																	
 						<value>0x1</value>																	
 					</enumeratedValue>																		
 					<enumeratedValue>																		
-						<name>PULL_UP_RESISTOR_ENA</name>																	
+						<name>PULL_UP</name>																	
 						<description>Pull-up resistor enabled.</description>																	
 						<value>0x2</value>																	
 					</enumeratedValue>																		
 					<enumeratedValue>																		
-						<name>REPEATER_MODE_</name>																	
+						<name>REPEATER</name>																	
 						<description>Repeater mode.</description>																	
 						<value>0x3</value>																	
 					</enumeratedValue>																		
@@ -12036,12 +12036,12 @@ controller </description>
 				<name>ENUM</name>																			
 																							
 					<enumeratedValue>																		
-						<name>DISABLE_</name>																	
+						<name>DISABLED</name>																	
 						<description>Disable.</description>																	
 						<value>0</value>																	
 					</enumeratedValue>																		
 					<enumeratedValue>																		
-						<name>ENABLE_</name>																	
+						<name>ENABLED</name>																	
 						<description>Enable.</description>																	
 						<value>1</value>																	
 					</enumeratedValue>																		
@@ -12056,12 +12056,12 @@ controller </description>
 				<name>ENUM</name>																			
 																							
 					<enumeratedValue>																		
-						<name>INPUT_NOT_INVERTED_</name>																	
+						<name>NOT_INVERTED</name>																	
 						<description>Input not inverted (HIGH on pin reads as 1, LOW on pin reads as 0).</description>																	
 						<value>0</value>																	
 					</enumeratedValue>																		
 					<enumeratedValue>																		
-						<name>INPUT_INVERTED_HIGH</name>																	
+						<name>INVERTED</name>																	
 						<description>Input inverted (HIGH on pin reads as 0, LOW on pin reads as 1).</description>																	
 						<value>1</value>																	
 					</enumeratedValue>																		
@@ -12083,12 +12083,12 @@ controller </description>
 				<name>ENUM</name>																			
 																							
 					<enumeratedValue>																		
-						<name>DISABLE_</name>																	
+						<name>DISABLED</name>																	
 						<description>Disable.</description>																	
 						<value>0</value>																	
 					</enumeratedValue>																		
 					<enumeratedValue>																		
-						<name>OPEN_DRAIN_MODE_ENAB</name>																	
+						<name>OPEN_DRAIN</name>																	
 						<description>Open-drain mode enabled. This is not a true open-drain mode. Input cannot be pulled up above VDD.</description>																	
 						<value>1</value>																	
 					</enumeratedValue>																		
@@ -12120,7 +12120,7 @@ controller </description>
 				<name>ENUM</name>																			
 																							
 					<enumeratedValue>																		
-						<name>PIO1_11_</name>																	
+						<name>PIO1_11</name>																	
 						<description>PIO1_11.</description>																	
 						<value>0x0</value>																	
 					</enumeratedValue>																		
@@ -12135,22 +12135,22 @@ controller </description>
 				<name>ENUM</name>																			
 																							
 					<enumeratedValue>																		
-						<name>INACTIVE_NO_PULL_DO</name>																	
+						<name>INACTIVE</name>																	
 						<description>Inactive (no pull-down/pull-up resistor enabled).</description>																	
 						<value>0x0</value>																	
 					</enumeratedValue>																		
 					<enumeratedValue>																		
-						<name>PULL_DOWN_RESISTOR_E</name>																	
+						<name>PULL_DOWN</name>																	
 						<description>Pull-down resistor enabled.</description>																	
 						<value>0x1</value>																	
 					</enumeratedValue>																		
 					<enumeratedValue>																		
-						<name>PULL_UP_RESISTOR_ENA</name>																	
+						<name>PULL_UP</name>																	
 						<description>Pull-up resistor enabled.</description>																	
 						<value>0x2</value>																	
 					</enumeratedValue>																		
 					<enumeratedValue>																		
-						<name>REPEATER_MODE_</name>																	
+						<name>REPEATER</name>																	
 						<description>Repeater mode.</description>																	
 						<value>0x3</value>																	
 					</enumeratedValue>																		
@@ -12165,12 +12165,12 @@ controller </description>
 				<name>ENUM</name>																			
 																							
 					<enumeratedValue>																		
-						<name>DISABLE_</name>																	
+						<name>DISABLED</name>																	
 						<description>Disable.</description>																	
 						<value>0</value>																	
 					</enumeratedValue>																		
 					<enumeratedValue>																		
-						<name>ENABLE_</name>																	
+						<name>ENABLED</name>																	
 						<description>Enable.</description>																	
 						<value>1</value>																	
 					</enumeratedValue>																		
@@ -12185,12 +12185,12 @@ controller </description>
 				<name>ENUM</name>																			
 																							
 					<enumeratedValue>																		
-						<name>INPUT_NOT_INVERTED_</name>																	
+						<name>NOT_INVERTED</name>																	
 						<description>Input not inverted (HIGH on pin reads as 1, LOW on pin reads as 0).</description>																	
 						<value>0</value>																	
 					</enumeratedValue>																		
 					<enumeratedValue>																		
-						<name>INPUT_INVERTED_HIGH</name>																	
+						<name>INVERTED</name>																	
 						<description>Input inverted (HIGH on pin reads as 0, LOW on pin reads as 1).</description>																	
 						<value>1</value>																	
 					</enumeratedValue>																		
@@ -12212,12 +12212,12 @@ controller </description>
 				<name>ENUM</name>																			
 																							
 					<enumeratedValue>																		
-						<name>DISABLE_</name>																	
+						<name>DISABLED</name>																	
 						<description>Disable.</description>																	
 						<value>0</value>																	
 					</enumeratedValue>																		
 					<enumeratedValue>																		
-						<name>OPEN_DRAIN_MODE_ENAB</name>																	
+						<name>OPEN_DRAIN</name>																	
 						<description>Open-drain mode enabled. This is not a true open-drain mode. Input cannot be pulled up above VDD.</description>																	
 						<value>1</value>																	
 					</enumeratedValue>																		
@@ -12249,7 +12249,7 @@ controller </description>
 				<name>ENUM</name>																			
 																							
 					<enumeratedValue>																		
-						<name>PIO1_12_</name>																	
+						<name>PIO1_12</name>																	
 						<description>PIO1_12.</description>																	
 						<value>0x0</value>																	
 					</enumeratedValue>																		
@@ -12264,22 +12264,22 @@ controller </description>
 				<name>ENUM</name>																			
 																							
 					<enumeratedValue>																		
-						<name>INACTIVE_NO_PULL_DO</name>																	
+						<name>INACTIVE</name>																	
 						<description>Inactive (no pull-down/pull-up resistor enabled).</description>																	
 						<value>0x0</value>																	
 					</enumeratedValue>																		
 					<enumeratedValue>																		
-						<name>PULL_DOWN_RESISTOR_E</name>																	
+						<name>PULL_DOWN</name>																	
 						<description>Pull-down resistor enabled.</description>																	
 						<value>0x1</value>																	
 					</enumeratedValue>																		
 					<enumeratedValue>																		
-						<name>PULL_UP_RESISTOR_ENA</name>																	
+						<name>PULL_UP</name>																	
 						<description>Pull-up resistor enabled.</description>																	
 						<value>0x2</value>																	
 					</enumeratedValue>																		
 					<enumeratedValue>																		
-						<name>REPEATER_MODE_</name>																	
+						<name>REPEATER</name>																	
 						<description>Repeater mode.</description>																	
 						<value>0x3</value>																	
 					</enumeratedValue>																		
@@ -12294,12 +12294,12 @@ controller </description>
 				<name>ENUM</name>																			
 																							
 					<enumeratedValue>																		
-						<name>DISABLE_</name>																	
+						<name>DISABLED</name>																	
 						<description>Disable.</description>																	
 						<value>0</value>																	
 					</enumeratedValue>																		
 					<enumeratedValue>																		
-						<name>ENABLE_</name>																	
+						<name>ENABLED</name>																	
 						<description>Enable.</description>																	
 						<value>1</value>																	
 					</enumeratedValue>																		
@@ -12314,12 +12314,12 @@ controller </description>
 				<name>ENUM</name>																			
 																							
 					<enumeratedValue>																		
-						<name>INPUT_NOT_INVERTED_</name>																	
+						<name>NOT_INVERTED</name>																	
 						<description>Input not inverted (HIGH on pin reads as 1, LOW on pin reads as 0).</description>																	
 						<value>0</value>																	
 					</enumeratedValue>																		
 					<enumeratedValue>																		
-						<name>INPUT_INVERTED_HIGH</name>																	
+						<name>INVERTED</name>																	
 						<description>Input inverted (HIGH on pin reads as 0, LOW on pin reads as 1).</description>																	
 						<value>1</value>																	
 					</enumeratedValue>																		
@@ -12341,12 +12341,12 @@ controller </description>
 				<name>ENUM</name>																			
 																							
 					<enumeratedValue>																		
-						<name>DISABLE_</name>																	
+						<name>DISABLED</name>																	
 						<description>Disable.</description>																	
 						<value>0</value>																	
 					</enumeratedValue>																		
 					<enumeratedValue>																		
-						<name>OPEN_DRAIN_MODE_ENAB</name>																	
+						<name>OPEN_DRAIN</name>																	
 						<description>Open-drain mode enabled. This is not a true open-drain mode. Input cannot be pulled up above VDD.</description>																	
 						<value>1</value>																	
 					</enumeratedValue>																		
@@ -12378,22 +12378,22 @@ controller </description>
 				<name>ENUM</name>																			
 																							
 					<enumeratedValue>																		
-						<name>PIO1_13_</name>																	
+						<name>PIO1_13</name>																	
 						<description>PIO1_13.</description>																	
 						<value>0x0</value>																	
 					</enumeratedValue>																		
 					<enumeratedValue>																		
-						<name>DTR_</name>																	
+						<name>DTR</name>																	
 						<description>DTR.</description>																	
 						<value>0x1</value>																	
 					</enumeratedValue>																		
 					<enumeratedValue>																		
-						<name>CT16B0_MAT0_</name>																	
+						<name>CT16B0_MAT0</name>																	
 						<description>CT16B0_MAT0.</description>																	
 						<value>0x2</value>																	
 					</enumeratedValue>																		
 					<enumeratedValue>																		
-						<name>TXD_</name>																	
+						<name>TXD</name>																	
 						<description>TXD.</description>																	
 						<value>0x3</value>																	
 					</enumeratedValue>																		
@@ -12408,22 +12408,22 @@ controller </description>
 				<name>ENUM</name>																			
 																							
 					<enumeratedValue>																		
-						<name>INACTIVE_NO_PULL_DO</name>																	
+						<name>INACTIVE</name>																	
 						<description>Inactive (no pull-down/pull-up resistor enabled).</description>																	
 						<value>0x0</value>																	
 					</enumeratedValue>																		
 					<enumeratedValue>																		
-						<name>PULL_DOWN_RESISTOR_E</name>																	
+						<name>PULL_DOWN</name>																	
 						<description>Pull-down resistor enabled.</description>																	
 						<value>0x1</value>																	
 					</enumeratedValue>																		
 					<enumeratedValue>																		
-						<name>PULL_UP_RESISTOR_ENA</name>																	
+						<name>PULL_UP</name>																	
 						<description>Pull-up resistor enabled.</description>																	
 						<value>0x2</value>																	
 					</enumeratedValue>																		
 					<enumeratedValue>																		
-						<name>REPEATER_MODE_</name>																	
+						<name>REPEATER</name>																	
 						<description>Repeater mode.</description>																	
 						<value>0x3</value>																	
 					</enumeratedValue>																		
@@ -12438,12 +12438,12 @@ controller </description>
 				<name>ENUM</name>																			
 																							
 					<enumeratedValue>																		
-						<name>DISABLE_</name>																	
+						<name>DISABLED</name>																	
 						<description>Disable.</description>																	
 						<value>0</value>																	
 					</enumeratedValue>																		
 					<enumeratedValue>																		
-						<name>ENABLE_</name>																	
+						<name>ENABLED</name>																	
 						<description>Enable.</description>																	
 						<value>1</value>																	
 					</enumeratedValue>																		
@@ -12458,12 +12458,12 @@ controller </description>
 				<name>ENUM</name>																			
 																							
 					<enumeratedValue>																		
-						<name>INPUT_NOT_INVERTED_</name>																	
+						<name>NOT_INVERTED</name>																	
 						<description>Input not inverted (HIGH on pin reads as 1, LOW on pin reads as 0).</description>																	
 						<value>0</value>																	
 					</enumeratedValue>																		
 					<enumeratedValue>																		
-						<name>INPUT_INVERTED_HIGH</name>																	
+						<name>INVERTED</name>																	
 						<description>Input inverted (HIGH on pin reads as 0, LOW on pin reads as 1).</description>																	
 						<value>1</value>																	
 					</enumeratedValue>																		
@@ -12485,12 +12485,12 @@ controller </description>
 				<name>ENUM</name>																			
 																							
 					<enumeratedValue>																		
-						<name>DISABLE_</name>																	
+						<name>DISABLED</name>																	
 						<description>Disable.</description>																	
 						<value>0</value>																	
 					</enumeratedValue>																		
 					<enumeratedValue>																		
-						<name>OPEN_DRAIN_MODE_ENAB</name>																	
+						<name>OPEN_DRAIN</name>																	
 						<description>Open-drain mode enabled.  This is not a true open-drain mode.</description>																	
 						<value>1</value>																	
 					</enumeratedValue>																		
@@ -12522,22 +12522,22 @@ controller </description>
 				<name>ENUM</name>																			
 																							
 					<enumeratedValue>																		
-						<name>PIO1_14_</name>																	
+						<name>PIO1_14</name>																	
 						<description>PIO1_14.</description>																	
 						<value>0x0</value>																	
 					</enumeratedValue>																		
 					<enumeratedValue>																		
-						<name>DSR_</name>																	
+						<name>DSR</name>																	
 						<description>DSR.</description>																	
 						<value>0x1</value>																	
 					</enumeratedValue>																		
 					<enumeratedValue>																		
-						<name>CT16B0_MAT1_</name>																	
+						<name>CT16B0_MAT1</name>																	
 						<description>CT16B0_MAT1.</description>																	
 						<value>0x2</value>																	
 					</enumeratedValue>																		
 					<enumeratedValue>																		
-						<name>RXD_</name>																	
+						<name>RXD</name>																	
 						<description>RXD.</description>																	
 						<value>0x3</value>																	
 					</enumeratedValue>																		
@@ -12552,22 +12552,22 @@ controller </description>
 				<name>ENUM</name>																			
 																							
 					<enumeratedValue>																		
-						<name>INACTIVE_NO_PULL_DO</name>																	
+						<name>INACTIVE</name>																	
 						<description>Inactive (no pull-down/pull-up resistor enabled).</description>																	
 						<value>0x0</value>																	
 					</enumeratedValue>																		
 					<enumeratedValue>																		
-						<name>PULL_DOWN_RESISTOR_E</name>																	
+						<name>PULL_DOWN</name>																	
 						<description>Pull-down resistor enabled.</description>																	
 						<value>0x1</value>																	
 					</enumeratedValue>																		
 					<enumeratedValue>																		
-						<name>PULL_UP_RESISTOR_ENA</name>																	
+						<name>PULL_UP</name>																	
 						<description>Pull-up resistor enabled.</description>																	
 						<value>0x2</value>																	
 					</enumeratedValue>																		
 					<enumeratedValue>																		
-						<name>REPEATER_MODE_</name>																	
+						<name>REPEATER</name>																	
 						<description>Repeater mode.</description>																	
 						<value>0x3</value>																	
 					</enumeratedValue>																		
@@ -12582,12 +12582,12 @@ controller </description>
 				<name>ENUM</name>																			
 																							
 					<enumeratedValue>																		
-						<name>DISABLE_</name>																	
+						<name>DISABLED</name>																	
 						<description>Disable.</description>																	
 						<value>0</value>																	
 					</enumeratedValue>																		
 					<enumeratedValue>																		
-						<name>ENABLE_</name>																	
+						<name>ENABLED</name>																	
 						<description>Enable.</description>																	
 						<value>1</value>																	
 					</enumeratedValue>																		
@@ -12602,12 +12602,12 @@ controller </description>
 				<name>ENUM</name>																			
 																							
 					<enumeratedValue>																		
-						<name>INPUT_NOT_INVERTED_</name>																	
+						<name>NOT_INVERTED</name>																	
 						<description>Input not inverted (HIGH on pin reads as 1, LOW on pin reads as 0).</description>																	
 						<value>0</value>																	
 					</enumeratedValue>																		
 					<enumeratedValue>																		
-						<name>INPUT_INVERTED_HIGH</name>																	
+						<name>INVERTED</name>																	
 						<description>Input inverted (HIGH on pin reads as 0, LOW on pin reads as 1).</description>																	
 						<value>1</value>																	
 					</enumeratedValue>																		
@@ -12629,12 +12629,12 @@ controller </description>
 				<name>ENUM</name>																			
 																							
 					<enumeratedValue>																		
-						<name>DISABLE_</name>																	
+						<name>DISABLED</name>																	
 						<description>Disable.</description>																	
 						<value>0</value>																	
 					</enumeratedValue>																		
 					<enumeratedValue>																		
-						<name>OPEN_DRAIN_MODE_ENAB</name>																	
+						<name>OPEN_DRAIN</name>																	
 						<description>Open-drain mode enabled.  This is not a true open-drain mode.</description>																	
 						<value>1</value>																	
 					</enumeratedValue>																		
@@ -12666,22 +12666,22 @@ controller </description>
 				<name>ENUM</name>																			
 																							
 					<enumeratedValue>																		
-						<name>PIO1_15_</name>																	
+						<name>PIO1_15</name>																	
 						<description>PIO1_15.</description>																	
 						<value>0x0</value>																	
 					</enumeratedValue>																		
 					<enumeratedValue>																		
-						<name>DCD_</name>																	
+						<name>DCD</name>																	
 						<description>DCD.</description>																	
 						<value>0x1</value>																	
 					</enumeratedValue>																		
 					<enumeratedValue>																		
-						<name>CT16B0_MAT2_</name>																	
+						<name>CT16B0_MAT2</name>																	
 						<description>CT16B0_MAT2.</description>																	
 						<value>0x2</value>																	
 					</enumeratedValue>																		
 					<enumeratedValue>																		
-						<name>SCK1_</name>																	
+						<name>SCK1</name>																	
 						<description>SCK1.</description>																	
 						<value>0x3</value>																	
 					</enumeratedValue>																		
@@ -12696,22 +12696,22 @@ controller </description>
 				<name>ENUM</name>																			
 																							
 					<enumeratedValue>																		
-						<name>INACTIVE_NO_PULL_DO</name>																	
+						<name>INACTIVE</name>																	
 						<description>Inactive (no pull-down/pull-up resistor enabled).</description>																	
 						<value>0x0</value>																	
 					</enumeratedValue>																		
 					<enumeratedValue>																		
-						<name>PULL_DOWN_RESISTOR_E</name>																	
+						<name>PULL_DOWN</name>																	
 						<description>Pull-down resistor enabled.</description>																	
 						<value>0x1</value>																	
 					</enumeratedValue>																		
 					<enumeratedValue>																		
-						<name>PULL_UP_RESISTOR_ENA</name>																	
+						<name>PULL_UP</name>																	
 						<description>Pull-up resistor enabled.</description>																	
 						<value>0x2</value>																	
 					</enumeratedValue>																		
 					<enumeratedValue>																		
-						<name>REPEATER_MODE_</name>																	
+						<name>REPEATER</name>																	
 						<description>Repeater mode.</description>																	
 						<value>0x3</value>																	
 					</enumeratedValue>																		
@@ -12726,12 +12726,12 @@ controller </description>
 				<name>ENUM</name>																			
 																							
 					<enumeratedValue>																		
-						<name>DISABLE_</name>																	
+						<name>DISABLED</name>																	
 						<description>Disable.</description>																	
 						<value>0</value>																	
 					</enumeratedValue>																		
 					<enumeratedValue>																		
-						<name>ENABLE_</name>																	
+						<name>ENABLED</name>																	
 						<description>Enable.</description>																	
 						<value>1</value>																	
 					</enumeratedValue>																		
@@ -12746,12 +12746,12 @@ controller </description>
 				<name>ENUM</name>																			
 																							
 					<enumeratedValue>																		
-						<name>INPUT_NOT_INVERTED_</name>																	
+						<name>NOT_INVERTED</name>																	
 						<description>Input not inverted (HIGH on pin reads as 1, LOW on pin reads as 0).</description>																	
 						<value>0</value>																	
 					</enumeratedValue>																		
 					<enumeratedValue>																		
-						<name>INPUT_INVERTED_HIGH</name>																	
+						<name>INVERTED</name>																	
 						<description>Input inverted (HIGH on pin reads as 0, LOW on pin reads as 1).</description>																	
 						<value>1</value>																	
 					</enumeratedValue>																		
@@ -12773,12 +12773,12 @@ controller </description>
 				<name>ENUM</name>																			
 																							
 					<enumeratedValue>																		
-						<name>DISABLE_</name>																	
+						<name>DISABLED</name>																	
 						<description>Disable.</description>																	
 						<value>0</value>																	
 					</enumeratedValue>																		
 					<enumeratedValue>																		
-						<name>OPEN_DRAIN_MODE_ENAB</name>																	
+						<name>OPEN_DRAIN</name>																	
 						<description>Open-drain mode enabled.  This is not a true open-drain mode.</description>																	
 						<value>1</value>																	
 					</enumeratedValue>																		
@@ -12810,17 +12810,17 @@ controller </description>
 				<name>ENUM</name>																			
 																							
 					<enumeratedValue>																		
-						<name>PIO1_16_</name>																	
+						<name>PIO1_16</name>																	
 						<description>PIO1_16.</description>																	
 						<value>0x0</value>																	
 					</enumeratedValue>																		
 					<enumeratedValue>																		
-						<name>RI_</name>																	
+						<name>RI</name>																	
 						<description>RI.</description>																	
 						<value>0x1</value>																	
 					</enumeratedValue>																		
 					<enumeratedValue>																		
-						<name>CT16B0_CAP0_</name>																	
+						<name>CT16B0_CAP0</name>																	
 						<description>CT16B0_CAP0.</description>																	
 						<value>0x2</value>																	
 					</enumeratedValue>																		
@@ -12835,22 +12835,22 @@ controller </description>
 				<name>ENUM</name>																			
 																							
 					<enumeratedValue>																		
-						<name>INACTIVE_NO_PULL_DO</name>																	
+						<name>INACTIVE</name>																	
 						<description>Inactive (no pull-down/pull-up resistor enabled).</description>																	
 						<value>0x0</value>																	
 					</enumeratedValue>																		
 					<enumeratedValue>																		
-						<name>PULL_DOWN_RESISTOR_E</name>																	
+						<name>PULL_DOWN</name>																	
 						<description>Pull-down resistor enabled.</description>																	
 						<value>0x1</value>																	
 					</enumeratedValue>																		
 					<enumeratedValue>																		
-						<name>PULL_UP_RESISTOR_ENA</name>																	
+						<name>PULL_UP</name>																	
 						<description>Pull-up resistor enabled.</description>																	
 						<value>0x2</value>																	
 					</enumeratedValue>																		
 					<enumeratedValue>																		
-						<name>REPEATER_MODE_</name>																	
+						<name>REPEATER</name>																	
 						<description>Repeater mode.</description>																	
 						<value>0x3</value>																	
 					</enumeratedValue>																		
@@ -12865,12 +12865,12 @@ controller </description>
 				<name>ENUM</name>																			
 																							
 					<enumeratedValue>																		
-						<name>DISABLE_</name>																	
+						<name>DISABLED</name>																	
 						<description>Disable.</description>																	
 						<value>0</value>																	
 					</enumeratedValue>																		
 					<enumeratedValue>																		
-						<name>ENABLE_</name>																	
+						<name>ENABLED</name>																	
 						<description>Enable.</description>																	
 						<value>1</value>																	
 					</enumeratedValue>																		
@@ -12885,12 +12885,12 @@ controller </description>
 				<name>ENUM</name>																			
 																							
 					<enumeratedValue>																		
-						<name>INPUT_NOT_INVERTED_</name>																	
+						<name>NOT_INVERTED</name>																	
 						<description>Input not inverted (HIGH on pin reads as 1, LOW on pin reads as 0).</description>																	
 						<value>0</value>																	
 					</enumeratedValue>																		
 					<enumeratedValue>																		
-						<name>INPUT_INVERTED_HIGH</name>																	
+						<name>INVERTED</name>																	
 						<description>Input inverted (HIGH on pin reads as 0, LOW on pin reads as 1).</description>																	
 						<value>1</value>																	
 					</enumeratedValue>																		
@@ -12912,12 +12912,12 @@ controller </description>
 				<name>ENUM</name>																			
 																							
 					<enumeratedValue>																		
-						<name>DISABLE_</name>																	
+						<name>DISABLED</name>																	
 						<description>Disable.</description>																	
 						<value>0</value>																	
 					</enumeratedValue>																		
 					<enumeratedValue>																		
-						<name>OPEN_DRAIN_MODE_ENAB</name>																	
+						<name>OPEN_DRAIN</name>																	
 						<description>Open-drain mode enabled.  This is not a true open-drain mode.</description>																	
 						<value>1</value>																	
 					</enumeratedValue>																		
@@ -12949,7 +12949,7 @@ controller </description>
 				<name>ENUM</name>																			
 																							
 					<enumeratedValue>																		
-						<name>PIO1_17_</name>																	
+						<name>PIO1_17</name>																	
 						<description>PIO1_17.</description>																	
 						<value>0x0</value>																	
 					</enumeratedValue>																		
@@ -12974,22 +12974,22 @@ controller </description>
 				<name>ENUM</name>																			
 																							
 					<enumeratedValue>																		
-						<name>INACTIVE_NO_PULL_DO</name>																	
+						<name>INACTIVE</name>																	
 						<description>Inactive (no pull-down/pull-up resistor enabled).</description>																	
 						<value>0x0</value>																	
 					</enumeratedValue>																		
 					<enumeratedValue>																		
-						<name>PULL_DOWN_RESISTOR_E</name>																	
+						<name>PULL_DOWN</name>																	
 						<description>Pull-down resistor enabled.</description>																	
 						<value>0x1</value>																	
 					</enumeratedValue>																		
 					<enumeratedValue>																		
-						<name>PULL_UP_RESISTOR_ENA</name>																	
+						<name>PULL_UP</name>																	
 						<description>Pull-up resistor enabled.</description>																	
 						<value>0x2</value>																	
 					</enumeratedValue>																		
 					<enumeratedValue>																		
-						<name>REPEATER_MODE_</name>																	
+						<name>REPEATER</name>																	
 						<description>Repeater mode.</description>																	
 						<value>0x3</value>																	
 					</enumeratedValue>																		
@@ -13004,12 +13004,12 @@ controller </description>
 				<name>ENUM</name>																			
 																							
 					<enumeratedValue>																		
-						<name>DISABLE_</name>																	
+						<name>DISABLED</name>																	
 						<description>Disable.</description>																	
 						<value>0</value>																	
 					</enumeratedValue>																		
 					<enumeratedValue>																		
-						<name>ENABLE_</name>																	
+						<name>ENABLED</name>																	
 						<description>Enable.</description>																	
 						<value>1</value>																	
 					</enumeratedValue>																		
@@ -13024,12 +13024,12 @@ controller </description>
 				<name>ENUM</name>																			
 																							
 					<enumeratedValue>																		
-						<name>INPUT_NOT_INVERTED_</name>																	
+						<name>NOT_INVERTED</name>																	
 						<description>Input not inverted (HIGH on pin reads as 1, LOW on pin reads as 0).</description>																	
 						<value>0</value>																	
 					</enumeratedValue>																		
 					<enumeratedValue>																		
-						<name>INPUT_INVERTED_HIGH</name>																	
+						<name>INVERTED</name>																	
 						<description>Input inverted (HIGH on pin reads as 0, LOW on pin reads as 1).</description>																	
 						<value>1</value>																	
 					</enumeratedValue>																		
@@ -13051,12 +13051,12 @@ controller </description>
 				<name>ENUM</name>																			
 																							
 					<enumeratedValue>																		
-						<name>DISABLE_</name>																	
+						<name>DISABLED</name>																	
 						<description>Disable.</description>																	
 						<value>0</value>																	
 					</enumeratedValue>																		
 					<enumeratedValue>																		
-						<name>OPEN_DRAIN_MODE_ENAB</name>																	
+						<name>OPEN_DRAIN</name>																	
 						<description>Open-drain mode enabled. This is not a true open-drain mode. Input cannot be pulled up above VDD.</description>																	
 						<value>1</value>																	
 					</enumeratedValue>																		
@@ -13113,22 +13113,22 @@ controller </description>
 				<name>ENUM</name>																			
 																							
 					<enumeratedValue>																		
-						<name>INACTIVE_NO_PULL_DO</name>																	
+						<name>INACTIVE</name>																	
 						<description>Inactive (no pull-down/pull-up resistor enabled).</description>																	
 						<value>0x0</value>																	
 					</enumeratedValue>																		
 					<enumeratedValue>																		
-						<name>PULL_DOWN_RESISTOR_E</name>																	
+						<name>PULL_DOWN</name>																	
 						<description>Pull-down resistor enabled.</description>																	
 						<value>0x1</value>																	
 					</enumeratedValue>																		
 					<enumeratedValue>																		
-						<name>PULL_UP_RESISTOR_ENA</name>																	
+						<name>PULL_UP</name>																	
 						<description>Pull-up resistor enabled.</description>																	
 						<value>0x2</value>																	
 					</enumeratedValue>																		
 					<enumeratedValue>																		
-						<name>REPEATER_MODE_</name>																	
+						<name>REPEATER</name>																	
 						<description>Repeater mode.</description>																	
 						<value>0x3</value>																	
 					</enumeratedValue>																		
@@ -13143,12 +13143,12 @@ controller </description>
 				<name>ENUM</name>																			
 																							
 					<enumeratedValue>																		
-						<name>DISABLE_</name>																	
+						<name>DISABLED</name>																	
 						<description>Disable.</description>																	
 						<value>0</value>																	
 					</enumeratedValue>																		
 					<enumeratedValue>																		
-						<name>ENABLE_</name>																	
+						<name>ENABLED</name>																	
 						<description>Enable.</description>																	
 						<value>1</value>																	
 					</enumeratedValue>																		
@@ -13163,12 +13163,12 @@ controller </description>
 				<name>ENUM</name>																			
 																							
 					<enumeratedValue>																		
-						<name>INPUT_NOT_INVERTED_</name>																	
+						<name>NOT_INVERTED</name>																	
 						<description>Input not inverted (HIGH on pin reads as 1, LOW on pin reads as 0).</description>																	
 						<value>0</value>																	
 					</enumeratedValue>																		
 					<enumeratedValue>																		
-						<name>INPUT_INVERTED_HIGH</name>																	
+						<name>INVERTED</name>																	
 						<description>Input inverted (HIGH on pin reads as 0, LOW on pin reads as 1).</description>																	
 						<value>1</value>																	
 					</enumeratedValue>																		
@@ -13190,12 +13190,12 @@ controller </description>
 				<name>ENUM</name>																			
 																							
 					<enumeratedValue>																		
-						<name>DISABLE_</name>																	
+						<name>DISABLED</name>																	
 						<description>Disable.</description>																	
 						<value>0</value>																	
 					</enumeratedValue>																		
 					<enumeratedValue>																		
-						<name>OPEN_DRAIN_MODE_ENAB</name>																	
+						<name>OPEN_DRAIN</name>																	
 						<description>Open-drain mode enabled. This is not a true open-drain mode. Input cannot be pulled up above VDD.</description>																	
 						<value>1</value>																	
 					</enumeratedValue>																		
@@ -13227,17 +13227,17 @@ controller </description>
 				<name>ENUM</name>																			
 																							
 					<enumeratedValue>																		
-						<name>PIO1_19_</name>																	
+						<name>PIO1_19</name>																	
 						<description>PIO1_19.</description>																	
 						<value>0x0</value>																	
 					</enumeratedValue>																		
 					<enumeratedValue>																		
-						<name>DTR_</name>																	
+						<name>DTR</name>																	
 						<description>DTR.</description>																	
 						<value>0x1</value>																	
 					</enumeratedValue>																		
 					<enumeratedValue>																		
-						<name>SSEL1_</name>																	
+						<name>SSEL1</name>																	
 						<description>SSEL1.</description>																	
 						<value>0x2</value>																	
 					</enumeratedValue>																		
@@ -13252,22 +13252,22 @@ controller </description>
 				<name>ENUM</name>																			
 																							
 					<enumeratedValue>																		
-						<name>INACTIVE_NO_PULL_DO</name>																	
+						<name>INACTIVE</name>																	
 						<description>Inactive (no pull-down/pull-up resistor enabled).</description>																	
 						<value>0x0</value>																	
 					</enumeratedValue>																		
 					<enumeratedValue>																		
-						<name>PULL_DOWN_RESISTOR_E</name>																	
+						<name>PULL_DOWN</name>																	
 						<description>Pull-down resistor enabled.</description>																	
 						<value>0x1</value>																	
 					</enumeratedValue>																		
 					<enumeratedValue>																		
-						<name>PULL_UP_RESISTOR_ENA</name>																	
+						<name>PULL_UP</name>																	
 						<description>Pull-up resistor enabled.</description>																	
 						<value>0x2</value>																	
 					</enumeratedValue>																		
 					<enumeratedValue>																		
-						<name>REPEATER_MODE_</name>																	
+						<name>REPEATER</name>																	
 						<description>Repeater mode.</description>																	
 						<value>0x3</value>																	
 					</enumeratedValue>																		
@@ -13282,12 +13282,12 @@ controller </description>
 				<name>ENUM</name>																			
 																							
 					<enumeratedValue>																		
-						<name>DISABLE_</name>																	
+						<name>DISABLED</name>																	
 						<description>Disable.</description>																	
 						<value>0</value>																	
 					</enumeratedValue>																		
 					<enumeratedValue>																		
-						<name>ENABLE_</name>																	
+						<name>ENABLED</name>																	
 						<description>Enable.</description>																	
 						<value>1</value>																	
 					</enumeratedValue>																		
@@ -13302,12 +13302,12 @@ controller </description>
 				<name>ENUM</name>																			
 																							
 					<enumeratedValue>																		
-						<name>INPUT_NOT_INVERTED_</name>																	
+						<name>NOT_INVERTED</name>																	
 						<description>Input not inverted (HIGH on pin reads as 1, LOW on pin reads as 0).</description>																	
 						<value>0</value>																	
 					</enumeratedValue>																		
 					<enumeratedValue>																		
-						<name>INPUT_INVERTED_HIGH</name>																	
+						<name>INVERTED</name>																	
 						<description>Input inverted (HIGH on pin reads as 0, LOW on pin reads as 1).</description>																	
 						<value>1</value>																	
 					</enumeratedValue>																		
@@ -13329,12 +13329,12 @@ controller </description>
 				<name>ENUM</name>																			
 																							
 					<enumeratedValue>																		
-						<name>DISABLE_</name>																	
+						<name>DISABLED</name>																	
 						<description>Disable.</description>																	
 						<value>0</value>																	
 					</enumeratedValue>																		
 					<enumeratedValue>																		
-						<name>OPEN_DRAIN_MODE_ENAB</name>																	
+						<name>OPEN_DRAIN</name>																	
 						<description>Open-drain mode enabled.  This is not a true open-drain mode.</description>																	
 						<value>1</value>																	
 					</enumeratedValue>																		
@@ -13366,17 +13366,17 @@ controller </description>
 				<name>ENUM</name>																			
 																							
 					<enumeratedValue>																		
-						<name>PIO1_20_</name>																	
+						<name>PIO1_20</name>																	
 						<description>PIO1_20.</description>																	
 						<value>0x0</value>																	
 					</enumeratedValue>																		
 					<enumeratedValue>																		
-						<name>DSR_</name>																	
+						<name>DSR</name>																	
 						<description>DSR.</description>																	
 						<value>0x1</value>																	
 					</enumeratedValue>																		
 					<enumeratedValue>																		
-						<name>SCK1_</name>																	
+						<name>SCK1</name>																	
 						<description>SCK1.</description>																	
 						<value>0x2</value>																	
 					</enumeratedValue>																		
@@ -13391,22 +13391,22 @@ controller </description>
 				<name>ENUM</name>																			
 																							
 					<enumeratedValue>																		
-						<name>INACTIVE_NO_PULL_DO</name>																	
+						<name>INACTIVE</name>																	
 						<description>Inactive (no pull-down/pull-up resistor enabled).</description>																	
 						<value>0x0</value>																	
 					</enumeratedValue>																		
 					<enumeratedValue>																		
-						<name>PULL_DOWN_RESISTOR_E</name>																	
+						<name>PULL_DOWN</name>																	
 						<description>Pull-down resistor enabled.</description>																	
 						<value>0x1</value>																	
 					</enumeratedValue>																		
 					<enumeratedValue>																		
-						<name>PULL_UP_RESISTOR_ENA</name>																	
+						<name>PULL_UP</name>																	
 						<description>Pull-up resistor enabled.</description>																	
 						<value>0x2</value>																	
 					</enumeratedValue>																		
 					<enumeratedValue>																		
-						<name>REPEATER_MODE_</name>																	
+						<name>REPEATER</name>																	
 						<description>Repeater mode.</description>																	
 						<value>0x3</value>																	
 					</enumeratedValue>																		
@@ -13421,12 +13421,12 @@ controller </description>
 				<name>ENUM</name>																			
 																							
 					<enumeratedValue>																		
-						<name>DISABLE_</name>																	
+						<name>DISABLED</name>																	
 						<description>Disable.</description>																	
 						<value>0</value>																	
 					</enumeratedValue>																		
 					<enumeratedValue>																		
-						<name>ENABLE_</name>																	
+						<name>ENABLED</name>																	
 						<description>Enable.</description>																	
 						<value>1</value>																	
 					</enumeratedValue>																		
@@ -13441,12 +13441,12 @@ controller </description>
 				<name>ENUM</name>																			
 																							
 					<enumeratedValue>																		
-						<name>INPUT_NOT_INVERTED_</name>																	
+						<name>NOT_INVERTED</name>																	
 						<description>Input not inverted (HIGH on pin reads as 1, LOW on pin reads as 0).</description>																	
 						<value>0</value>																	
 					</enumeratedValue>																		
 					<enumeratedValue>																		
-						<name>INPUT_INVERTED_HIGH</name>																	
+						<name>INVERTED</name>																	
 						<description>Input inverted (HIGH on pin reads as 0, LOW on pin reads as 1).</description>																	
 						<value>1</value>																	
 					</enumeratedValue>																		
@@ -13468,12 +13468,12 @@ controller </description>
 				<name>ENUM</name>																			
 																							
 					<enumeratedValue>																		
-						<name>DISABLE_</name>																	
+						<name>DISABLED</name>																	
 						<description>Disable.</description>																	
 						<value>0</value>																	
 					</enumeratedValue>																		
 					<enumeratedValue>																		
-						<name>OPEN_DRAIN_MODE_ENAB</name>																	
+						<name>OPEN_DRAIN</name>																	
 						<description>Open-drain mode enabled.  This is not a true open-drain mode.</description>																	
 						<value>1</value>																	
 					</enumeratedValue>																		
@@ -13505,17 +13505,17 @@ controller </description>
 				<name>ENUM</name>																			
 																							
 					<enumeratedValue>																		
-						<name>PIO1_21_</name>																	
+						<name>PIO1_21</name>																	
 						<description>PIO1_21.</description>																	
 						<value>0x0</value>																	
 					</enumeratedValue>																		
 					<enumeratedValue>																		
-						<name>DCD_</name>																	
+						<name>DCD</name>																	
 						<description>DCD.</description>																	
 						<value>0x1</value>																	
 					</enumeratedValue>																		
 					<enumeratedValue>																		
-						<name>MISO1_</name>																	
+						<name>MISO1</name>																	
 						<description>MISO1.</description>																	
 						<value>0x2</value>																	
 					</enumeratedValue>																		
@@ -13530,22 +13530,22 @@ controller </description>
 				<name>ENUM</name>																			
 																							
 					<enumeratedValue>																		
-						<name>INACTIVE_NO_PULL_DO</name>																	
+						<name>INACTIVE</name>																	
 						<description>Inactive (no pull-down/pull-up resistor enabled).</description>																	
 						<value>0x0</value>																	
 					</enumeratedValue>																		
 					<enumeratedValue>																		
-						<name>PULL_DOWN_RESISTOR_E</name>																	
+						<name>PULL_DOWN</name>																	
 						<description>Pull-down resistor enabled.</description>																	
 						<value>0x1</value>																	
 					</enumeratedValue>																		
 					<enumeratedValue>																		
-						<name>PULL_UP_RESISTOR_ENA</name>																	
+						<name>PULL_UP</name>																	
 						<description>Pull-up resistor enabled.</description>																	
 						<value>0x2</value>																	
 					</enumeratedValue>																		
 					<enumeratedValue>																		
-						<name>REPEATER_MODE_</name>																	
+						<name>REPEATER</name>																	
 						<description>Repeater mode.</description>																	
 						<value>0x3</value>																	
 					</enumeratedValue>																		
@@ -13560,12 +13560,12 @@ controller </description>
 				<name>ENUM</name>																			
 																							
 					<enumeratedValue>																		
-						<name>DISABLE_</name>																	
+						<name>DISABLED</name>																	
 						<description>Disable.</description>																	
 						<value>0</value>																	
 					</enumeratedValue>																		
 					<enumeratedValue>																		
-						<name>ENABLE_</name>																	
+						<name>ENABLED</name>																	
 						<description>Enable.</description>																	
 						<value>1</value>																	
 					</enumeratedValue>																		
@@ -13580,12 +13580,12 @@ controller </description>
 				<name>ENUM</name>																			
 																							
 					<enumeratedValue>																		
-						<name>INPUT_NOT_INVERTED_</name>																	
+						<name>NOT_INVERTED</name>																	
 						<description>Input not inverted (HIGH on pin reads as 1, LOW on pin reads as 0).</description>																	
 						<value>0</value>																	
 					</enumeratedValue>																		
 					<enumeratedValue>																		
-						<name>INPUT_INVERTED_HIGH</name>																	
+						<name>INVERTED</name>																	
 						<description>Input inverted (HIGH on pin reads as 0, LOW on pin reads as 1).</description>																	
 						<value>1</value>																	
 					</enumeratedValue>																		
@@ -13607,12 +13607,12 @@ controller </description>
 				<name>ENUM</name>																			
 																							
 					<enumeratedValue>																		
-						<name>DISABLE_</name>																	
+						<name>DISABLED</name>																	
 						<description>Disable.</description>																	
 						<value>0</value>																	
 					</enumeratedValue>																		
 					<enumeratedValue>																		
-						<name>OPEN_DRAIN_MODE_ENAB</name>																	
+						<name>OPEN_DRAIN</name>																	
 						<description>Open-drain mode enabled.  This is not a true open-drain mode.</description>																	
 						<value>1</value>																	
 					</enumeratedValue>																		
@@ -13644,17 +13644,17 @@ controller </description>
 				<name>ENUM</name>																			
 																							
 					<enumeratedValue>																		
-						<name>PIO1_22_</name>																	
+						<name>PIO1_22</name>																	
 						<description>PIO1_22.</description>																	
 						<value>0x0</value>																	
 					</enumeratedValue>																		
 					<enumeratedValue>																		
-						<name>RI_</name>																	
+						<name>RI</name>																	
 						<description>RI.</description>																	
 						<value>0x1</value>																	
 					</enumeratedValue>																		
 					<enumeratedValue>																		
-						<name>MOSI1_</name>																	
+						<name>MOSI1</name>																	
 						<description>MOSI1.</description>																	
 						<value>0x2</value>																	
 					</enumeratedValue>																		
@@ -13669,22 +13669,22 @@ controller </description>
 				<name>ENUM</name>																			
 																							
 					<enumeratedValue>																		
-						<name>INACTIVE_NO_PULL_DO</name>																	
+						<name>INACTIVE</name>																	
 						<description>Inactive (no pull-down/pull-up resistor enabled).</description>																	
 						<value>0x0</value>																	
 					</enumeratedValue>																		
 					<enumeratedValue>																		
-						<name>PULL_DOWN_RESISTOR_E</name>																	
+						<name>PULL_DOWN</name>																	
 						<description>Pull-down resistor enabled.</description>																	
 						<value>0x1</value>																	
 					</enumeratedValue>																		
 					<enumeratedValue>																		
-						<name>PULL_UP_RESISTOR_ENA</name>																	
+						<name>PULL_UP</name>																	
 						<description>Pull-up resistor enabled.</description>																	
 						<value>0x2</value>																	
 					</enumeratedValue>																		
 					<enumeratedValue>																		
-						<name>REPEATER_MODE_</name>																	
+						<name>REPEATER</name>																	
 						<description>Repeater mode.</description>																	
 						<value>0x3</value>																	
 					</enumeratedValue>																		
@@ -13699,12 +13699,12 @@ controller </description>
 				<name>ENUM</name>																			
 																							
 					<enumeratedValue>																		
-						<name>DISABLE_</name>																	
+						<name>DISABLED</name>																	
 						<description>Disable.</description>																	
 						<value>0</value>																	
 					</enumeratedValue>																		
 					<enumeratedValue>																		
-						<name>ENABLE_</name>																	
+						<name>ENABLED</name>																	
 						<description>Enable.</description>																	
 						<value>1</value>																	
 					</enumeratedValue>																		
@@ -13719,12 +13719,12 @@ controller </description>
 				<name>ENUM</name>																			
 																							
 					<enumeratedValue>																		
-						<name>INPUT_NOT_INVERTED_</name>																	
+						<name>NOT_INVERTED</name>																	
 						<description>Input not inverted (HIGH on pin reads as 1, LOW on pin reads as 0).</description>																	
 						<value>0</value>																	
 					</enumeratedValue>																		
 					<enumeratedValue>																		
-						<name>INPUT_INVERTED_HIGH</name>																	
+						<name>INVERTED</name>																	
 						<description>Input inverted (HIGH on pin reads as 0, LOW on pin reads as 1).</description>																	
 						<value>1</value>																	
 					</enumeratedValue>																		
@@ -13746,12 +13746,12 @@ controller </description>
 				<name>ENUM</name>																			
 																							
 					<enumeratedValue>																		
-						<name>DISABLE_</name>																	
+						<name>DISABLED</name>																	
 						<description>Disable.</description>																	
 						<value>0</value>																	
 					</enumeratedValue>																		
 					<enumeratedValue>																		
-						<name>OPEN_DRAIN_MODE_ENAB</name>																	
+						<name>OPEN_DRAIN</name>																	
 						<description>Open-drain mode enabled.  This is not a true open-drain mode.</description>																	
 						<value>1</value>																	
 					</enumeratedValue>																		
@@ -13783,17 +13783,17 @@ controller </description>
 				<name>ENUM</name>																			
 																							
 					<enumeratedValue>																		
-						<name>PIO1_23_</name>																	
+						<name>PIO1_23</name>																	
 						<description>PIO1_23.</description>																	
 						<value>0x0</value>																	
 					</enumeratedValue>																		
 					<enumeratedValue>																		
-						<name>CT16B1_MAT1_</name>																	
+						<name>CT16B1_MAT1</name>																	
 						<description>CT16B1_MAT1.</description>																	
 						<value>0x1</value>																	
 					</enumeratedValue>																		
 					<enumeratedValue>																		
-						<name>SSEL1_</name>																	
+						<name>SSEL1</name>																	
 						<description>SSEL1.</description>																	
 						<value>0x2</value>																	
 					</enumeratedValue>																		
@@ -13808,22 +13808,22 @@ controller </description>
 				<name>ENUM</name>																			
 																							
 					<enumeratedValue>																		
-						<name>INACTIVE_NO_PULL_DO</name>																	
+						<name>INACTIVE</name>																	
 						<description>Inactive (no pull-down/pull-up resistor enabled).</description>																	
 						<value>0x0</value>																	
 					</enumeratedValue>																		
 					<enumeratedValue>																		
-						<name>PULL_DOWN_RESISTOR_E</name>																	
+						<name>PULL_DOWN</name>																	
 						<description>Pull-down resistor enabled.</description>																	
 						<value>0x1</value>																	
 					</enumeratedValue>																		
 					<enumeratedValue>																		
-						<name>PULL_UP_RESISTOR_ENA</name>																	
+						<name>PULL_UP</name>																	
 						<description>Pull-up resistor enabled.</description>																	
 						<value>0x2</value>																	
 					</enumeratedValue>																		
 					<enumeratedValue>																		
-						<name>REPEATER_MODE_</name>																	
+						<name>REPEATER</name>																	
 						<description>Repeater mode.</description>																	
 						<value>0x3</value>																	
 					</enumeratedValue>																		
@@ -13838,12 +13838,12 @@ controller </description>
 				<name>ENUM</name>																			
 																							
 					<enumeratedValue>																		
-						<name>DISABLE_</name>																	
+						<name>DISABLED</name>																	
 						<description>Disable.</description>																	
 						<value>0</value>																	
 					</enumeratedValue>																		
 					<enumeratedValue>																		
-						<name>ENABLE_</name>																	
+						<name>ENABLED</name>																	
 						<description>Enable.</description>																	
 						<value>1</value>																	
 					</enumeratedValue>																		
@@ -13858,12 +13858,12 @@ controller </description>
 				<name>ENUM</name>																			
 																							
 					<enumeratedValue>																		
-						<name>INPUT_NOT_INVERTED_</name>																	
+						<name>NOT_INVERTED</name>																	
 						<description>Input not inverted (HIGH on pin reads as 1, LOW on pin reads as 0).</description>																	
 						<value>0</value>																	
 					</enumeratedValue>																		
 					<enumeratedValue>																		
-						<name>INPUT_INVERTED_HIGH</name>																	
+						<name>INVERTED</name>																	
 						<description>Input inverted (HIGH on pin reads as 0, LOW on pin reads as 1).</description>																	
 						<value>1</value>																	
 					</enumeratedValue>																		
@@ -13885,12 +13885,12 @@ controller </description>
 				<name>ENUM</name>																			
 																							
 					<enumeratedValue>																		
-						<name>DISABLE_</name>																	
+						<name>DISABLED</name>																	
 						<description>Disable.</description>																	
 						<value>0</value>																	
 					</enumeratedValue>																		
 					<enumeratedValue>																		
-						<name>OPEN_DRAIN_MODE_ENAB</name>																	
+						<name>OPEN_DRAIN</name>																	
 						<description>Open-drain mode enabled.  This is not a true open-drain mode.</description>																	
 						<value>1</value>																	
 					</enumeratedValue>																		
@@ -13922,12 +13922,12 @@ controller </description>
 				<name>ENUM</name>																			
 																							
 					<enumeratedValue>																		
-						<name>PIO1_24_</name>																	
+						<name>PIO1_24</name>																	
 						<description>PIO1_24.</description>																	
 						<value>0x0</value>																	
 					</enumeratedValue>																		
 					<enumeratedValue>																		
-						<name>CT32B0_MAT0_</name>																	
+						<name>CT32B0_MAT0</name>																	
 						<description>CT32B0_MAT0.</description>																	
 						<value>0x1</value>																	
 					</enumeratedValue>																		
@@ -13942,22 +13942,22 @@ controller </description>
 				<name>ENUM</name>																			
 																							
 					<enumeratedValue>																		
-						<name>INACTIVE_NO_PULL_DO</name>																	
+						<name>INACTIVE</name>																	
 						<description>Inactive (no pull-down/pull-up resistor enabled).</description>																	
 						<value>0x0</value>																	
 					</enumeratedValue>																		
 					<enumeratedValue>																		
-						<name>PULL_DOWN_RESISTOR_E</name>																	
+						<name>PULL_DOWN</name>																	
 						<description>Pull-down resistor enabled.</description>																	
 						<value>0x1</value>																	
 					</enumeratedValue>																		
 					<enumeratedValue>																		
-						<name>PULL_UP_RESISTOR_ENA</name>																	
+						<name>PULL_UP</name>																	
 						<description>Pull-up resistor enabled.</description>																	
 						<value>0x2</value>																	
 					</enumeratedValue>																		
 					<enumeratedValue>																		
-						<name>REPEATER_MODE_</name>																	
+						<name>REPEATER</name>																	
 						<description>Repeater mode.</description>																	
 						<value>0x3</value>																	
 					</enumeratedValue>																		
@@ -13972,12 +13972,12 @@ controller </description>
 				<name>ENUM</name>																			
 																							
 					<enumeratedValue>																		
-						<name>DISABLE_</name>																	
+						<name>DISABLED</name>																	
 						<description>Disable.</description>																	
 						<value>0</value>																	
 					</enumeratedValue>																		
 					<enumeratedValue>																		
-						<name>ENABLE_</name>																	
+						<name>ENABLED</name>																	
 						<description>Enable.</description>																	
 						<value>1</value>																	
 					</enumeratedValue>																		
@@ -13992,12 +13992,12 @@ controller </description>
 				<name>ENUM</name>																			
 																							
 					<enumeratedValue>																		
-						<name>INPUT_NOT_INVERTED_</name>																	
+						<name>NOT_INVERTED</name>																	
 						<description>Input not inverted (HIGH on pin reads as 1, LOW on pin reads as 0).</description>																	
 						<value>0</value>																	
 					</enumeratedValue>																		
 					<enumeratedValue>																		
-						<name>INPUT_INVERTED_HIGH</name>																	
+						<name>INVERTED</name>																	
 						<description>Input inverted (HIGH on pin reads as 0, LOW on pin reads as 1).</description>																	
 						<value>1</value>																	
 					</enumeratedValue>																		
@@ -14019,12 +14019,12 @@ controller </description>
 				<name>ENUM</name>																			
 																							
 					<enumeratedValue>																		
-						<name>DISABLE_</name>																	
+						<name>DISABLED</name>																	
 						<description>Disable.</description>																	
 						<value>0</value>																	
 					</enumeratedValue>																		
 					<enumeratedValue>																		
-						<name>OPEN_DRAIN_MODE_ENAB</name>																	
+						<name>OPEN_DRAIN</name>																	
 						<description>Open-drain mode enabled.  This is not a true open-drain mode.</description>																	
 						<value>1</value>																	
 					</enumeratedValue>																		
@@ -14056,12 +14056,12 @@ controller </description>
 				<name>ENUM</name>																			
 																							
 					<enumeratedValue>																		
-						<name>PIO1_25_</name>																	
+						<name>PIO1_25</name>																	
 						<description>PIO1_25.</description>																	
 						<value>0x0</value>																	
 					</enumeratedValue>																		
 					<enumeratedValue>																		
-						<name>CT32B0_MAT1_</name>																	
+						<name>CT32B0_MAT1</name>																	
 						<description>CT32B0_MAT1.</description>																	
 						<value>0x1</value>																	
 					</enumeratedValue>																		
@@ -14076,22 +14076,22 @@ controller </description>
 				<name>ENUM</name>																			
 																							
 					<enumeratedValue>																		
-						<name>INACTIVE_NO_PULL_DO</name>																	
+						<name>INACTIVE</name>																	
 						<description>Inactive (no pull-down/pull-up resistor enabled).</description>																	
 						<value>0x0</value>																	
 					</enumeratedValue>																		
 					<enumeratedValue>																		
-						<name>PULL_DOWN_RESISTOR_E</name>																	
+						<name>PULL_DOWN</name>																	
 						<description>Pull-down resistor enabled.</description>																	
 						<value>0x1</value>																	
 					</enumeratedValue>																		
 					<enumeratedValue>																		
-						<name>PULL_UP_RESISTOR_ENA</name>																	
+						<name>PULL_UP</name>																	
 						<description>Pull-up resistor enabled.</description>																	
 						<value>0x2</value>																	
 					</enumeratedValue>																		
 					<enumeratedValue>																		
-						<name>REPEATER_MODE_</name>																	
+						<name>REPEATER</name>																	
 						<description>Repeater mode.</description>																	
 						<value>0x3</value>																	
 					</enumeratedValue>																		
@@ -14106,12 +14106,12 @@ controller </description>
 				<name>ENUM</name>																			
 																							
 					<enumeratedValue>																		
-						<name>DISABLE_</name>																	
+						<name>DISABLED</name>																	
 						<description>Disable.</description>																	
 						<value>0</value>																	
 					</enumeratedValue>																		
 					<enumeratedValue>																		
-						<name>ENABLE_</name>																	
+						<name>ENABLED</name>																	
 						<description>Enable.</description>																	
 						<value>1</value>																	
 					</enumeratedValue>																		
@@ -14126,12 +14126,12 @@ controller </description>
 				<name>ENUM</name>																			
 																							
 					<enumeratedValue>																		
-						<name>INPUT_NOT_INVERTED_</name>																	
+						<name>NOT_INVERTED</name>																	
 						<description>Input not inverted (HIGH on pin reads as 1, LOW on pin reads as 0).</description>																	
 						<value>0</value>																	
 					</enumeratedValue>																		
 					<enumeratedValue>																		
-						<name>INPUT_INVERTED_HIGH</name>																	
+						<name>INVERTED</name>																	
 						<description>Input inverted (HIGH on pin reads as 0, LOW on pin reads as 1).</description>																	
 						<value>1</value>																	
 					</enumeratedValue>																		
@@ -14153,12 +14153,12 @@ controller </description>
 				<name>ENUM</name>																			
 																							
 					<enumeratedValue>																		
-						<name>DISABLE_</name>																	
+						<name>DISABLED</name>																	
 						<description>Disable.</description>																	
 						<value>0</value>																	
 					</enumeratedValue>																		
 					<enumeratedValue>																		
-						<name>OPEN_DRAIN_MODE_ENAB</name>																	
+						<name>OPEN_DRAIN</name>																	
 						<description>Open-drain mode enabled.  This is not a true open-drain mode.</description>																	
 						<value>1</value>																	
 					</enumeratedValue>																		
@@ -14190,7 +14190,7 @@ controller </description>
 				<name>ENUM</name>																			
 																							
 					<enumeratedValue>																		
-						<name>PIO1_26_</name>																	
+						<name>PIO1_26</name>																	
 						<description>PIO1_26.</description>																	
 						<value>0x0</value>																	
 					</enumeratedValue>																		
@@ -14200,7 +14200,7 @@ controller </description>
 						<value>0x1</value>																	
 					</enumeratedValue>																		
 					<enumeratedValue>																		
-						<name>RXD_</name>																	
+						<name>RXD</name>																	
 						<description>RXD.</description>																	
 						<value>0x2</value>																	
 					</enumeratedValue>																		
@@ -14215,22 +14215,22 @@ controller </description>
 				<name>ENUM</name>																			
 																							
 					<enumeratedValue>																		
-						<name>INACTIVE_NO_PULL_DO</name>																	
+						<name>INACTIVE</name>																	
 						<description>Inactive (no pull-down/pull-up resistor enabled).</description>																	
 						<value>0x0</value>																	
 					</enumeratedValue>																		
 					<enumeratedValue>																		
-						<name>PULL_DOWN_RESISTOR_E</name>																	
+						<name>PULL_DOWN</name>																	
 						<description>Pull-down resistor enabled.</description>																	
 						<value>0x1</value>																	
 					</enumeratedValue>																		
 					<enumeratedValue>																		
-						<name>PULL_UP_RESISTOR_ENA</name>																	
+						<name>PULL_UP</name>																	
 						<description>Pull-up resistor enabled.</description>																	
 						<value>0x2</value>																	
 					</enumeratedValue>																		
 					<enumeratedValue>																		
-						<name>REPEATER_MODE_</name>																	
+						<name>REPEATER</name>																	
 						<description>Repeater mode.</description>																	
 						<value>0x3</value>																	
 					</enumeratedValue>																		
@@ -14245,12 +14245,12 @@ controller </description>
 				<name>ENUM</name>																			
 																							
 					<enumeratedValue>																		
-						<name>DISABLE_</name>																	
+						<name>DISABLED</name>																	
 						<description>Disable.</description>																	
 						<value>0</value>																	
 					</enumeratedValue>																		
 					<enumeratedValue>																		
-						<name>ENABLE_</name>																	
+						<name>ENABLED</name>																	
 						<description>Enable.</description>																	
 						<value>1</value>																	
 					</enumeratedValue>																		
@@ -14265,12 +14265,12 @@ controller </description>
 				<name>ENUM</name>																			
 																							
 					<enumeratedValue>																		
-						<name>INPUT_NOT_INVERTED_</name>																	
+						<name>NOT_INVERTED</name>																	
 						<description>Input not inverted (HIGH on pin reads as 1, LOW on pin reads as 0).</description>																	
 						<value>0</value>																	
 					</enumeratedValue>																		
 					<enumeratedValue>																		
-						<name>INPUT_INVERTED_HIGH</name>																	
+						<name>INVERTED</name>																	
 						<description>Input inverted (HIGH on pin reads as 0, LOW on pin reads as 1).</description>																	
 						<value>1</value>																	
 					</enumeratedValue>																		
@@ -14292,12 +14292,12 @@ controller </description>
 				<name>ENUM</name>																			
 																							
 					<enumeratedValue>																		
-						<name>DISABLE_</name>																	
+						<name>DISABLED</name>																	
 						<description>Disable.</description>																	
 						<value>0</value>																	
 					</enumeratedValue>																		
 					<enumeratedValue>																		
-						<name>OPEN_DRAIN_MODE_ENAB</name>																	
+						<name>OPEN_DRAIN</name>																	
 						<description>Open-drain mode enabled.  This is not a true open-drain mode.</description>																	
 						<value>1</value>																	
 					</enumeratedValue>																		
@@ -14329,17 +14329,17 @@ controller </description>
 				<name>ENUM</name>																			
 																							
 					<enumeratedValue>																		
-						<name>PIO1_27_</name>																	
+						<name>PIO1_27</name>																	
 						<description>PIO1_27.</description>																	
 						<value>0x0</value>																	
 					</enumeratedValue>																		
 					<enumeratedValue>																		
-						<name>CT32B0_MAT3_</name>																	
+						<name>CT32B0_MAT3</name>																	
 						<description>CT32B0_MAT3.</description>																	
 						<value>0x1</value>																	
 					</enumeratedValue>																		
 					<enumeratedValue>																		
-						<name>TXD_</name>																	
+						<name>TXD</name>																	
 						<description>TXD.</description>																	
 						<value>0x2</value>																	
 					</enumeratedValue>																		
@@ -14354,22 +14354,22 @@ controller </description>
 				<name>ENUM</name>																			
 																							
 					<enumeratedValue>																		
-						<name>INACTIVE_NO_PULL_DO</name>																	
+						<name>INACTIVE</name>																	
 						<description>Inactive (no pull-down/pull-up resistor enabled).</description>																	
 						<value>0x0</value>																	
 					</enumeratedValue>																		
 					<enumeratedValue>																		
-						<name>PULL_DOWN_RESISTOR_E</name>																	
+						<name>PULL_DOWN</name>																	
 						<description>Pull-down resistor enabled.</description>																	
 						<value>0x1</value>																	
 					</enumeratedValue>																		
 					<enumeratedValue>																		
-						<name>PULL_UP_RESISTOR_ENA</name>																	
+						<name>PULL_UP</name>																	
 						<description>Pull-up resistor enabled.</description>																	
 						<value>0x2</value>																	
 					</enumeratedValue>																		
 					<enumeratedValue>																		
-						<name>REPEATER_MODE_</name>																	
+						<name>REPEATER</name>																	
 						<description>Repeater mode.</description>																	
 						<value>0x3</value>																	
 					</enumeratedValue>																		
@@ -14384,12 +14384,12 @@ controller </description>
 				<name>ENUM</name>																			
 																							
 					<enumeratedValue>																		
-						<name>DISABLE_</name>																	
+						<name>DISABLED</name>																	
 						<description>Disable.</description>																	
 						<value>0</value>																	
 					</enumeratedValue>																		
 					<enumeratedValue>																		
-						<name>ENABLE_</name>																	
+						<name>ENABLED</name>																	
 						<description>Enable.</description>																	
 						<value>1</value>																	
 					</enumeratedValue>																		
@@ -14404,12 +14404,12 @@ controller </description>
 				<name>ENUM</name>																			
 																							
 					<enumeratedValue>																		
-						<name>INPUT_NOT_INVERTED_</name>																	
+						<name>NOT_INVERTED</name>																	
 						<description>Input not inverted (HIGH on pin reads as 1, LOW on pin reads as 0).</description>																	
 						<value>0</value>																	
 					</enumeratedValue>																		
 					<enumeratedValue>																		
-						<name>INPUT_INVERTED_HIGH</name>																	
+						<name>INVERTED</name>																	
 						<description>Input inverted (HIGH on pin reads as 0, LOW on pin reads as 1).</description>																	
 						<value>1</value>																	
 					</enumeratedValue>																		
@@ -14431,12 +14431,12 @@ controller </description>
 				<name>ENUM</name>																			
 																							
 					<enumeratedValue>																		
-						<name>DISABLE_</name>																	
+						<name>DISABLED</name>																	
 						<description>Disable.</description>																	
 						<value>0</value>																	
 					</enumeratedValue>																		
 					<enumeratedValue>																		
-						<name>OPEN_DRAIN_MODE_ENAB</name>																	
+						<name>OPEN_DRAIN</name>																	
 						<description>Open-drain mode enabled.  This is not a true open-drain mode.</description>																	
 						<value>1</value>																	
 					</enumeratedValue>																		
@@ -14468,17 +14468,17 @@ controller </description>
 				<name>ENUM</name>																			
 																							
 					<enumeratedValue>																		
-						<name>PIO1_28_</name>																	
+						<name>PIO1_28</name>																	
 						<description>PIO1_28.</description>																	
 						<value>0x0</value>																	
 					</enumeratedValue>																		
 					<enumeratedValue>																		
-						<name>CT32B0_CAP0_</name>																	
+						<name>CT32B0_CAP0</name>																	
 						<description>CT32B0_CAP0.</description>																	
 						<value>0x1</value>																	
 					</enumeratedValue>																		
 					<enumeratedValue>																		
-						<name>SCLK_</name>																	
+						<name>SCLK</name>																	
 						<description>SCLK.</description>																	
 						<value>0x2</value>																	
 					</enumeratedValue>																		
@@ -14493,22 +14493,22 @@ controller </description>
 				<name>ENUM</name>																			
 																							
 					<enumeratedValue>																		
-						<name>INACTIVE_NO_PULL_DO</name>																	
+						<name>INACTIVE</name>																	
 						<description>Inactive (no pull-down/pull-up resistor enabled).</description>																	
 						<value>0x0</value>																	
 					</enumeratedValue>																		
 					<enumeratedValue>																		
-						<name>PULL_DOWN_RESISTOR_E</name>																	
+						<name>PULL_DOWN</name>																	
 						<description>Pull-down resistor enabled.</description>																	
 						<value>0x1</value>																	
 					</enumeratedValue>																		
 					<enumeratedValue>																		
-						<name>PULL_UP_RESISTOR_ENA</name>																	
+						<name>PULL_UP</name>																	
 						<description>Pull-up resistor enabled.</description>																	
 						<value>0x2</value>																	
 					</enumeratedValue>																		
 					<enumeratedValue>																		
-						<name>REPEATER_MODE_</name>																	
+						<name>REPEATER</name>																	
 						<description>Repeater mode.</description>																	
 						<value>0x3</value>																	
 					</enumeratedValue>																		
@@ -14523,12 +14523,12 @@ controller </description>
 				<name>ENUM</name>																			
 																							
 					<enumeratedValue>																		
-						<name>DISABLE_</name>																	
+						<name>DISABLED</name>																	
 						<description>Disable.</description>																	
 						<value>0</value>																	
 					</enumeratedValue>																		
 					<enumeratedValue>																		
-						<name>ENABLE_</name>																	
+						<name>ENABLED</name>																	
 						<description>Enable.</description>																	
 						<value>1</value>																	
 					</enumeratedValue>																		
@@ -14543,12 +14543,12 @@ controller </description>
 				<name>ENUM</name>																			
 																							
 					<enumeratedValue>																		
-						<name>INPUT_NOT_INVERTED_</name>																	
+						<name>NOT_INVERTED</name>																	
 						<description>Input not inverted (HIGH on pin reads as 1, LOW on pin reads as 0).</description>																	
 						<value>0</value>																	
 					</enumeratedValue>																		
 					<enumeratedValue>																		
-						<name>INPUT_INVERTED_HIGH</name>																	
+						<name>INVERTED</name>																	
 						<description>Input inverted (HIGH on pin reads as 0, LOW on pin reads as 1).</description>																	
 						<value>1</value>																	
 					</enumeratedValue>																		
@@ -14570,12 +14570,12 @@ controller </description>
 				<name>ENUM</name>																			
 																							
 					<enumeratedValue>																		
-						<name>DISABLE_</name>																	
+						<name>DISABLED</name>																	
 						<description>Disable.</description>																	
 						<value>0</value>																	
 					</enumeratedValue>																		
 					<enumeratedValue>																		
-						<name>OPEN_DRAIN_MODE_ENAB</name>																	
+						<name>OPEN_DRAIN</name>																	
 						<description>Open-drain mode enabled.  This is not a true open-drain mode.</description>																	
 						<value>1</value>																	
 					</enumeratedValue>																		
@@ -14607,17 +14607,17 @@ controller </description>
 				<name>ENUM</name>																			
 																							
 					<enumeratedValue>																		
-						<name>PIO1_29_</name>																	
+						<name>PIO1_29</name>																	
 						<description>PIO1_29.</description>																	
 						<value>0x0</value>																	
 					</enumeratedValue>																		
 					<enumeratedValue>																		
-						<name>SCK0_</name>																	
+						<name>SCK0</name>																	
 						<description>SCK0.</description>																	
 						<value>0x1</value>																	
 					</enumeratedValue>																		
 					<enumeratedValue>																		
-						<name>CT32B0_CAP1_</name>																	
+						<name>CT32B0_CAP1</name>																	
 						<description>CT32B0_CAP1.</description>																	
 						<value>0x2</value>																	
 					</enumeratedValue>																		
@@ -14632,22 +14632,22 @@ controller </description>
 				<name>ENUM</name>																			
 																							
 					<enumeratedValue>																		
-						<name>INACTIVE_NO_PULL_DO</name>																	
+						<name>INACTIVE</name>																	
 						<description>Inactive (no pull-down/pull-up resistor enabled).</description>																	
 						<value>0x0</value>																	
 					</enumeratedValue>																		
 					<enumeratedValue>																		
-						<name>PULL_DOWN_RESISTOR_E</name>																	
+						<name>PULL_DOWN</name>																	
 						<description>Pull-down resistor enabled.</description>																	
 						<value>0x1</value>																	
 					</enumeratedValue>																		
 					<enumeratedValue>																		
-						<name>PULL_UP_RESISTOR_ENA</name>																	
+						<name>PULL_UP</name>																	
 						<description>Pull-up resistor enabled.</description>																	
 						<value>0x2</value>																	
 					</enumeratedValue>																		
 					<enumeratedValue>																		
-						<name>REPEATER_MODE_</name>																	
+						<name>REPEATER</name>																	
 						<description>Repeater mode.</description>																	
 						<value>0x3</value>																	
 					</enumeratedValue>																		
@@ -14662,12 +14662,12 @@ controller </description>
 				<name>ENUM</name>																			
 																							
 					<enumeratedValue>																		
-						<name>DISABLE_</name>																	
+						<name>DISABLED</name>																	
 						<description>Disable.</description>																	
 						<value>0</value>																	
 					</enumeratedValue>																		
 					<enumeratedValue>																		
-						<name>ENABLE_</name>																	
+						<name>ENABLED</name>																	
 						<description>Enable.</description>																	
 						<value>1</value>																	
 					</enumeratedValue>																		
@@ -14682,12 +14682,12 @@ controller </description>
 				<name>ENUM</name>																			
 																							
 					<enumeratedValue>																		
-						<name>INPUT_NOT_INVERTED_</name>																	
+						<name>NOT_INVERTED</name>																	
 						<description>Input not inverted (HIGH on pin reads as 1, LOW on pin reads as 0).</description>																	
 						<value>0</value>																	
 					</enumeratedValue>																		
 					<enumeratedValue>																		
-						<name>INPUT_INVERTED_HIGH</name>																	
+						<name>INVERTED</name>																	
 						<description>Input inverted (HIGH on pin reads as 0, LOW on pin reads as 1).</description>																	
 						<value>1</value>																	
 					</enumeratedValue>																		
@@ -14709,12 +14709,12 @@ controller </description>
 				<name>ENUM</name>																			
 																							
 					<enumeratedValue>																		
-						<name>DISABLE_</name>																	
+						<name>DISABLED</name>																	
 						<description>Disable.</description>																	
 						<value>0</value>																	
 					</enumeratedValue>																		
 					<enumeratedValue>																		
-						<name>OPEN_DRAIN_MODE_ENAB</name>																	
+						<name>OPEN_DRAIN</name>																	
 						<description>Open-drain mode enabled.  This is not a true open-drain mode.</description>																	
 						<value>1</value>																	
 					</enumeratedValue>																		
@@ -14746,7 +14746,7 @@ controller </description>
 				<name>ENUM</name>																			
 																							
 					<enumeratedValue>																		
-						<name>PIO1_31_</name>																	
+						<name>PIO1_31</name>																	
 						<description>PIO1_31.</description>																	
 						<value>0x0</value>																	
 					</enumeratedValue>																		
@@ -14761,22 +14761,22 @@ controller </description>
 				<name>ENUM</name>																			
 																							
 					<enumeratedValue>																		
-						<name>INACTIVE_NO_PULL_DO</name>																	
+						<name>INACTIVE</name>																	
 						<description>Inactive (no pull-down/pull-up resistor enabled).</description>																	
 						<value>0x0</value>																	
 					</enumeratedValue>																		
 					<enumeratedValue>																		
-						<name>PULL_DOWN_RESISTOR_E</name>																	
+						<name>PULL_DOWN</name>																	
 						<description>Pull-down resistor enabled.</description>																	
 						<value>0x1</value>																	
 					</enumeratedValue>																		
 					<enumeratedValue>																		
-						<name>PULL_UP_RESISTOR_ENA</name>																	
+						<name>PULL_UP</name>																	
 						<description>Pull-up resistor enabled.</description>																	
 						<value>0x2</value>																	
 					</enumeratedValue>																		
 					<enumeratedValue>																		
-						<name>REPEATER_MODE_</name>																	
+						<name>REPEATER</name>																	
 						<description>Repeater mode.</description>																	
 						<value>0x3</value>																	
 					</enumeratedValue>																		
@@ -14791,12 +14791,12 @@ controller </description>
 				<name>ENUM</name>																			
 																							
 					<enumeratedValue>																		
-						<name>DISABLE_</name>																	
+						<name>DISABLED</name>																	
 						<description>Disable.</description>																	
 						<value>0</value>																	
 					</enumeratedValue>																		
 					<enumeratedValue>																		
-						<name>ENABLE_</name>																	
+						<name>ENABLED</name>																	
 						<description>Enable.</description>																	
 						<value>1</value>																	
 					</enumeratedValue>																		
@@ -14811,12 +14811,12 @@ controller </description>
 				<name>ENUM</name>																			
 																							
 					<enumeratedValue>																		
-						<name>INPUT_NOT_INVERTED_</name>																	
+						<name>NOT_INVERTED</name>																	
 						<description>Input not inverted (HIGH on pin reads as 1, LOW on pin reads as 0).</description>																	
 						<value>0</value>																	
 					</enumeratedValue>																		
 					<enumeratedValue>																		
-						<name>INPUT_INVERTED_HIGH</name>																	
+						<name>INVERTED</name>																	
 						<description>Input inverted (HIGH on pin reads as 0, LOW on pin reads as 1).</description>																	
 						<value>1</value>																	
 					</enumeratedValue>																		
@@ -14838,12 +14838,12 @@ controller </description>
 				<name>ENUM</name>																			
 																							
 					<enumeratedValue>																		
-						<name>DISABLE_</name>																	
+						<name>DISABLED</name>																	
 						<description>Disable.</description>																	
 						<value>0</value>																	
 					</enumeratedValue>																		
 					<enumeratedValue>																		
-						<name>OPEN_DRAIN_MODE_ENAB</name>																	
+						<name>OPEN_DRAIN</name>																	
 						<description>Open-drain mode enabled.  This is not a true open-drain mode.</description>																	
 						<value>1</value>																	
 					</enumeratedValue>																		
@@ -15213,12 +15213,12 @@ controller </description>
 				<enumeratedValues>		
 				<name>ENUM</name>		
 					<enumeratedValue>	
-						<name>OSCILLATOR_IS_NOT_BY</name>
+						<name>DISABLED</name>
 						<description>Oscillator is not bypassed.</description>
 						<value>0</value>
 					</enumeratedValue>	
 					<enumeratedValue>	
-						<name>BYPASS_ENABLED_PLL_</name>
+						<name>ENABLED</name>
 						<description>Bypass enabled. PLL input (sys_osc_clk) is fed directly from the XTALIN pin bypassing the oscillator. Use this mode when using an external clock source instead of the crystal oscillator.</description>
 						<value>1</value>
 					</enumeratedValue>	
@@ -15406,12 +15406,12 @@ controller </description>
 				<enumeratedValues>		
 				<name>ENUM</name>		
 					<enumeratedValue>	
-						<name>NO_WDT_RESET_DETECTE</name>
+						<name>NO_RESET</name>
 						<description>No WDT reset detected</description>
 						<value>0</value>
 					</enumeratedValue>	
 					<enumeratedValue>	
-						<name>WDT_RESET_DETECTED_</name>
+						<name>RESET_CLEAR</name>
 						<description>WDT reset detected. Writing a one clears this reset.</description>
 						<value>1</value>
 					</enumeratedValue>	
@@ -15424,12 +15424,12 @@ controller </description>
 				<enumeratedValues>		
 				<name>ENUM</name>		
 					<enumeratedValue>	
-						<name>NO_BOD_RESET_DETECTE</name>
+						<name>NO_RESET</name>
 						<description>No BOD reset detected</description>
 						<value>0</value>
 					</enumeratedValue>	
 					<enumeratedValue>	
-						<name>BOD_RESET_DETECTED_</name>
+						<name>RESET_CLEAR</name>
 						<description>BOD reset detected. Writing a one clears this reset.</description>
 						<value>1</value>
 					</enumeratedValue>	
@@ -15481,7 +15481,7 @@ controller </description>
 						<value>0x0</value>
 					</enumeratedValue>	
 					<enumeratedValue>	
-						<name>CRYSTAL_OSCILLATOR_</name>
+						<name>CRYSTAL_OSCILLATOR</name>
 						<description>Crystal Oscillator (SYSOSC)</description>
 						<value>0x1</value>
 					</enumeratedValue>	
@@ -15735,7 +15735,7 @@ controller </description>
 						<value>0</value>
 					</enumeratedValue>	
 					<enumeratedValue>	
-						<name>ENABLE</name>
+						<name>ENABLED</name>
 						<description>Enable</description>
 						<value>1</value>
 					</enumeratedValue>	
@@ -15748,12 +15748,12 @@ controller </description>
 				<enumeratedValues>		
 				<name>ENUM</name>		
 					<enumeratedValue>	
-						<name>DISABLE</name>
+						<name>DISABLED</name>
 						<description>Disable</description>
 						<value>0</value>
 					</enumeratedValue>	
 					<enumeratedValue>	
-						<name>ENABLE</name>
+						<name>ENABLED</name>
 						<description>Enable</description>
 						<value>1</value>
 					</enumeratedValue>	
@@ -15766,12 +15766,12 @@ controller </description>
 				<enumeratedValues>		
 				<name>ENUM</name>		
 					<enumeratedValue>	
-						<name>DISABLE</name>
+						<name>DISABLED</name>
 						<description>Disable</description>
 						<value>0</value>
 					</enumeratedValue>	
 					<enumeratedValue>	
-						<name>ENABLE</name>
+						<name>ENABLED</name>
 						<description>Enable</description>
 						<value>1</value>
 					</enumeratedValue>	
@@ -15784,12 +15784,12 @@ controller </description>
 				<enumeratedValues>		
 				<name>ENUM</name>		
 					<enumeratedValue>	
-						<name>DISABLE</name>
+						<name>DISABLED</name>
 						<description>Disable</description>
 						<value>0</value>
 					</enumeratedValue>	
 					<enumeratedValue>	
-						<name>ENABLE</name>
+						<name>ENABLED</name>
 						<description>Enable</description>
 						<value>1</value>
 					</enumeratedValue>	
@@ -15802,12 +15802,12 @@ controller </description>
 				<enumeratedValues>		
 				<name>ENUM</name>		
 					<enumeratedValue>	
-						<name>DISABLE</name>
+						<name>DISABLED</name>
 						<description>Disable</description>
 						<value>0</value>
 					</enumeratedValue>	
 					<enumeratedValue>	
-						<name>ENABLE</name>
+						<name>ENABLED</name>
 						<description>Enable</description>
 						<value>1</value>
 					</enumeratedValue>	
@@ -15820,12 +15820,12 @@ controller </description>
 				<enumeratedValues>		
 				<name>ENUM</name>		
 					<enumeratedValue>	
-						<name>DISABLE</name>
+						<name>DISABLED</name>
 						<description>Disable</description>
 						<value>0</value>
 					</enumeratedValue>	
 					<enumeratedValue>	
-						<name>ENABLE</name>
+						<name>ENABLED</name>
 						<description>Enable</description>
 						<value>1</value>
 					</enumeratedValue>	
@@ -15838,12 +15838,12 @@ controller </description>
 				<enumeratedValues>		
 				<name>ENUM</name>		
 					<enumeratedValue>	
-						<name>DISABLE</name>
+						<name>DISABLED</name>
 						<description>Disable</description>
 						<value>0</value>
 					</enumeratedValue>	
 					<enumeratedValue>	
-						<name>ENABLE</name>
+						<name>ENABLED</name>
 						<description>Enable</description>
 						<value>1</value>
 					</enumeratedValue>	
@@ -15856,12 +15856,12 @@ controller </description>
 				<enumeratedValues>		
 				<name>ENUM</name>		
 					<enumeratedValue>	
-						<name>DISABLE</name>
+						<name>DISABLED</name>
 						<description>Disable</description>
 						<value>0</value>
 					</enumeratedValue>	
 					<enumeratedValue>	
-						<name>ENABLE</name>
+						<name>ENABLED</name>
 						<description>Enable</description>
 						<value>1</value>
 					</enumeratedValue>	
@@ -15874,12 +15874,12 @@ controller </description>
 				<enumeratedValues>		
 				<name>ENUM</name>		
 					<enumeratedValue>	
-						<name>DISABLE</name>
+						<name>DISABLED</name>
 						<description>Disable</description>
 						<value>0</value>
 					</enumeratedValue>	
 					<enumeratedValue>	
-						<name>ENABLE</name>
+						<name>ENABLED</name>
 						<description>Enable</description>
 						<value>1</value>
 					</enumeratedValue>	
@@ -15892,12 +15892,12 @@ controller </description>
 				<enumeratedValues>		
 				<name>ENUM</name>		
 					<enumeratedValue>	
-						<name>DISABLE</name>
+						<name>DISABLED</name>
 						<description>Disable</description>
 						<value>0</value>
 					</enumeratedValue>	
 					<enumeratedValue>	
-						<name>ENABLE</name>
+						<name>ENABLED</name>
 						<description>Enable</description>
 						<value>1</value>
 					</enumeratedValue>	
@@ -15910,12 +15910,12 @@ controller </description>
 				<enumeratedValues>		
 				<name>ENUM</name>		
 					<enumeratedValue>	
-						<name>DISABLE</name>
+						<name>DISABLED</name>
 						<description>Disable</description>
 						<value>0</value>
 					</enumeratedValue>	
 					<enumeratedValue>	
-						<name>ENABLE</name>
+						<name>ENABLED</name>
 						<description>Enable</description>
 						<value>1</value>
 					</enumeratedValue>	
@@ -15928,12 +15928,12 @@ controller </description>
 				<enumeratedValues>		
 				<name>ENUM</name>		
 					<enumeratedValue>	
-						<name>DISABLE</name>
+						<name>DISABLED</name>
 						<description>Disable</description>
 						<value>0</value>
 					</enumeratedValue>	
 					<enumeratedValue>	
-						<name>ENABLE</name>
+						<name>ENABLED</name>
 						<description>Enable</description>
 						<value>1</value>
 					</enumeratedValue>	
@@ -15946,12 +15946,12 @@ controller </description>
 				<enumeratedValues>		
 				<name>ENUM</name>		
 					<enumeratedValue>	
-						<name>DISABLE</name>
+						<name>DISABLED</name>
 						<description>Disable</description>
 						<value>0</value>
 					</enumeratedValue>	
 					<enumeratedValue>	
-						<name>ENABLE</name>
+						<name>ENABLED</name>
 						<description>Enable</description>
 						<value>1</value>
 					</enumeratedValue>	
@@ -15964,12 +15964,12 @@ controller </description>
 				<enumeratedValues>		
 				<name>ENUM</name>		
 					<enumeratedValue>	
-						<name>DISABLE</name>
+						<name>DISABLED</name>
 						<description>Disable</description>
 						<value>0</value>
 					</enumeratedValue>	
 					<enumeratedValue>	
-						<name>ENABLE</name>
+						<name>ENABLED</name>
 						<description>Enable</description>
 						<value>1</value>
 					</enumeratedValue>	
@@ -15982,12 +15982,12 @@ controller </description>
 				<enumeratedValues>		
 				<name>ENUM</name>		
 					<enumeratedValue>	
-						<name>DISABLE</name>
+						<name>DISABLED</name>
 						<description>Disable</description>
 						<value>0</value>
 					</enumeratedValue>	
 					<enumeratedValue>	
-						<name>ENABLE</name>
+						<name>ENABLED</name>
 						<description>Enable</description>
 						<value>1</value>
 					</enumeratedValue>	
@@ -16000,12 +16000,12 @@ controller </description>
 				<enumeratedValues>		
 				<name>ENUM</name>		
 					<enumeratedValue>	
-						<name>DISABLE</name>
+						<name>DISABLED</name>
 						<description>Disable</description>
 						<value>0</value>
 					</enumeratedValue>	
 					<enumeratedValue>	
-						<name>ENABLE</name>
+						<name>ENABLED</name>
 						<description>Enable</description>
 						<value>1</value>
 					</enumeratedValue>	
@@ -16018,12 +16018,12 @@ controller </description>
 				<enumeratedValues>		
 				<name>ENUM</name>		
 					<enumeratedValue>	
-						<name>DISABLE</name>
+						<name>DISABLED</name>
 						<description>Disable</description>
 						<value>0</value>
 					</enumeratedValue>	
 					<enumeratedValue>	
-						<name>ENABLE</name>
+						<name>ENABLED</name>
 						<description>Enable</description>
 						<value>1</value>
 					</enumeratedValue>	
@@ -16042,12 +16042,12 @@ controller </description>
 				<enumeratedValues>		
 				<name>ENUM</name>		
 					<enumeratedValue>	
-						<name>DISABLE</name>
+						<name>DISABLED</name>
 						<description>Disable</description>
 						<value>0</value>
 					</enumeratedValue>	
 					<enumeratedValue>	
-						<name>ENABLE</name>
+						<name>ENABLED</name>
 						<description>Enable</description>
 						<value>1</value>
 					</enumeratedValue>	
@@ -16060,12 +16060,12 @@ controller </description>
 				<enumeratedValues>		
 				<name>ENUM</name>		
 					<enumeratedValue>	
-						<name>DISABLE</name>
+						<name>DISABLED</name>
 						<description>Disable</description>
 						<value>0</value>
 					</enumeratedValue>	
 					<enumeratedValue>	
-						<name>ENABLE</name>
+						<name>ENABLED</name>
 						<description>Enable</description>
 						<value>1</value>
 					</enumeratedValue>	
@@ -16084,12 +16084,12 @@ controller </description>
 				<enumeratedValues>		
 				<name>ENUM</name>		
 					<enumeratedValue>	
-						<name>DISABLE</name>
+						<name>DISABLED</name>
 						<description>Disable</description>
 						<value>0</value>
 					</enumeratedValue>	
 					<enumeratedValue>	
-						<name>ENABLE</name>
+						<name>ENABLED</name>
 						<description>Enable</description>
 						<value>1</value>
 					</enumeratedValue>	
@@ -16102,12 +16102,12 @@ controller </description>
 				<enumeratedValues>		
 				<name>ENUM</name>		
 					<enumeratedValue>	
-						<name>DISABLE</name>
+						<name>DISABLED</name>
 						<description>Disable</description>
 						<value>0</value>
 					</enumeratedValue>	
 					<enumeratedValue>	
-						<name>ENABLE</name>
+						<name>ENABLED</name>
 						<description>Enable</description>
 						<value>1</value>
 					</enumeratedValue>	
@@ -16126,12 +16126,12 @@ controller </description>
 				<enumeratedValues>		
 				<name>ENUM</name>		
 					<enumeratedValue>	
-						<name>DISABLE</name>
+						<name>DISABLED</name>
 						<description>Disable</description>
 						<value>0</value>
 					</enumeratedValue>	
 					<enumeratedValue>	
-						<name>ENABLE</name>
+						<name>ENABLED</name>
 						<description>Enable</description>
 						<value>1</value>
 					</enumeratedValue>	
@@ -16144,12 +16144,12 @@ controller </description>
 				<enumeratedValues>		
 				<name>ENUM</name>		
 					<enumeratedValue>	
-						<name>DISABLE</name>
+						<name>DISABLED</name>
 						<description>Disable</description>
 						<value>0</value>
 					</enumeratedValue>	
 					<enumeratedValue>	
-						<name>ENABLE</name>
+						<name>ENABLED</name>
 						<description>Enable</description>
 						<value>1</value>
 					</enumeratedValue>	
@@ -16331,7 +16331,7 @@ controller </description>
 						<value>0x0</value>
 					</enumeratedValue>	
 					<enumeratedValue>	
-						<name>CRYSTAL_OSCILLATOR_</name>
+						<name>CRYSTAL_OSCILLATOR</name>
 						<description>Crystal oscillator (SYSOSC)</description>
 						<value>0x1</value>
 					</enumeratedValue>	
@@ -16487,7 +16487,7 @@ controller </description>
 				<enumeratedValues>		
 				<name>ENUM</name>		
 					<enumeratedValue>	
-						<name>LEVEL_0_RESERVED_</name>
+						<name>LEVEL_0_RESERVED</name>
 						<description>Level 0: Reserved.</description>
 						<value>0x0</value>
 					</enumeratedValue>	
@@ -16637,12 +16637,12 @@ controller </description>
 				<enumeratedValues>		
 				<name>ENUM</name>		
 					<enumeratedValue>	
-						<name>UNDER_HARDWARE_CONTR</name>
+						<name>UNDER_HARDWARE_CONTROL</name>
 						<description>Under hardware control.</description>
 						<value>0</value>
 					</enumeratedValue>	
 					<enumeratedValue>	
-						<name>FORCED_HIGH_</name>
+						<name>FORCED_HIGH</name>
 						<description>Forced HIGH.</description>
 						<value>1</value>
 					</enumeratedValue>	
@@ -16655,12 +16655,12 @@ controller </description>
 				<enumeratedValues>		
 				<name>ENUM</name>		
 					<enumeratedValue>	
-						<name>FALLING_EDGE_OF_THE_</name>
+						<name>FALLING_EDGE</name>
 						<description>Falling edge of the USB need_clock triggers the USB wake-up (default).</description>
 						<value>0</value>
 					</enumeratedValue>	
 					<enumeratedValue>	
-						<name>RISING_EDGE_OF_THE_U</name>
+						<name>RISING_EDGE</name>
 						<description>Rising edge of the USB need_clock triggers the USB wake-up.</description>
 						<value>1</value>
 					</enumeratedValue>	
@@ -18141,12 +18141,12 @@ controller </description>
 							<enumeratedValues>
 								<name>ENUM</name>
 								<enumeratedValue>
-									<name>OR_FUNCTIONALITY_A_</name>
+									<name>OR</name>
 									<description>OR functionality: A grouped interrupt is generated when any one of the enabled inputs is active (based on its programmed polarity).</description>
 									<value>0</value>
 								</enumeratedValue>
 								<enumeratedValue>
-									<name>AND_FUNCTIONALITY_A</name>
+									<name>AND</name>
 									<description>AND functionality: An interrupt is generated when all enabled bits are active (based on their programmed polarity).</description>
 									<value>1</value>
 								</enumeratedValue>
@@ -18619,12 +18619,12 @@ controller </description>
 					<enumeratedValues>
 					<name>ENUM</name>
 						<enumeratedValue>
-							<name>LPM_NOT_SUPPORTED_</name>
+							<name>NOT_SUPPORTED</name>
 							<description>LPM not supported.</description>
 							<value>0</value>
 						</enumeratedValue>
 						<enumeratedValue>
-							<name>LPM_SUPPORTED_</name>
+							<name>SUPPORTED</name>
 							<description>LPM supported.</description>
 							<value>1</value>
 						</enumeratedValue>

--- a/lpc11uxx/src/adc/cr.rs
+++ b/lpc11uxx/src/adc/cr.rs
@@ -68,9 +68,9 @@ impl CLKDIVR {
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum BURSTR {
     #[doc = "Software-controlled mode: Conversions are software-controlled and require 11 clocks."]
-    SOFTWARE_CONTROLLED_,
+    SOFTWARE_CONTROLLED,
     #[doc = "Hardware scan mode: The AD converter does repeated conversions at the rate selected by the CLKS field, scanning (if necessary) through the pins selected by 1s in the SEL field. The first conversion after the start corresponds to the least-significant bit set to 1 in the SEL field, then the next higher  bits (pins) set to 1 are scanned if applicable. Repeated conversions can be terminated by clearing this bit, but the conversion in progress when this bit is cleared will be completed. Important: START bits must be 000 when BURST = 1 or conversions will not start."]
-    HARDWARE_SCAN_MODE_,
+    HARDWARE_SCAN,
 }
 impl BURSTR {
     #[doc = r" Returns `true` if the bit is clear (0)"]
@@ -87,8 +87,8 @@ impl BURSTR {
     #[inline]
     pub fn bit(&self) -> bool {
         match *self {
-            BURSTR::SOFTWARE_CONTROLLED_ => false,
-            BURSTR::HARDWARE_SCAN_MODE_ => true,
+            BURSTR::SOFTWARE_CONTROLLED => false,
+            BURSTR::HARDWARE_SCAN => true,
         }
     }
     #[allow(missing_docs)]
@@ -96,54 +96,54 @@ impl BURSTR {
     #[inline]
     pub fn _from(value: bool) -> BURSTR {
         match value {
-            false => BURSTR::SOFTWARE_CONTROLLED_,
-            true => BURSTR::HARDWARE_SCAN_MODE_,
+            false => BURSTR::SOFTWARE_CONTROLLED,
+            true => BURSTR::HARDWARE_SCAN,
         }
     }
-    #[doc = "Checks if the value of the field is `SOFTWARE_CONTROLLED_`"]
+    #[doc = "Checks if the value of the field is `SOFTWARE_CONTROLLED`"]
     #[inline]
-    pub fn is_software_controlled_(&self) -> bool {
-        *self == BURSTR::SOFTWARE_CONTROLLED_
+    pub fn is_software_controlled(&self) -> bool {
+        *self == BURSTR::SOFTWARE_CONTROLLED
     }
-    #[doc = "Checks if the value of the field is `HARDWARE_SCAN_MODE_`"]
+    #[doc = "Checks if the value of the field is `HARDWARE_SCAN`"]
     #[inline]
-    pub fn is_hardware_scan_mode_(&self) -> bool {
-        *self == BURSTR::HARDWARE_SCAN_MODE_
+    pub fn is_hardware_scan(&self) -> bool {
+        *self == BURSTR::HARDWARE_SCAN
     }
 }
 #[doc = "Possible values of the field `CLKS`"]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum CLKSR {
     #[doc = "11 clocks / 10 bits"]
-    _11_CLOCKS,
+    _11_CLOCKS_10_BITS,
     #[doc = "10 clocks / 9 bits"]
-    _10_CLOCKS,
+    _10_CLOCKS_9_BITS,
     #[doc = "9 clocks / 8 bits"]
-    _9_CLOCKS,
+    _9_CLOCKS_8_BITS,
     #[doc = "8 clocks / 7 bits"]
-    _8_CLOCKS,
+    _8_CLOCKS_7_BITS,
     #[doc = "7 clocks / 6 bits"]
-    _7_CLOCKS,
+    _7_CLOCKS_6_BITS,
     #[doc = "6 clocks / 5 bits"]
-    _6_CLOCKS,
+    _6_CLOCKS_5_BITS,
     #[doc = "5 clocks / 4 bits"]
-    _5_CLOCKS,
+    _5_CLOCKS_4_BITS,
     #[doc = "4 clocks / 3 bits"]
-    _4_CLOCKS,
+    _4_CLOCKS_3_BITS,
 }
 impl CLKSR {
     #[doc = r" Value of the field as raw bits"]
     #[inline]
     pub fn bits(&self) -> u8 {
         match *self {
-            CLKSR::_11_CLOCKS => 0,
-            CLKSR::_10_CLOCKS => 1,
-            CLKSR::_9_CLOCKS => 2,
-            CLKSR::_8_CLOCKS => 3,
-            CLKSR::_7_CLOCKS => 4,
-            CLKSR::_6_CLOCKS => 5,
-            CLKSR::_5_CLOCKS => 6,
-            CLKSR::_4_CLOCKS => 7,
+            CLKSR::_11_CLOCKS_10_BITS => 0,
+            CLKSR::_10_CLOCKS_9_BITS => 1,
+            CLKSR::_9_CLOCKS_8_BITS => 2,
+            CLKSR::_8_CLOCKS_7_BITS => 3,
+            CLKSR::_7_CLOCKS_6_BITS => 4,
+            CLKSR::_6_CLOCKS_5_BITS => 5,
+            CLKSR::_5_CLOCKS_4_BITS => 6,
+            CLKSR::_4_CLOCKS_3_BITS => 7,
         }
     }
     #[allow(missing_docs)]
@@ -151,56 +151,56 @@ impl CLKSR {
     #[inline]
     pub fn _from(value: u8) -> CLKSR {
         match value {
-            0 => CLKSR::_11_CLOCKS,
-            1 => CLKSR::_10_CLOCKS,
-            2 => CLKSR::_9_CLOCKS,
-            3 => CLKSR::_8_CLOCKS,
-            4 => CLKSR::_7_CLOCKS,
-            5 => CLKSR::_6_CLOCKS,
-            6 => CLKSR::_5_CLOCKS,
-            7 => CLKSR::_4_CLOCKS,
+            0 => CLKSR::_11_CLOCKS_10_BITS,
+            1 => CLKSR::_10_CLOCKS_9_BITS,
+            2 => CLKSR::_9_CLOCKS_8_BITS,
+            3 => CLKSR::_8_CLOCKS_7_BITS,
+            4 => CLKSR::_7_CLOCKS_6_BITS,
+            5 => CLKSR::_6_CLOCKS_5_BITS,
+            6 => CLKSR::_5_CLOCKS_4_BITS,
+            7 => CLKSR::_4_CLOCKS_3_BITS,
             _ => unreachable!(),
         }
     }
-    #[doc = "Checks if the value of the field is `_11_CLOCKS`"]
+    #[doc = "Checks if the value of the field is `_11_CLOCKS_10_BITS`"]
     #[inline]
-    pub fn is_11_clocks(&self) -> bool {
-        *self == CLKSR::_11_CLOCKS
+    pub fn is_11_clocks_10_bits(&self) -> bool {
+        *self == CLKSR::_11_CLOCKS_10_BITS
     }
-    #[doc = "Checks if the value of the field is `_10_CLOCKS`"]
+    #[doc = "Checks if the value of the field is `_10_CLOCKS_9_BITS`"]
     #[inline]
-    pub fn is_10_clocks(&self) -> bool {
-        *self == CLKSR::_10_CLOCKS
+    pub fn is_10_clocks_9_bits(&self) -> bool {
+        *self == CLKSR::_10_CLOCKS_9_BITS
     }
-    #[doc = "Checks if the value of the field is `_9_CLOCKS`"]
+    #[doc = "Checks if the value of the field is `_9_CLOCKS_8_BITS`"]
     #[inline]
-    pub fn is_9_clocks(&self) -> bool {
-        *self == CLKSR::_9_CLOCKS
+    pub fn is_9_clocks_8_bits(&self) -> bool {
+        *self == CLKSR::_9_CLOCKS_8_BITS
     }
-    #[doc = "Checks if the value of the field is `_8_CLOCKS`"]
+    #[doc = "Checks if the value of the field is `_8_CLOCKS_7_BITS`"]
     #[inline]
-    pub fn is_8_clocks(&self) -> bool {
-        *self == CLKSR::_8_CLOCKS
+    pub fn is_8_clocks_7_bits(&self) -> bool {
+        *self == CLKSR::_8_CLOCKS_7_BITS
     }
-    #[doc = "Checks if the value of the field is `_7_CLOCKS`"]
+    #[doc = "Checks if the value of the field is `_7_CLOCKS_6_BITS`"]
     #[inline]
-    pub fn is_7_clocks(&self) -> bool {
-        *self == CLKSR::_7_CLOCKS
+    pub fn is_7_clocks_6_bits(&self) -> bool {
+        *self == CLKSR::_7_CLOCKS_6_BITS
     }
-    #[doc = "Checks if the value of the field is `_6_CLOCKS`"]
+    #[doc = "Checks if the value of the field is `_6_CLOCKS_5_BITS`"]
     #[inline]
-    pub fn is_6_clocks(&self) -> bool {
-        *self == CLKSR::_6_CLOCKS
+    pub fn is_6_clocks_5_bits(&self) -> bool {
+        *self == CLKSR::_6_CLOCKS_5_BITS
     }
-    #[doc = "Checks if the value of the field is `_5_CLOCKS`"]
+    #[doc = "Checks if the value of the field is `_5_CLOCKS_4_BITS`"]
     #[inline]
-    pub fn is_5_clocks(&self) -> bool {
-        *self == CLKSR::_5_CLOCKS
+    pub fn is_5_clocks_4_bits(&self) -> bool {
+        *self == CLKSR::_5_CLOCKS_4_BITS
     }
-    #[doc = "Checks if the value of the field is `_4_CLOCKS`"]
+    #[doc = "Checks if the value of the field is `_4_CLOCKS_3_BITS`"]
     #[inline]
-    pub fn is_4_clocks(&self) -> bool {
-        *self == CLKSR::_4_CLOCKS
+    pub fn is_4_clocks_3_bits(&self) -> bool {
+        *self == CLKSR::_4_CLOCKS_3_BITS
     }
 }
 #[doc = "Possible values of the field `START`"]
@@ -375,9 +375,9 @@ impl<'a> _CLKDIVW<'a> {
 #[doc = "Values that can be written to the field `BURST`"]
 pub enum BURSTW {
     #[doc = "Software-controlled mode: Conversions are software-controlled and require 11 clocks."]
-    SOFTWARE_CONTROLLED_,
+    SOFTWARE_CONTROLLED,
     #[doc = "Hardware scan mode: The AD converter does repeated conversions at the rate selected by the CLKS field, scanning (if necessary) through the pins selected by 1s in the SEL field. The first conversion after the start corresponds to the least-significant bit set to 1 in the SEL field, then the next higher  bits (pins) set to 1 are scanned if applicable. Repeated conversions can be terminated by clearing this bit, but the conversion in progress when this bit is cleared will be completed. Important: START bits must be 000 when BURST = 1 or conversions will not start."]
-    HARDWARE_SCAN_MODE_,
+    HARDWARE_SCAN,
 }
 impl BURSTW {
     #[allow(missing_docs)]
@@ -385,8 +385,8 @@ impl BURSTW {
     #[inline]
     pub fn _bits(&self) -> bool {
         match *self {
-            BURSTW::SOFTWARE_CONTROLLED_ => false,
-            BURSTW::HARDWARE_SCAN_MODE_ => true,
+            BURSTW::SOFTWARE_CONTROLLED => false,
+            BURSTW::HARDWARE_SCAN => true,
         }
     }
 }
@@ -404,13 +404,13 @@ impl<'a> _BURSTW<'a> {
     }
     #[doc = "Software-controlled mode: Conversions are software-controlled and require 11 clocks."]
     #[inline]
-    pub fn software_controlled_(self) -> &'a mut W {
-        self.variant(BURSTW::SOFTWARE_CONTROLLED_)
+    pub fn software_controlled(self) -> &'a mut W {
+        self.variant(BURSTW::SOFTWARE_CONTROLLED)
     }
     #[doc = "Hardware scan mode: The AD converter does repeated conversions at the rate selected by the CLKS field, scanning (if necessary) through the pins selected by 1s in the SEL field. The first conversion after the start corresponds to the least-significant bit set to 1 in the SEL field, then the next higher bits (pins) set to 1 are scanned if applicable. Repeated conversions can be terminated by clearing this bit, but the conversion in progress when this bit is cleared will be completed. Important: START bits must be 000 when BURST = 1 or conversions will not start."]
     #[inline]
-    pub fn hardware_scan_mode_(self) -> &'a mut W {
-        self.variant(BURSTW::HARDWARE_SCAN_MODE_)
+    pub fn hardware_scan(self) -> &'a mut W {
+        self.variant(BURSTW::HARDWARE_SCAN)
     }
     #[doc = r" Sets the field bit"]
     pub fn set_bit(self) -> &'a mut W {
@@ -433,21 +433,21 @@ impl<'a> _BURSTW<'a> {
 #[doc = "Values that can be written to the field `CLKS`"]
 pub enum CLKSW {
     #[doc = "11 clocks / 10 bits"]
-    _11_CLOCKS,
+    _11_CLOCKS_10_BITS,
     #[doc = "10 clocks / 9 bits"]
-    _10_CLOCKS,
+    _10_CLOCKS_9_BITS,
     #[doc = "9 clocks / 8 bits"]
-    _9_CLOCKS,
+    _9_CLOCKS_8_BITS,
     #[doc = "8 clocks / 7 bits"]
-    _8_CLOCKS,
+    _8_CLOCKS_7_BITS,
     #[doc = "7 clocks / 6 bits"]
-    _7_CLOCKS,
+    _7_CLOCKS_6_BITS,
     #[doc = "6 clocks / 5 bits"]
-    _6_CLOCKS,
+    _6_CLOCKS_5_BITS,
     #[doc = "5 clocks / 4 bits"]
-    _5_CLOCKS,
+    _5_CLOCKS_4_BITS,
     #[doc = "4 clocks / 3 bits"]
-    _4_CLOCKS,
+    _4_CLOCKS_3_BITS,
 }
 impl CLKSW {
     #[allow(missing_docs)]
@@ -455,14 +455,14 @@ impl CLKSW {
     #[inline]
     pub fn _bits(&self) -> u8 {
         match *self {
-            CLKSW::_11_CLOCKS => 0,
-            CLKSW::_10_CLOCKS => 1,
-            CLKSW::_9_CLOCKS => 2,
-            CLKSW::_8_CLOCKS => 3,
-            CLKSW::_7_CLOCKS => 4,
-            CLKSW::_6_CLOCKS => 5,
-            CLKSW::_5_CLOCKS => 6,
-            CLKSW::_4_CLOCKS => 7,
+            CLKSW::_11_CLOCKS_10_BITS => 0,
+            CLKSW::_10_CLOCKS_9_BITS => 1,
+            CLKSW::_9_CLOCKS_8_BITS => 2,
+            CLKSW::_8_CLOCKS_7_BITS => 3,
+            CLKSW::_7_CLOCKS_6_BITS => 4,
+            CLKSW::_6_CLOCKS_5_BITS => 5,
+            CLKSW::_5_CLOCKS_4_BITS => 6,
+            CLKSW::_4_CLOCKS_3_BITS => 7,
         }
     }
 }
@@ -480,43 +480,43 @@ impl<'a> _CLKSW<'a> {
     }
     #[doc = "11 clocks / 10 bits"]
     #[inline]
-    pub fn _11_clocks(self) -> &'a mut W {
-        self.variant(CLKSW::_11_CLOCKS)
+    pub fn _11_clocks_10_bits(self) -> &'a mut W {
+        self.variant(CLKSW::_11_CLOCKS_10_BITS)
     }
     #[doc = "10 clocks / 9 bits"]
     #[inline]
-    pub fn _10_clocks(self) -> &'a mut W {
-        self.variant(CLKSW::_10_CLOCKS)
+    pub fn _10_clocks_9_bits(self) -> &'a mut W {
+        self.variant(CLKSW::_10_CLOCKS_9_BITS)
     }
     #[doc = "9 clocks / 8 bits"]
     #[inline]
-    pub fn _9_clocks(self) -> &'a mut W {
-        self.variant(CLKSW::_9_CLOCKS)
+    pub fn _9_clocks_8_bits(self) -> &'a mut W {
+        self.variant(CLKSW::_9_CLOCKS_8_BITS)
     }
     #[doc = "8 clocks / 7 bits"]
     #[inline]
-    pub fn _8_clocks(self) -> &'a mut W {
-        self.variant(CLKSW::_8_CLOCKS)
+    pub fn _8_clocks_7_bits(self) -> &'a mut W {
+        self.variant(CLKSW::_8_CLOCKS_7_BITS)
     }
     #[doc = "7 clocks / 6 bits"]
     #[inline]
-    pub fn _7_clocks(self) -> &'a mut W {
-        self.variant(CLKSW::_7_CLOCKS)
+    pub fn _7_clocks_6_bits(self) -> &'a mut W {
+        self.variant(CLKSW::_7_CLOCKS_6_BITS)
     }
     #[doc = "6 clocks / 5 bits"]
     #[inline]
-    pub fn _6_clocks(self) -> &'a mut W {
-        self.variant(CLKSW::_6_CLOCKS)
+    pub fn _6_clocks_5_bits(self) -> &'a mut W {
+        self.variant(CLKSW::_6_CLOCKS_5_BITS)
     }
     #[doc = "5 clocks / 4 bits"]
     #[inline]
-    pub fn _5_clocks(self) -> &'a mut W {
-        self.variant(CLKSW::_5_CLOCKS)
+    pub fn _5_clocks_4_bits(self) -> &'a mut W {
+        self.variant(CLKSW::_5_CLOCKS_4_BITS)
     }
     #[doc = "4 clocks / 3 bits"]
     #[inline]
-    pub fn _4_clocks(self) -> &'a mut W {
-        self.variant(CLKSW::_4_CLOCKS)
+    pub fn _4_clocks_3_bits(self) -> &'a mut W {
+        self.variant(CLKSW::_4_CLOCKS_3_BITS)
     }
     #[doc = r" Writes raw bits to the field"]
     #[inline]

--- a/lpc11uxx/src/ct16b0/ccr.rs
+++ b/lpc11uxx/src/ct16b0/ccr.rs
@@ -46,9 +46,9 @@ impl super::CCR {
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum CAP0RER {
     #[doc = "Enabled."]
-    ENABLED_,
+    ENABLED,
     #[doc = "Disabled."]
-    DISABLED_,
+    DISABLED,
 }
 impl CAP0RER {
     #[doc = r" Returns `true` if the bit is clear (0)"]
@@ -65,8 +65,8 @@ impl CAP0RER {
     #[inline]
     pub fn bit(&self) -> bool {
         match *self {
-            CAP0RER::ENABLED_ => true,
-            CAP0RER::DISABLED_ => false,
+            CAP0RER::ENABLED => true,
+            CAP0RER::DISABLED => false,
         }
     }
     #[allow(missing_docs)]
@@ -74,28 +74,28 @@ impl CAP0RER {
     #[inline]
     pub fn _from(value: bool) -> CAP0RER {
         match value {
-            true => CAP0RER::ENABLED_,
-            false => CAP0RER::DISABLED_,
+            true => CAP0RER::ENABLED,
+            false => CAP0RER::DISABLED,
         }
     }
-    #[doc = "Checks if the value of the field is `ENABLED_`"]
+    #[doc = "Checks if the value of the field is `ENABLED`"]
     #[inline]
-    pub fn is_enabled_(&self) -> bool {
-        *self == CAP0RER::ENABLED_
+    pub fn is_enabled(&self) -> bool {
+        *self == CAP0RER::ENABLED
     }
-    #[doc = "Checks if the value of the field is `DISABLED_`"]
+    #[doc = "Checks if the value of the field is `DISABLED`"]
     #[inline]
-    pub fn is_disabled_(&self) -> bool {
-        *self == CAP0RER::DISABLED_
+    pub fn is_disabled(&self) -> bool {
+        *self == CAP0RER::DISABLED
     }
 }
 #[doc = "Possible values of the field `CAP0FE`"]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum CAP0FER {
     #[doc = "Enabled."]
-    ENABLED_,
+    ENABLED,
     #[doc = "Disabled."]
-    DISABLED_,
+    DISABLED,
 }
 impl CAP0FER {
     #[doc = r" Returns `true` if the bit is clear (0)"]
@@ -112,8 +112,8 @@ impl CAP0FER {
     #[inline]
     pub fn bit(&self) -> bool {
         match *self {
-            CAP0FER::ENABLED_ => true,
-            CAP0FER::DISABLED_ => false,
+            CAP0FER::ENABLED => true,
+            CAP0FER::DISABLED => false,
         }
     }
     #[allow(missing_docs)]
@@ -121,28 +121,28 @@ impl CAP0FER {
     #[inline]
     pub fn _from(value: bool) -> CAP0FER {
         match value {
-            true => CAP0FER::ENABLED_,
-            false => CAP0FER::DISABLED_,
+            true => CAP0FER::ENABLED,
+            false => CAP0FER::DISABLED,
         }
     }
-    #[doc = "Checks if the value of the field is `ENABLED_`"]
+    #[doc = "Checks if the value of the field is `ENABLED`"]
     #[inline]
-    pub fn is_enabled_(&self) -> bool {
-        *self == CAP0FER::ENABLED_
+    pub fn is_enabled(&self) -> bool {
+        *self == CAP0FER::ENABLED
     }
-    #[doc = "Checks if the value of the field is `DISABLED_`"]
+    #[doc = "Checks if the value of the field is `DISABLED`"]
     #[inline]
-    pub fn is_disabled_(&self) -> bool {
-        *self == CAP0FER::DISABLED_
+    pub fn is_disabled(&self) -> bool {
+        *self == CAP0FER::DISABLED
     }
 }
 #[doc = "Possible values of the field `CAP0I`"]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum CAP0IR {
     #[doc = "Enabled."]
-    ENABLED_,
+    ENABLED,
     #[doc = "Disabled."]
-    DISABLED_,
+    DISABLED,
 }
 impl CAP0IR {
     #[doc = r" Returns `true` if the bit is clear (0)"]
@@ -159,8 +159,8 @@ impl CAP0IR {
     #[inline]
     pub fn bit(&self) -> bool {
         match *self {
-            CAP0IR::ENABLED_ => true,
-            CAP0IR::DISABLED_ => false,
+            CAP0IR::ENABLED => true,
+            CAP0IR::DISABLED => false,
         }
     }
     #[allow(missing_docs)]
@@ -168,28 +168,28 @@ impl CAP0IR {
     #[inline]
     pub fn _from(value: bool) -> CAP0IR {
         match value {
-            true => CAP0IR::ENABLED_,
-            false => CAP0IR::DISABLED_,
+            true => CAP0IR::ENABLED,
+            false => CAP0IR::DISABLED,
         }
     }
-    #[doc = "Checks if the value of the field is `ENABLED_`"]
+    #[doc = "Checks if the value of the field is `ENABLED`"]
     #[inline]
-    pub fn is_enabled_(&self) -> bool {
-        *self == CAP0IR::ENABLED_
+    pub fn is_enabled(&self) -> bool {
+        *self == CAP0IR::ENABLED
     }
-    #[doc = "Checks if the value of the field is `DISABLED_`"]
+    #[doc = "Checks if the value of the field is `DISABLED`"]
     #[inline]
-    pub fn is_disabled_(&self) -> bool {
-        *self == CAP0IR::DISABLED_
+    pub fn is_disabled(&self) -> bool {
+        *self == CAP0IR::DISABLED
     }
 }
 #[doc = "Possible values of the field `CAP1RE`"]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum CAP1RER {
     #[doc = "Enabled."]
-    ENABLED_,
+    ENABLED,
     #[doc = "Disabled."]
-    DISABLED_,
+    DISABLED,
 }
 impl CAP1RER {
     #[doc = r" Returns `true` if the bit is clear (0)"]
@@ -206,8 +206,8 @@ impl CAP1RER {
     #[inline]
     pub fn bit(&self) -> bool {
         match *self {
-            CAP1RER::ENABLED_ => true,
-            CAP1RER::DISABLED_ => false,
+            CAP1RER::ENABLED => true,
+            CAP1RER::DISABLED => false,
         }
     }
     #[allow(missing_docs)]
@@ -215,28 +215,28 @@ impl CAP1RER {
     #[inline]
     pub fn _from(value: bool) -> CAP1RER {
         match value {
-            true => CAP1RER::ENABLED_,
-            false => CAP1RER::DISABLED_,
+            true => CAP1RER::ENABLED,
+            false => CAP1RER::DISABLED,
         }
     }
-    #[doc = "Checks if the value of the field is `ENABLED_`"]
+    #[doc = "Checks if the value of the field is `ENABLED`"]
     #[inline]
-    pub fn is_enabled_(&self) -> bool {
-        *self == CAP1RER::ENABLED_
+    pub fn is_enabled(&self) -> bool {
+        *self == CAP1RER::ENABLED
     }
-    #[doc = "Checks if the value of the field is `DISABLED_`"]
+    #[doc = "Checks if the value of the field is `DISABLED`"]
     #[inline]
-    pub fn is_disabled_(&self) -> bool {
-        *self == CAP1RER::DISABLED_
+    pub fn is_disabled(&self) -> bool {
+        *self == CAP1RER::DISABLED
     }
 }
 #[doc = "Possible values of the field `CAP1FE`"]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum CAP1FER {
     #[doc = "Enabled."]
-    ENABLED_,
+    ENABLED,
     #[doc = "Disabled."]
-    DISABLED_,
+    DISABLED,
 }
 impl CAP1FER {
     #[doc = r" Returns `true` if the bit is clear (0)"]
@@ -253,8 +253,8 @@ impl CAP1FER {
     #[inline]
     pub fn bit(&self) -> bool {
         match *self {
-            CAP1FER::ENABLED_ => true,
-            CAP1FER::DISABLED_ => false,
+            CAP1FER::ENABLED => true,
+            CAP1FER::DISABLED => false,
         }
     }
     #[allow(missing_docs)]
@@ -262,28 +262,28 @@ impl CAP1FER {
     #[inline]
     pub fn _from(value: bool) -> CAP1FER {
         match value {
-            true => CAP1FER::ENABLED_,
-            false => CAP1FER::DISABLED_,
+            true => CAP1FER::ENABLED,
+            false => CAP1FER::DISABLED,
         }
     }
-    #[doc = "Checks if the value of the field is `ENABLED_`"]
+    #[doc = "Checks if the value of the field is `ENABLED`"]
     #[inline]
-    pub fn is_enabled_(&self) -> bool {
-        *self == CAP1FER::ENABLED_
+    pub fn is_enabled(&self) -> bool {
+        *self == CAP1FER::ENABLED
     }
-    #[doc = "Checks if the value of the field is `DISABLED_`"]
+    #[doc = "Checks if the value of the field is `DISABLED`"]
     #[inline]
-    pub fn is_disabled_(&self) -> bool {
-        *self == CAP1FER::DISABLED_
+    pub fn is_disabled(&self) -> bool {
+        *self == CAP1FER::DISABLED
     }
 }
 #[doc = "Possible values of the field `CAP1I`"]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum CAP1IR {
     #[doc = "Enabled."]
-    ENABLED_,
+    ENABLED,
     #[doc = "Disabled."]
-    DISABLED_,
+    DISABLED,
 }
 impl CAP1IR {
     #[doc = r" Returns `true` if the bit is clear (0)"]
@@ -300,8 +300,8 @@ impl CAP1IR {
     #[inline]
     pub fn bit(&self) -> bool {
         match *self {
-            CAP1IR::ENABLED_ => true,
-            CAP1IR::DISABLED_ => false,
+            CAP1IR::ENABLED => true,
+            CAP1IR::DISABLED => false,
         }
     }
     #[allow(missing_docs)]
@@ -309,27 +309,27 @@ impl CAP1IR {
     #[inline]
     pub fn _from(value: bool) -> CAP1IR {
         match value {
-            true => CAP1IR::ENABLED_,
-            false => CAP1IR::DISABLED_,
+            true => CAP1IR::ENABLED,
+            false => CAP1IR::DISABLED,
         }
     }
-    #[doc = "Checks if the value of the field is `ENABLED_`"]
+    #[doc = "Checks if the value of the field is `ENABLED`"]
     #[inline]
-    pub fn is_enabled_(&self) -> bool {
-        *self == CAP1IR::ENABLED_
+    pub fn is_enabled(&self) -> bool {
+        *self == CAP1IR::ENABLED
     }
-    #[doc = "Checks if the value of the field is `DISABLED_`"]
+    #[doc = "Checks if the value of the field is `DISABLED`"]
     #[inline]
-    pub fn is_disabled_(&self) -> bool {
-        *self == CAP1IR::DISABLED_
+    pub fn is_disabled(&self) -> bool {
+        *self == CAP1IR::DISABLED
     }
 }
 #[doc = "Values that can be written to the field `CAP0RE`"]
 pub enum CAP0REW {
     #[doc = "Enabled."]
-    ENABLED_,
+    ENABLED,
     #[doc = "Disabled."]
-    DISABLED_,
+    DISABLED,
 }
 impl CAP0REW {
     #[allow(missing_docs)]
@@ -337,8 +337,8 @@ impl CAP0REW {
     #[inline]
     pub fn _bits(&self) -> bool {
         match *self {
-            CAP0REW::ENABLED_ => true,
-            CAP0REW::DISABLED_ => false,
+            CAP0REW::ENABLED => true,
+            CAP0REW::DISABLED => false,
         }
     }
 }
@@ -356,13 +356,13 @@ impl<'a> _CAP0REW<'a> {
     }
     #[doc = "Enabled."]
     #[inline]
-    pub fn enabled_(self) -> &'a mut W {
-        self.variant(CAP0REW::ENABLED_)
+    pub fn enabled(self) -> &'a mut W {
+        self.variant(CAP0REW::ENABLED)
     }
     #[doc = "Disabled."]
     #[inline]
-    pub fn disabled_(self) -> &'a mut W {
-        self.variant(CAP0REW::DISABLED_)
+    pub fn disabled(self) -> &'a mut W {
+        self.variant(CAP0REW::DISABLED)
     }
     #[doc = r" Sets the field bit"]
     pub fn set_bit(self) -> &'a mut W {
@@ -385,9 +385,9 @@ impl<'a> _CAP0REW<'a> {
 #[doc = "Values that can be written to the field `CAP0FE`"]
 pub enum CAP0FEW {
     #[doc = "Enabled."]
-    ENABLED_,
+    ENABLED,
     #[doc = "Disabled."]
-    DISABLED_,
+    DISABLED,
 }
 impl CAP0FEW {
     #[allow(missing_docs)]
@@ -395,8 +395,8 @@ impl CAP0FEW {
     #[inline]
     pub fn _bits(&self) -> bool {
         match *self {
-            CAP0FEW::ENABLED_ => true,
-            CAP0FEW::DISABLED_ => false,
+            CAP0FEW::ENABLED => true,
+            CAP0FEW::DISABLED => false,
         }
     }
 }
@@ -414,13 +414,13 @@ impl<'a> _CAP0FEW<'a> {
     }
     #[doc = "Enabled."]
     #[inline]
-    pub fn enabled_(self) -> &'a mut W {
-        self.variant(CAP0FEW::ENABLED_)
+    pub fn enabled(self) -> &'a mut W {
+        self.variant(CAP0FEW::ENABLED)
     }
     #[doc = "Disabled."]
     #[inline]
-    pub fn disabled_(self) -> &'a mut W {
-        self.variant(CAP0FEW::DISABLED_)
+    pub fn disabled(self) -> &'a mut W {
+        self.variant(CAP0FEW::DISABLED)
     }
     #[doc = r" Sets the field bit"]
     pub fn set_bit(self) -> &'a mut W {
@@ -443,9 +443,9 @@ impl<'a> _CAP0FEW<'a> {
 #[doc = "Values that can be written to the field `CAP0I`"]
 pub enum CAP0IW {
     #[doc = "Enabled."]
-    ENABLED_,
+    ENABLED,
     #[doc = "Disabled."]
-    DISABLED_,
+    DISABLED,
 }
 impl CAP0IW {
     #[allow(missing_docs)]
@@ -453,8 +453,8 @@ impl CAP0IW {
     #[inline]
     pub fn _bits(&self) -> bool {
         match *self {
-            CAP0IW::ENABLED_ => true,
-            CAP0IW::DISABLED_ => false,
+            CAP0IW::ENABLED => true,
+            CAP0IW::DISABLED => false,
         }
     }
 }
@@ -472,13 +472,13 @@ impl<'a> _CAP0IW<'a> {
     }
     #[doc = "Enabled."]
     #[inline]
-    pub fn enabled_(self) -> &'a mut W {
-        self.variant(CAP0IW::ENABLED_)
+    pub fn enabled(self) -> &'a mut W {
+        self.variant(CAP0IW::ENABLED)
     }
     #[doc = "Disabled."]
     #[inline]
-    pub fn disabled_(self) -> &'a mut W {
-        self.variant(CAP0IW::DISABLED_)
+    pub fn disabled(self) -> &'a mut W {
+        self.variant(CAP0IW::DISABLED)
     }
     #[doc = r" Sets the field bit"]
     pub fn set_bit(self) -> &'a mut W {
@@ -501,9 +501,9 @@ impl<'a> _CAP0IW<'a> {
 #[doc = "Values that can be written to the field `CAP1RE`"]
 pub enum CAP1REW {
     #[doc = "Enabled."]
-    ENABLED_,
+    ENABLED,
     #[doc = "Disabled."]
-    DISABLED_,
+    DISABLED,
 }
 impl CAP1REW {
     #[allow(missing_docs)]
@@ -511,8 +511,8 @@ impl CAP1REW {
     #[inline]
     pub fn _bits(&self) -> bool {
         match *self {
-            CAP1REW::ENABLED_ => true,
-            CAP1REW::DISABLED_ => false,
+            CAP1REW::ENABLED => true,
+            CAP1REW::DISABLED => false,
         }
     }
 }
@@ -530,13 +530,13 @@ impl<'a> _CAP1REW<'a> {
     }
     #[doc = "Enabled."]
     #[inline]
-    pub fn enabled_(self) -> &'a mut W {
-        self.variant(CAP1REW::ENABLED_)
+    pub fn enabled(self) -> &'a mut W {
+        self.variant(CAP1REW::ENABLED)
     }
     #[doc = "Disabled."]
     #[inline]
-    pub fn disabled_(self) -> &'a mut W {
-        self.variant(CAP1REW::DISABLED_)
+    pub fn disabled(self) -> &'a mut W {
+        self.variant(CAP1REW::DISABLED)
     }
     #[doc = r" Sets the field bit"]
     pub fn set_bit(self) -> &'a mut W {
@@ -559,9 +559,9 @@ impl<'a> _CAP1REW<'a> {
 #[doc = "Values that can be written to the field `CAP1FE`"]
 pub enum CAP1FEW {
     #[doc = "Enabled."]
-    ENABLED_,
+    ENABLED,
     #[doc = "Disabled."]
-    DISABLED_,
+    DISABLED,
 }
 impl CAP1FEW {
     #[allow(missing_docs)]
@@ -569,8 +569,8 @@ impl CAP1FEW {
     #[inline]
     pub fn _bits(&self) -> bool {
         match *self {
-            CAP1FEW::ENABLED_ => true,
-            CAP1FEW::DISABLED_ => false,
+            CAP1FEW::ENABLED => true,
+            CAP1FEW::DISABLED => false,
         }
     }
 }
@@ -588,13 +588,13 @@ impl<'a> _CAP1FEW<'a> {
     }
     #[doc = "Enabled."]
     #[inline]
-    pub fn enabled_(self) -> &'a mut W {
-        self.variant(CAP1FEW::ENABLED_)
+    pub fn enabled(self) -> &'a mut W {
+        self.variant(CAP1FEW::ENABLED)
     }
     #[doc = "Disabled."]
     #[inline]
-    pub fn disabled_(self) -> &'a mut W {
-        self.variant(CAP1FEW::DISABLED_)
+    pub fn disabled(self) -> &'a mut W {
+        self.variant(CAP1FEW::DISABLED)
     }
     #[doc = r" Sets the field bit"]
     pub fn set_bit(self) -> &'a mut W {
@@ -617,9 +617,9 @@ impl<'a> _CAP1FEW<'a> {
 #[doc = "Values that can be written to the field `CAP1I`"]
 pub enum CAP1IW {
     #[doc = "Enabled."]
-    ENABLED_,
+    ENABLED,
     #[doc = "Disabled."]
-    DISABLED_,
+    DISABLED,
 }
 impl CAP1IW {
     #[allow(missing_docs)]
@@ -627,8 +627,8 @@ impl CAP1IW {
     #[inline]
     pub fn _bits(&self) -> bool {
         match *self {
-            CAP1IW::ENABLED_ => true,
-            CAP1IW::DISABLED_ => false,
+            CAP1IW::ENABLED => true,
+            CAP1IW::DISABLED => false,
         }
     }
 }
@@ -646,13 +646,13 @@ impl<'a> _CAP1IW<'a> {
     }
     #[doc = "Enabled."]
     #[inline]
-    pub fn enabled_(self) -> &'a mut W {
-        self.variant(CAP1IW::ENABLED_)
+    pub fn enabled(self) -> &'a mut W {
+        self.variant(CAP1IW::ENABLED)
     }
     #[doc = "Disabled."]
     #[inline]
-    pub fn disabled_(self) -> &'a mut W {
-        self.variant(CAP1IW::DISABLED_)
+    pub fn disabled(self) -> &'a mut W {
+        self.variant(CAP1IW::DISABLED)
     }
     #[doc = r" Sets the field bit"]
     pub fn set_bit(self) -> &'a mut W {

--- a/lpc11uxx/src/ct16b0/ctcr.rs
+++ b/lpc11uxx/src/ct16b0/ctcr.rs
@@ -48,11 +48,11 @@ pub enum CTMR {
     #[doc = "Timer Mode: every rising PCLK edge"]
     TIMER_MODE_EVERY_RI,
     #[doc = "Counter Mode: TC is incremented on rising edges on the CAP input selected by bits 3:2."]
-    COUNTER_MODE_TC_IS_RISING,
+    RISING,
     #[doc = "Counter Mode: TC is incremented on falling edges on the CAP input selected by bits 3:2."]
-    COUNTER_MODE_TC_IS_FALLING,
+    FALLING,
     #[doc = "Counter Mode: TC is incremented on both edges on the CAP input selected by bits 3:2."]
-    COUNTER_MODE_TC_IS_BOTH,
+    BOTH,
 }
 impl CTMR {
     #[doc = r" Value of the field as raw bits"]
@@ -60,9 +60,9 @@ impl CTMR {
     pub fn bits(&self) -> u8 {
         match *self {
             CTMR::TIMER_MODE_EVERY_RI => 0,
-            CTMR::COUNTER_MODE_TC_IS_RISING => 1,
-            CTMR::COUNTER_MODE_TC_IS_FALLING => 2,
-            CTMR::COUNTER_MODE_TC_IS_BOTH => 3,
+            CTMR::RISING => 1,
+            CTMR::FALLING => 2,
+            CTMR::BOTH => 3,
         }
     }
     #[allow(missing_docs)]
@@ -71,9 +71,9 @@ impl CTMR {
     pub fn _from(value: u8) -> CTMR {
         match value {
             0 => CTMR::TIMER_MODE_EVERY_RI,
-            1 => CTMR::COUNTER_MODE_TC_IS_RISING,
-            2 => CTMR::COUNTER_MODE_TC_IS_FALLING,
-            3 => CTMR::COUNTER_MODE_TC_IS_BOTH,
+            1 => CTMR::RISING,
+            2 => CTMR::FALLING,
+            3 => CTMR::BOTH,
             _ => unreachable!(),
         }
     }
@@ -82,31 +82,31 @@ impl CTMR {
     pub fn is_timer_mode_every_ri(&self) -> bool {
         *self == CTMR::TIMER_MODE_EVERY_RI
     }
-    #[doc = "Checks if the value of the field is `COUNTER_MODE_TC_IS_RISING`"]
+    #[doc = "Checks if the value of the field is `RISING`"]
     #[inline]
-    pub fn is_counter_mode_tc_is_rising(&self) -> bool {
-        *self == CTMR::COUNTER_MODE_TC_IS_RISING
+    pub fn is_rising(&self) -> bool {
+        *self == CTMR::RISING
     }
-    #[doc = "Checks if the value of the field is `COUNTER_MODE_TC_IS_FALLING`"]
+    #[doc = "Checks if the value of the field is `FALLING`"]
     #[inline]
-    pub fn is_counter_mode_tc_is_falling(&self) -> bool {
-        *self == CTMR::COUNTER_MODE_TC_IS_FALLING
+    pub fn is_falling(&self) -> bool {
+        *self == CTMR::FALLING
     }
-    #[doc = "Checks if the value of the field is `COUNTER_MODE_TC_IS_BOTH`"]
+    #[doc = "Checks if the value of the field is `BOTH`"]
     #[inline]
-    pub fn is_counter_mode_tc_is_both(&self) -> bool {
-        *self == CTMR::COUNTER_MODE_TC_IS_BOTH
+    pub fn is_both(&self) -> bool {
+        *self == CTMR::BOTH
     }
 }
 #[doc = "Possible values of the field `CIS`"]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum CISR {
     #[doc = "CT16B0_CAP0."]
-    CT16B0_CAP0_,
+    CT16B0_CAP0,
     #[doc = "Reserved."]
     RESERVED_1,
     #[doc = "CT16B0_CAP1."]
-    CT16B0_CAP1_,
+    CT16B0_CAP1,
     #[doc = r" Reserved"]
     _Reserved(u8),
 }
@@ -115,9 +115,9 @@ impl CISR {
     #[inline]
     pub fn bits(&self) -> u8 {
         match *self {
-            CISR::CT16B0_CAP0_ => 0,
+            CISR::CT16B0_CAP0 => 0,
             CISR::RESERVED_1 => 1,
-            CISR::CT16B0_CAP1_ => 2,
+            CISR::CT16B0_CAP1 => 2,
             CISR::_Reserved(bits) => bits,
         }
     }
@@ -126,26 +126,26 @@ impl CISR {
     #[inline]
     pub fn _from(value: u8) -> CISR {
         match value {
-            0 => CISR::CT16B0_CAP0_,
+            0 => CISR::CT16B0_CAP0,
             1 => CISR::RESERVED_1,
-            2 => CISR::CT16B0_CAP1_,
+            2 => CISR::CT16B0_CAP1,
             i => CISR::_Reserved(i),
         }
     }
-    #[doc = "Checks if the value of the field is `CT16B0_CAP0_`"]
+    #[doc = "Checks if the value of the field is `CT16B0_CAP0`"]
     #[inline]
-    pub fn is_ct16b0_cap0_(&self) -> bool {
-        *self == CISR::CT16B0_CAP0_
+    pub fn is_ct16b0_cap0(&self) -> bool {
+        *self == CISR::CT16B0_CAP0
     }
     #[doc = "Checks if the value of the field is `RESERVED_1`"]
     #[inline]
     pub fn is_reserved_1(&self) -> bool {
         *self == CISR::RESERVED_1
     }
-    #[doc = "Checks if the value of the field is `CT16B0_CAP1_`"]
+    #[doc = "Checks if the value of the field is `CT16B0_CAP1`"]
     #[inline]
-    pub fn is_ct16b0_cap1_(&self) -> bool {
-        *self == CISR::CT16B0_CAP1_
+    pub fn is_ct16b0_cap1(&self) -> bool {
+        *self == CISR::CT16B0_CAP1
     }
 }
 #[doc = r" Value of the field"]
@@ -251,11 +251,11 @@ pub enum CTMW {
     #[doc = "Timer Mode: every rising PCLK edge"]
     TIMER_MODE_EVERY_RI,
     #[doc = "Counter Mode: TC is incremented on rising edges on the CAP input selected by bits 3:2."]
-    COUNTER_MODE_TC_IS_RISING,
+    RISING,
     #[doc = "Counter Mode: TC is incremented on falling edges on the CAP input selected by bits 3:2."]
-    COUNTER_MODE_TC_IS_FALLING,
+    FALLING,
     #[doc = "Counter Mode: TC is incremented on both edges on the CAP input selected by bits 3:2."]
-    COUNTER_MODE_TC_IS_BOTH,
+    BOTH,
 }
 impl CTMW {
     #[allow(missing_docs)]
@@ -264,9 +264,9 @@ impl CTMW {
     pub fn _bits(&self) -> u8 {
         match *self {
             CTMW::TIMER_MODE_EVERY_RI => 0,
-            CTMW::COUNTER_MODE_TC_IS_RISING => 1,
-            CTMW::COUNTER_MODE_TC_IS_FALLING => 2,
-            CTMW::COUNTER_MODE_TC_IS_BOTH => 3,
+            CTMW::RISING => 1,
+            CTMW::FALLING => 2,
+            CTMW::BOTH => 3,
         }
     }
 }
@@ -289,18 +289,18 @@ impl<'a> _CTMW<'a> {
     }
     #[doc = "Counter Mode: TC is incremented on rising edges on the CAP input selected by bits 3:2."]
     #[inline]
-    pub fn counter_mode_tc_is_rising(self) -> &'a mut W {
-        self.variant(CTMW::COUNTER_MODE_TC_IS_RISING)
+    pub fn rising(self) -> &'a mut W {
+        self.variant(CTMW::RISING)
     }
     #[doc = "Counter Mode: TC is incremented on falling edges on the CAP input selected by bits 3:2."]
     #[inline]
-    pub fn counter_mode_tc_is_falling(self) -> &'a mut W {
-        self.variant(CTMW::COUNTER_MODE_TC_IS_FALLING)
+    pub fn falling(self) -> &'a mut W {
+        self.variant(CTMW::FALLING)
     }
     #[doc = "Counter Mode: TC is incremented on both edges on the CAP input selected by bits 3:2."]
     #[inline]
-    pub fn counter_mode_tc_is_both(self) -> &'a mut W {
-        self.variant(CTMW::COUNTER_MODE_TC_IS_BOTH)
+    pub fn both(self) -> &'a mut W {
+        self.variant(CTMW::BOTH)
     }
     #[doc = r" Writes raw bits to the field"]
     #[inline]
@@ -315,11 +315,11 @@ impl<'a> _CTMW<'a> {
 #[doc = "Values that can be written to the field `CIS`"]
 pub enum CISW {
     #[doc = "CT16B0_CAP0."]
-    CT16B0_CAP0_,
+    CT16B0_CAP0,
     #[doc = "Reserved."]
     RESERVED_1,
     #[doc = "CT16B0_CAP1."]
-    CT16B0_CAP1_,
+    CT16B0_CAP1,
 }
 impl CISW {
     #[allow(missing_docs)]
@@ -327,9 +327,9 @@ impl CISW {
     #[inline]
     pub fn _bits(&self) -> u8 {
         match *self {
-            CISW::CT16B0_CAP0_ => 0,
+            CISW::CT16B0_CAP0 => 0,
             CISW::RESERVED_1 => 1,
-            CISW::CT16B0_CAP1_ => 2,
+            CISW::CT16B0_CAP1 => 2,
         }
     }
 }
@@ -345,8 +345,8 @@ impl<'a> _CISW<'a> {
     }
     #[doc = "CT16B0_CAP0."]
     #[inline]
-    pub fn ct16b0_cap0_(self) -> &'a mut W {
-        self.variant(CISW::CT16B0_CAP0_)
+    pub fn ct16b0_cap0(self) -> &'a mut W {
+        self.variant(CISW::CT16B0_CAP0)
     }
     #[doc = "Reserved."]
     #[inline]
@@ -355,8 +355,8 @@ impl<'a> _CISW<'a> {
     }
     #[doc = "CT16B0_CAP1."]
     #[inline]
-    pub fn ct16b0_cap1_(self) -> &'a mut W {
-        self.variant(CISW::CT16B0_CAP1_)
+    pub fn ct16b0_cap1(self) -> &'a mut W {
+        self.variant(CISW::CT16B0_CAP1)
     }
     #[doc = r" Writes raw bits to the field"]
     #[inline]

--- a/lpc11uxx/src/ct16b0/emr.rs
+++ b/lpc11uxx/src/ct16b0/emr.rs
@@ -130,23 +130,23 @@ impl EM3R {
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum EMC0R {
     #[doc = "Do Nothing."]
-    DO_NOTHING_,
+    DO_NOTHING,
     #[doc = "Clear the corresponding External Match bit/output to 0 (CT16Bn_MAT0 pin is LOW if pinned out)."]
-    CLEAR_THE_CORRESPOND,
+    CLEAR,
     #[doc = "Set the corresponding External Match bit/output to 1 (CT16Bn_MAT0 pin is HIGH if pinned out)."]
-    SET_THE_CORRESPONDIN,
+    SET,
     #[doc = "Toggle the corresponding External Match bit/output."]
-    TOGGLE_THE_CORRESPON,
+    TOGGLE,
 }
 impl EMC0R {
     #[doc = r" Value of the field as raw bits"]
     #[inline]
     pub fn bits(&self) -> u8 {
         match *self {
-            EMC0R::DO_NOTHING_ => 0,
-            EMC0R::CLEAR_THE_CORRESPOND => 1,
-            EMC0R::SET_THE_CORRESPONDIN => 2,
-            EMC0R::TOGGLE_THE_CORRESPON => 3,
+            EMC0R::DO_NOTHING => 0,
+            EMC0R::CLEAR => 1,
+            EMC0R::SET => 2,
+            EMC0R::TOGGLE => 3,
         }
     }
     #[allow(missing_docs)]
@@ -154,55 +154,55 @@ impl EMC0R {
     #[inline]
     pub fn _from(value: u8) -> EMC0R {
         match value {
-            0 => EMC0R::DO_NOTHING_,
-            1 => EMC0R::CLEAR_THE_CORRESPOND,
-            2 => EMC0R::SET_THE_CORRESPONDIN,
-            3 => EMC0R::TOGGLE_THE_CORRESPON,
+            0 => EMC0R::DO_NOTHING,
+            1 => EMC0R::CLEAR,
+            2 => EMC0R::SET,
+            3 => EMC0R::TOGGLE,
             _ => unreachable!(),
         }
     }
-    #[doc = "Checks if the value of the field is `DO_NOTHING_`"]
+    #[doc = "Checks if the value of the field is `DO_NOTHING`"]
     #[inline]
-    pub fn is_do_nothing_(&self) -> bool {
-        *self == EMC0R::DO_NOTHING_
+    pub fn is_do_nothing(&self) -> bool {
+        *self == EMC0R::DO_NOTHING
     }
-    #[doc = "Checks if the value of the field is `CLEAR_THE_CORRESPOND`"]
+    #[doc = "Checks if the value of the field is `CLEAR`"]
     #[inline]
-    pub fn is_clear_the_correspond(&self) -> bool {
-        *self == EMC0R::CLEAR_THE_CORRESPOND
+    pub fn is_clear(&self) -> bool {
+        *self == EMC0R::CLEAR
     }
-    #[doc = "Checks if the value of the field is `SET_THE_CORRESPONDIN`"]
+    #[doc = "Checks if the value of the field is `SET`"]
     #[inline]
-    pub fn is_set_the_correspondin(&self) -> bool {
-        *self == EMC0R::SET_THE_CORRESPONDIN
+    pub fn is_set(&self) -> bool {
+        *self == EMC0R::SET
     }
-    #[doc = "Checks if the value of the field is `TOGGLE_THE_CORRESPON`"]
+    #[doc = "Checks if the value of the field is `TOGGLE`"]
     #[inline]
-    pub fn is_toggle_the_correspon(&self) -> bool {
-        *self == EMC0R::TOGGLE_THE_CORRESPON
+    pub fn is_toggle(&self) -> bool {
+        *self == EMC0R::TOGGLE
     }
 }
 #[doc = "Possible values of the field `EMC1`"]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum EMC1R {
     #[doc = "Do Nothing."]
-    DO_NOTHING_,
+    DO_NOTHING,
     #[doc = "Clear the corresponding External Match bit/output to 0 (CT16Bn_MAT1 pin is LOW if pinned out)."]
-    CLEAR_THE_CORRESPOND,
+    CLEAR,
     #[doc = "Set the corresponding External Match bit/output to 1 (CT16Bn_MAT1 pin is HIGH if pinned out)."]
-    SET_THE_CORRESPONDIN,
+    SET,
     #[doc = "Toggle the corresponding External Match bit/output."]
-    TOGGLE_THE_CORRESPON,
+    TOGGLE,
 }
 impl EMC1R {
     #[doc = r" Value of the field as raw bits"]
     #[inline]
     pub fn bits(&self) -> u8 {
         match *self {
-            EMC1R::DO_NOTHING_ => 0,
-            EMC1R::CLEAR_THE_CORRESPOND => 1,
-            EMC1R::SET_THE_CORRESPONDIN => 2,
-            EMC1R::TOGGLE_THE_CORRESPON => 3,
+            EMC1R::DO_NOTHING => 0,
+            EMC1R::CLEAR => 1,
+            EMC1R::SET => 2,
+            EMC1R::TOGGLE => 3,
         }
     }
     #[allow(missing_docs)]
@@ -210,55 +210,55 @@ impl EMC1R {
     #[inline]
     pub fn _from(value: u8) -> EMC1R {
         match value {
-            0 => EMC1R::DO_NOTHING_,
-            1 => EMC1R::CLEAR_THE_CORRESPOND,
-            2 => EMC1R::SET_THE_CORRESPONDIN,
-            3 => EMC1R::TOGGLE_THE_CORRESPON,
+            0 => EMC1R::DO_NOTHING,
+            1 => EMC1R::CLEAR,
+            2 => EMC1R::SET,
+            3 => EMC1R::TOGGLE,
             _ => unreachable!(),
         }
     }
-    #[doc = "Checks if the value of the field is `DO_NOTHING_`"]
+    #[doc = "Checks if the value of the field is `DO_NOTHING`"]
     #[inline]
-    pub fn is_do_nothing_(&self) -> bool {
-        *self == EMC1R::DO_NOTHING_
+    pub fn is_do_nothing(&self) -> bool {
+        *self == EMC1R::DO_NOTHING
     }
-    #[doc = "Checks if the value of the field is `CLEAR_THE_CORRESPOND`"]
+    #[doc = "Checks if the value of the field is `CLEAR`"]
     #[inline]
-    pub fn is_clear_the_correspond(&self) -> bool {
-        *self == EMC1R::CLEAR_THE_CORRESPOND
+    pub fn is_clear(&self) -> bool {
+        *self == EMC1R::CLEAR
     }
-    #[doc = "Checks if the value of the field is `SET_THE_CORRESPONDIN`"]
+    #[doc = "Checks if the value of the field is `SET`"]
     #[inline]
-    pub fn is_set_the_correspondin(&self) -> bool {
-        *self == EMC1R::SET_THE_CORRESPONDIN
+    pub fn is_set(&self) -> bool {
+        *self == EMC1R::SET
     }
-    #[doc = "Checks if the value of the field is `TOGGLE_THE_CORRESPON`"]
+    #[doc = "Checks if the value of the field is `TOGGLE`"]
     #[inline]
-    pub fn is_toggle_the_correspon(&self) -> bool {
-        *self == EMC1R::TOGGLE_THE_CORRESPON
+    pub fn is_toggle(&self) -> bool {
+        *self == EMC1R::TOGGLE
     }
 }
 #[doc = "Possible values of the field `EMC2`"]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum EMC2R {
     #[doc = "Do Nothing."]
-    DO_NOTHING_,
+    DO_NOTHING,
     #[doc = "Clear the corresponding External Match bit/output to 0 (CT16Bn_MAT2 pin is LOW if pinned out)."]
-    CLEAR_THE_CORRESPOND,
+    CLEAR,
     #[doc = "Set the corresponding External Match bit/output to 1 (CT16Bn_MAT2 pin is HIGH if pinned out)."]
-    SET_THE_CORRESPONDIN,
+    SET,
     #[doc = "Toggle the corresponding External Match bit/output."]
-    TOGGLE_THE_CORRESPON,
+    TOGGLE,
 }
 impl EMC2R {
     #[doc = r" Value of the field as raw bits"]
     #[inline]
     pub fn bits(&self) -> u8 {
         match *self {
-            EMC2R::DO_NOTHING_ => 0,
-            EMC2R::CLEAR_THE_CORRESPOND => 1,
-            EMC2R::SET_THE_CORRESPONDIN => 2,
-            EMC2R::TOGGLE_THE_CORRESPON => 3,
+            EMC2R::DO_NOTHING => 0,
+            EMC2R::CLEAR => 1,
+            EMC2R::SET => 2,
+            EMC2R::TOGGLE => 3,
         }
     }
     #[allow(missing_docs)]
@@ -266,55 +266,55 @@ impl EMC2R {
     #[inline]
     pub fn _from(value: u8) -> EMC2R {
         match value {
-            0 => EMC2R::DO_NOTHING_,
-            1 => EMC2R::CLEAR_THE_CORRESPOND,
-            2 => EMC2R::SET_THE_CORRESPONDIN,
-            3 => EMC2R::TOGGLE_THE_CORRESPON,
+            0 => EMC2R::DO_NOTHING,
+            1 => EMC2R::CLEAR,
+            2 => EMC2R::SET,
+            3 => EMC2R::TOGGLE,
             _ => unreachable!(),
         }
     }
-    #[doc = "Checks if the value of the field is `DO_NOTHING_`"]
+    #[doc = "Checks if the value of the field is `DO_NOTHING`"]
     #[inline]
-    pub fn is_do_nothing_(&self) -> bool {
-        *self == EMC2R::DO_NOTHING_
+    pub fn is_do_nothing(&self) -> bool {
+        *self == EMC2R::DO_NOTHING
     }
-    #[doc = "Checks if the value of the field is `CLEAR_THE_CORRESPOND`"]
+    #[doc = "Checks if the value of the field is `CLEAR`"]
     #[inline]
-    pub fn is_clear_the_correspond(&self) -> bool {
-        *self == EMC2R::CLEAR_THE_CORRESPOND
+    pub fn is_clear(&self) -> bool {
+        *self == EMC2R::CLEAR
     }
-    #[doc = "Checks if the value of the field is `SET_THE_CORRESPONDIN`"]
+    #[doc = "Checks if the value of the field is `SET`"]
     #[inline]
-    pub fn is_set_the_correspondin(&self) -> bool {
-        *self == EMC2R::SET_THE_CORRESPONDIN
+    pub fn is_set(&self) -> bool {
+        *self == EMC2R::SET
     }
-    #[doc = "Checks if the value of the field is `TOGGLE_THE_CORRESPON`"]
+    #[doc = "Checks if the value of the field is `TOGGLE`"]
     #[inline]
-    pub fn is_toggle_the_correspon(&self) -> bool {
-        *self == EMC2R::TOGGLE_THE_CORRESPON
+    pub fn is_toggle(&self) -> bool {
+        *self == EMC2R::TOGGLE
     }
 }
 #[doc = "Possible values of the field `EMC3`"]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum EMC3R {
     #[doc = "Do Nothing."]
-    DO_NOTHING_,
+    DO_NOTHING,
     #[doc = "Clear the corresponding External Match bit/output to 0 (CT16Bn_MAT3 pin is LOW if pinned out)."]
-    CLEAR_THE_CORRESPOND,
+    CLEAR,
     #[doc = "Set the corresponding External Match bit/output to 1 (CT16Bn_MAT3 pin is HIGH if pinned out)."]
-    SET_THE_CORRESPONDIN,
+    SET,
     #[doc = "Toggle the corresponding External Match bit/output."]
-    TOGGLE_THE_CORRESPON,
+    TOGGLE,
 }
 impl EMC3R {
     #[doc = r" Value of the field as raw bits"]
     #[inline]
     pub fn bits(&self) -> u8 {
         match *self {
-            EMC3R::DO_NOTHING_ => 0,
-            EMC3R::CLEAR_THE_CORRESPOND => 1,
-            EMC3R::SET_THE_CORRESPONDIN => 2,
-            EMC3R::TOGGLE_THE_CORRESPON => 3,
+            EMC3R::DO_NOTHING => 0,
+            EMC3R::CLEAR => 1,
+            EMC3R::SET => 2,
+            EMC3R::TOGGLE => 3,
         }
     }
     #[allow(missing_docs)]
@@ -322,32 +322,32 @@ impl EMC3R {
     #[inline]
     pub fn _from(value: u8) -> EMC3R {
         match value {
-            0 => EMC3R::DO_NOTHING_,
-            1 => EMC3R::CLEAR_THE_CORRESPOND,
-            2 => EMC3R::SET_THE_CORRESPONDIN,
-            3 => EMC3R::TOGGLE_THE_CORRESPON,
+            0 => EMC3R::DO_NOTHING,
+            1 => EMC3R::CLEAR,
+            2 => EMC3R::SET,
+            3 => EMC3R::TOGGLE,
             _ => unreachable!(),
         }
     }
-    #[doc = "Checks if the value of the field is `DO_NOTHING_`"]
+    #[doc = "Checks if the value of the field is `DO_NOTHING`"]
     #[inline]
-    pub fn is_do_nothing_(&self) -> bool {
-        *self == EMC3R::DO_NOTHING_
+    pub fn is_do_nothing(&self) -> bool {
+        *self == EMC3R::DO_NOTHING
     }
-    #[doc = "Checks if the value of the field is `CLEAR_THE_CORRESPOND`"]
+    #[doc = "Checks if the value of the field is `CLEAR`"]
     #[inline]
-    pub fn is_clear_the_correspond(&self) -> bool {
-        *self == EMC3R::CLEAR_THE_CORRESPOND
+    pub fn is_clear(&self) -> bool {
+        *self == EMC3R::CLEAR
     }
-    #[doc = "Checks if the value of the field is `SET_THE_CORRESPONDIN`"]
+    #[doc = "Checks if the value of the field is `SET`"]
     #[inline]
-    pub fn is_set_the_correspondin(&self) -> bool {
-        *self == EMC3R::SET_THE_CORRESPONDIN
+    pub fn is_set(&self) -> bool {
+        *self == EMC3R::SET
     }
-    #[doc = "Checks if the value of the field is `TOGGLE_THE_CORRESPON`"]
+    #[doc = "Checks if the value of the field is `TOGGLE`"]
     #[inline]
-    pub fn is_toggle_the_correspon(&self) -> bool {
-        *self == EMC3R::TOGGLE_THE_CORRESPON
+    pub fn is_toggle(&self) -> bool {
+        *self == EMC3R::TOGGLE
     }
 }
 #[doc = r" Proxy"]
@@ -445,13 +445,13 @@ impl<'a> _EM3W<'a> {
 #[doc = "Values that can be written to the field `EMC0`"]
 pub enum EMC0W {
     #[doc = "Do Nothing."]
-    DO_NOTHING_,
+    DO_NOTHING,
     #[doc = "Clear the corresponding External Match bit/output to 0 (CT16Bn_MAT0 pin is LOW if pinned out)."]
-    CLEAR_THE_CORRESPOND,
+    CLEAR,
     #[doc = "Set the corresponding External Match bit/output to 1 (CT16Bn_MAT0 pin is HIGH if pinned out)."]
-    SET_THE_CORRESPONDIN,
+    SET,
     #[doc = "Toggle the corresponding External Match bit/output."]
-    TOGGLE_THE_CORRESPON,
+    TOGGLE,
 }
 impl EMC0W {
     #[allow(missing_docs)]
@@ -459,10 +459,10 @@ impl EMC0W {
     #[inline]
     pub fn _bits(&self) -> u8 {
         match *self {
-            EMC0W::DO_NOTHING_ => 0,
-            EMC0W::CLEAR_THE_CORRESPOND => 1,
-            EMC0W::SET_THE_CORRESPONDIN => 2,
-            EMC0W::TOGGLE_THE_CORRESPON => 3,
+            EMC0W::DO_NOTHING => 0,
+            EMC0W::CLEAR => 1,
+            EMC0W::SET => 2,
+            EMC0W::TOGGLE => 3,
         }
     }
 }
@@ -480,23 +480,23 @@ impl<'a> _EMC0W<'a> {
     }
     #[doc = "Do Nothing."]
     #[inline]
-    pub fn do_nothing_(self) -> &'a mut W {
-        self.variant(EMC0W::DO_NOTHING_)
+    pub fn do_nothing(self) -> &'a mut W {
+        self.variant(EMC0W::DO_NOTHING)
     }
     #[doc = "Clear the corresponding External Match bit/output to 0 (CT16Bn_MAT0 pin is LOW if pinned out)."]
     #[inline]
-    pub fn clear_the_correspond(self) -> &'a mut W {
-        self.variant(EMC0W::CLEAR_THE_CORRESPOND)
+    pub fn clear(self) -> &'a mut W {
+        self.variant(EMC0W::CLEAR)
     }
     #[doc = "Set the corresponding External Match bit/output to 1 (CT16Bn_MAT0 pin is HIGH if pinned out)."]
     #[inline]
-    pub fn set_the_correspondin(self) -> &'a mut W {
-        self.variant(EMC0W::SET_THE_CORRESPONDIN)
+    pub fn set(self) -> &'a mut W {
+        self.variant(EMC0W::SET)
     }
     #[doc = "Toggle the corresponding External Match bit/output."]
     #[inline]
-    pub fn toggle_the_correspon(self) -> &'a mut W {
-        self.variant(EMC0W::TOGGLE_THE_CORRESPON)
+    pub fn toggle(self) -> &'a mut W {
+        self.variant(EMC0W::TOGGLE)
     }
     #[doc = r" Writes raw bits to the field"]
     #[inline]
@@ -511,13 +511,13 @@ impl<'a> _EMC0W<'a> {
 #[doc = "Values that can be written to the field `EMC1`"]
 pub enum EMC1W {
     #[doc = "Do Nothing."]
-    DO_NOTHING_,
+    DO_NOTHING,
     #[doc = "Clear the corresponding External Match bit/output to 0 (CT16Bn_MAT1 pin is LOW if pinned out)."]
-    CLEAR_THE_CORRESPOND,
+    CLEAR,
     #[doc = "Set the corresponding External Match bit/output to 1 (CT16Bn_MAT1 pin is HIGH if pinned out)."]
-    SET_THE_CORRESPONDIN,
+    SET,
     #[doc = "Toggle the corresponding External Match bit/output."]
-    TOGGLE_THE_CORRESPON,
+    TOGGLE,
 }
 impl EMC1W {
     #[allow(missing_docs)]
@@ -525,10 +525,10 @@ impl EMC1W {
     #[inline]
     pub fn _bits(&self) -> u8 {
         match *self {
-            EMC1W::DO_NOTHING_ => 0,
-            EMC1W::CLEAR_THE_CORRESPOND => 1,
-            EMC1W::SET_THE_CORRESPONDIN => 2,
-            EMC1W::TOGGLE_THE_CORRESPON => 3,
+            EMC1W::DO_NOTHING => 0,
+            EMC1W::CLEAR => 1,
+            EMC1W::SET => 2,
+            EMC1W::TOGGLE => 3,
         }
     }
 }
@@ -546,23 +546,23 @@ impl<'a> _EMC1W<'a> {
     }
     #[doc = "Do Nothing."]
     #[inline]
-    pub fn do_nothing_(self) -> &'a mut W {
-        self.variant(EMC1W::DO_NOTHING_)
+    pub fn do_nothing(self) -> &'a mut W {
+        self.variant(EMC1W::DO_NOTHING)
     }
     #[doc = "Clear the corresponding External Match bit/output to 0 (CT16Bn_MAT1 pin is LOW if pinned out)."]
     #[inline]
-    pub fn clear_the_correspond(self) -> &'a mut W {
-        self.variant(EMC1W::CLEAR_THE_CORRESPOND)
+    pub fn clear(self) -> &'a mut W {
+        self.variant(EMC1W::CLEAR)
     }
     #[doc = "Set the corresponding External Match bit/output to 1 (CT16Bn_MAT1 pin is HIGH if pinned out)."]
     #[inline]
-    pub fn set_the_correspondin(self) -> &'a mut W {
-        self.variant(EMC1W::SET_THE_CORRESPONDIN)
+    pub fn set(self) -> &'a mut W {
+        self.variant(EMC1W::SET)
     }
     #[doc = "Toggle the corresponding External Match bit/output."]
     #[inline]
-    pub fn toggle_the_correspon(self) -> &'a mut W {
-        self.variant(EMC1W::TOGGLE_THE_CORRESPON)
+    pub fn toggle(self) -> &'a mut W {
+        self.variant(EMC1W::TOGGLE)
     }
     #[doc = r" Writes raw bits to the field"]
     #[inline]
@@ -577,13 +577,13 @@ impl<'a> _EMC1W<'a> {
 #[doc = "Values that can be written to the field `EMC2`"]
 pub enum EMC2W {
     #[doc = "Do Nothing."]
-    DO_NOTHING_,
+    DO_NOTHING,
     #[doc = "Clear the corresponding External Match bit/output to 0 (CT16Bn_MAT2 pin is LOW if pinned out)."]
-    CLEAR_THE_CORRESPOND,
+    CLEAR,
     #[doc = "Set the corresponding External Match bit/output to 1 (CT16Bn_MAT2 pin is HIGH if pinned out)."]
-    SET_THE_CORRESPONDIN,
+    SET,
     #[doc = "Toggle the corresponding External Match bit/output."]
-    TOGGLE_THE_CORRESPON,
+    TOGGLE,
 }
 impl EMC2W {
     #[allow(missing_docs)]
@@ -591,10 +591,10 @@ impl EMC2W {
     #[inline]
     pub fn _bits(&self) -> u8 {
         match *self {
-            EMC2W::DO_NOTHING_ => 0,
-            EMC2W::CLEAR_THE_CORRESPOND => 1,
-            EMC2W::SET_THE_CORRESPONDIN => 2,
-            EMC2W::TOGGLE_THE_CORRESPON => 3,
+            EMC2W::DO_NOTHING => 0,
+            EMC2W::CLEAR => 1,
+            EMC2W::SET => 2,
+            EMC2W::TOGGLE => 3,
         }
     }
 }
@@ -612,23 +612,23 @@ impl<'a> _EMC2W<'a> {
     }
     #[doc = "Do Nothing."]
     #[inline]
-    pub fn do_nothing_(self) -> &'a mut W {
-        self.variant(EMC2W::DO_NOTHING_)
+    pub fn do_nothing(self) -> &'a mut W {
+        self.variant(EMC2W::DO_NOTHING)
     }
     #[doc = "Clear the corresponding External Match bit/output to 0 (CT16Bn_MAT2 pin is LOW if pinned out)."]
     #[inline]
-    pub fn clear_the_correspond(self) -> &'a mut W {
-        self.variant(EMC2W::CLEAR_THE_CORRESPOND)
+    pub fn clear(self) -> &'a mut W {
+        self.variant(EMC2W::CLEAR)
     }
     #[doc = "Set the corresponding External Match bit/output to 1 (CT16Bn_MAT2 pin is HIGH if pinned out)."]
     #[inline]
-    pub fn set_the_correspondin(self) -> &'a mut W {
-        self.variant(EMC2W::SET_THE_CORRESPONDIN)
+    pub fn set(self) -> &'a mut W {
+        self.variant(EMC2W::SET)
     }
     #[doc = "Toggle the corresponding External Match bit/output."]
     #[inline]
-    pub fn toggle_the_correspon(self) -> &'a mut W {
-        self.variant(EMC2W::TOGGLE_THE_CORRESPON)
+    pub fn toggle(self) -> &'a mut W {
+        self.variant(EMC2W::TOGGLE)
     }
     #[doc = r" Writes raw bits to the field"]
     #[inline]
@@ -643,13 +643,13 @@ impl<'a> _EMC2W<'a> {
 #[doc = "Values that can be written to the field `EMC3`"]
 pub enum EMC3W {
     #[doc = "Do Nothing."]
-    DO_NOTHING_,
+    DO_NOTHING,
     #[doc = "Clear the corresponding External Match bit/output to 0 (CT16Bn_MAT3 pin is LOW if pinned out)."]
-    CLEAR_THE_CORRESPOND,
+    CLEAR,
     #[doc = "Set the corresponding External Match bit/output to 1 (CT16Bn_MAT3 pin is HIGH if pinned out)."]
-    SET_THE_CORRESPONDIN,
+    SET,
     #[doc = "Toggle the corresponding External Match bit/output."]
-    TOGGLE_THE_CORRESPON,
+    TOGGLE,
 }
 impl EMC3W {
     #[allow(missing_docs)]
@@ -657,10 +657,10 @@ impl EMC3W {
     #[inline]
     pub fn _bits(&self) -> u8 {
         match *self {
-            EMC3W::DO_NOTHING_ => 0,
-            EMC3W::CLEAR_THE_CORRESPOND => 1,
-            EMC3W::SET_THE_CORRESPONDIN => 2,
-            EMC3W::TOGGLE_THE_CORRESPON => 3,
+            EMC3W::DO_NOTHING => 0,
+            EMC3W::CLEAR => 1,
+            EMC3W::SET => 2,
+            EMC3W::TOGGLE => 3,
         }
     }
 }
@@ -678,23 +678,23 @@ impl<'a> _EMC3W<'a> {
     }
     #[doc = "Do Nothing."]
     #[inline]
-    pub fn do_nothing_(self) -> &'a mut W {
-        self.variant(EMC3W::DO_NOTHING_)
+    pub fn do_nothing(self) -> &'a mut W {
+        self.variant(EMC3W::DO_NOTHING)
     }
     #[doc = "Clear the corresponding External Match bit/output to 0 (CT16Bn_MAT3 pin is LOW if pinned out)."]
     #[inline]
-    pub fn clear_the_correspond(self) -> &'a mut W {
-        self.variant(EMC3W::CLEAR_THE_CORRESPOND)
+    pub fn clear(self) -> &'a mut W {
+        self.variant(EMC3W::CLEAR)
     }
     #[doc = "Set the corresponding External Match bit/output to 1 (CT16Bn_MAT3 pin is HIGH if pinned out)."]
     #[inline]
-    pub fn set_the_correspondin(self) -> &'a mut W {
-        self.variant(EMC3W::SET_THE_CORRESPONDIN)
+    pub fn set(self) -> &'a mut W {
+        self.variant(EMC3W::SET)
     }
     #[doc = "Toggle the corresponding External Match bit/output."]
     #[inline]
-    pub fn toggle_the_correspon(self) -> &'a mut W {
-        self.variant(EMC3W::TOGGLE_THE_CORRESPON)
+    pub fn toggle(self) -> &'a mut W {
+        self.variant(EMC3W::TOGGLE)
     }
     #[doc = r" Writes raw bits to the field"]
     #[inline]

--- a/lpc11uxx/src/ct16b0/pwmc.rs
+++ b/lpc11uxx/src/ct16b0/pwmc.rs
@@ -46,9 +46,9 @@ impl super::PWMC {
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum PWMEN0R {
     #[doc = "CT16Bn_MAT0 is controlled by EM0."]
-    CT16BN_MAT0_IS_CONTR,
+    EM0,
     #[doc = "PWM mode is enabled for CT16Bn_MAT0."]
-    PWM_MODE_IS_ENABLED_,
+    ENABLED,
 }
 impl PWMEN0R {
     #[doc = r" Returns `true` if the bit is clear (0)"]
@@ -65,8 +65,8 @@ impl PWMEN0R {
     #[inline]
     pub fn bit(&self) -> bool {
         match *self {
-            PWMEN0R::CT16BN_MAT0_IS_CONTR => false,
-            PWMEN0R::PWM_MODE_IS_ENABLED_ => true,
+            PWMEN0R::EM0 => false,
+            PWMEN0R::ENABLED => true,
         }
     }
     #[allow(missing_docs)]
@@ -74,28 +74,28 @@ impl PWMEN0R {
     #[inline]
     pub fn _from(value: bool) -> PWMEN0R {
         match value {
-            false => PWMEN0R::CT16BN_MAT0_IS_CONTR,
-            true => PWMEN0R::PWM_MODE_IS_ENABLED_,
+            false => PWMEN0R::EM0,
+            true => PWMEN0R::ENABLED,
         }
     }
-    #[doc = "Checks if the value of the field is `CT16BN_MAT0_IS_CONTR`"]
+    #[doc = "Checks if the value of the field is `EM0`"]
     #[inline]
-    pub fn is_ct16bn_mat0_is_contr(&self) -> bool {
-        *self == PWMEN0R::CT16BN_MAT0_IS_CONTR
+    pub fn is_em0(&self) -> bool {
+        *self == PWMEN0R::EM0
     }
-    #[doc = "Checks if the value of the field is `PWM_MODE_IS_ENABLED_`"]
+    #[doc = "Checks if the value of the field is `ENABLED`"]
     #[inline]
-    pub fn is_pwm_mode_is_enabled_(&self) -> bool {
-        *self == PWMEN0R::PWM_MODE_IS_ENABLED_
+    pub fn is_enabled(&self) -> bool {
+        *self == PWMEN0R::ENABLED
     }
 }
 #[doc = "Possible values of the field `PWMEN1`"]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum PWMEN1R {
     #[doc = "CT16Bn_MAT01 is controlled by EM1."]
-    CT16BN_MAT01_IS_CONT,
+    EM1,
     #[doc = "PWM mode is enabled for CT16Bn_MAT1."]
-    PWM_MODE_IS_ENABLED_,
+    ENABLED,
 }
 impl PWMEN1R {
     #[doc = r" Returns `true` if the bit is clear (0)"]
@@ -112,8 +112,8 @@ impl PWMEN1R {
     #[inline]
     pub fn bit(&self) -> bool {
         match *self {
-            PWMEN1R::CT16BN_MAT01_IS_CONT => false,
-            PWMEN1R::PWM_MODE_IS_ENABLED_ => true,
+            PWMEN1R::EM1 => false,
+            PWMEN1R::ENABLED => true,
         }
     }
     #[allow(missing_docs)]
@@ -121,28 +121,28 @@ impl PWMEN1R {
     #[inline]
     pub fn _from(value: bool) -> PWMEN1R {
         match value {
-            false => PWMEN1R::CT16BN_MAT01_IS_CONT,
-            true => PWMEN1R::PWM_MODE_IS_ENABLED_,
+            false => PWMEN1R::EM1,
+            true => PWMEN1R::ENABLED,
         }
     }
-    #[doc = "Checks if the value of the field is `CT16BN_MAT01_IS_CONT`"]
+    #[doc = "Checks if the value of the field is `EM1`"]
     #[inline]
-    pub fn is_ct16bn_mat01_is_cont(&self) -> bool {
-        *self == PWMEN1R::CT16BN_MAT01_IS_CONT
+    pub fn is_em1(&self) -> bool {
+        *self == PWMEN1R::EM1
     }
-    #[doc = "Checks if the value of the field is `PWM_MODE_IS_ENABLED_`"]
+    #[doc = "Checks if the value of the field is `ENABLED`"]
     #[inline]
-    pub fn is_pwm_mode_is_enabled_(&self) -> bool {
-        *self == PWMEN1R::PWM_MODE_IS_ENABLED_
+    pub fn is_enabled(&self) -> bool {
+        *self == PWMEN1R::ENABLED
     }
 }
 #[doc = "Possible values of the field `PWMEN2`"]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum PWMEN2R {
     #[doc = "CT16Bn_MAT2 is controlled by EM2."]
-    CT16BN_MAT2_IS_CONTR,
+    EM2,
     #[doc = "PWM mode is enabled for CT16Bn_MAT2."]
-    PWM_MODE_IS_ENABLED_,
+    ENABLED,
 }
 impl PWMEN2R {
     #[doc = r" Returns `true` if the bit is clear (0)"]
@@ -159,8 +159,8 @@ impl PWMEN2R {
     #[inline]
     pub fn bit(&self) -> bool {
         match *self {
-            PWMEN2R::CT16BN_MAT2_IS_CONTR => false,
-            PWMEN2R::PWM_MODE_IS_ENABLED_ => true,
+            PWMEN2R::EM2 => false,
+            PWMEN2R::ENABLED => true,
         }
     }
     #[allow(missing_docs)]
@@ -168,28 +168,28 @@ impl PWMEN2R {
     #[inline]
     pub fn _from(value: bool) -> PWMEN2R {
         match value {
-            false => PWMEN2R::CT16BN_MAT2_IS_CONTR,
-            true => PWMEN2R::PWM_MODE_IS_ENABLED_,
+            false => PWMEN2R::EM2,
+            true => PWMEN2R::ENABLED,
         }
     }
-    #[doc = "Checks if the value of the field is `CT16BN_MAT2_IS_CONTR`"]
+    #[doc = "Checks if the value of the field is `EM2`"]
     #[inline]
-    pub fn is_ct16bn_mat2_is_contr(&self) -> bool {
-        *self == PWMEN2R::CT16BN_MAT2_IS_CONTR
+    pub fn is_em2(&self) -> bool {
+        *self == PWMEN2R::EM2
     }
-    #[doc = "Checks if the value of the field is `PWM_MODE_IS_ENABLED_`"]
+    #[doc = "Checks if the value of the field is `ENABLED`"]
     #[inline]
-    pub fn is_pwm_mode_is_enabled_(&self) -> bool {
-        *self == PWMEN2R::PWM_MODE_IS_ENABLED_
+    pub fn is_enabled(&self) -> bool {
+        *self == PWMEN2R::ENABLED
     }
 }
 #[doc = "Possible values of the field `PWMEN3`"]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum PWMEN3R {
     #[doc = "CT16Bn_MAT3 is controlled by EM3."]
-    CT16BN_MAT3_IS_CONTR,
+    EM3,
     #[doc = "PWM mode is enabled for CT16Bn_MAT3."]
-    PWM_MODE_IS_ENABLED_,
+    ENABLED,
 }
 impl PWMEN3R {
     #[doc = r" Returns `true` if the bit is clear (0)"]
@@ -206,8 +206,8 @@ impl PWMEN3R {
     #[inline]
     pub fn bit(&self) -> bool {
         match *self {
-            PWMEN3R::CT16BN_MAT3_IS_CONTR => false,
-            PWMEN3R::PWM_MODE_IS_ENABLED_ => true,
+            PWMEN3R::EM3 => false,
+            PWMEN3R::ENABLED => true,
         }
     }
     #[allow(missing_docs)]
@@ -215,27 +215,27 @@ impl PWMEN3R {
     #[inline]
     pub fn _from(value: bool) -> PWMEN3R {
         match value {
-            false => PWMEN3R::CT16BN_MAT3_IS_CONTR,
-            true => PWMEN3R::PWM_MODE_IS_ENABLED_,
+            false => PWMEN3R::EM3,
+            true => PWMEN3R::ENABLED,
         }
     }
-    #[doc = "Checks if the value of the field is `CT16BN_MAT3_IS_CONTR`"]
+    #[doc = "Checks if the value of the field is `EM3`"]
     #[inline]
-    pub fn is_ct16bn_mat3_is_contr(&self) -> bool {
-        *self == PWMEN3R::CT16BN_MAT3_IS_CONTR
+    pub fn is_em3(&self) -> bool {
+        *self == PWMEN3R::EM3
     }
-    #[doc = "Checks if the value of the field is `PWM_MODE_IS_ENABLED_`"]
+    #[doc = "Checks if the value of the field is `ENABLED`"]
     #[inline]
-    pub fn is_pwm_mode_is_enabled_(&self) -> bool {
-        *self == PWMEN3R::PWM_MODE_IS_ENABLED_
+    pub fn is_enabled(&self) -> bool {
+        *self == PWMEN3R::ENABLED
     }
 }
 #[doc = "Values that can be written to the field `PWMEN0`"]
 pub enum PWMEN0W {
     #[doc = "CT16Bn_MAT0 is controlled by EM0."]
-    CT16BN_MAT0_IS_CONTR,
+    EM0,
     #[doc = "PWM mode is enabled for CT16Bn_MAT0."]
-    PWM_MODE_IS_ENABLED_,
+    ENABLED,
 }
 impl PWMEN0W {
     #[allow(missing_docs)]
@@ -243,8 +243,8 @@ impl PWMEN0W {
     #[inline]
     pub fn _bits(&self) -> bool {
         match *self {
-            PWMEN0W::CT16BN_MAT0_IS_CONTR => false,
-            PWMEN0W::PWM_MODE_IS_ENABLED_ => true,
+            PWMEN0W::EM0 => false,
+            PWMEN0W::ENABLED => true,
         }
     }
 }
@@ -262,13 +262,13 @@ impl<'a> _PWMEN0W<'a> {
     }
     #[doc = "CT16Bn_MAT0 is controlled by EM0."]
     #[inline]
-    pub fn ct16bn_mat0_is_contr(self) -> &'a mut W {
-        self.variant(PWMEN0W::CT16BN_MAT0_IS_CONTR)
+    pub fn em0(self) -> &'a mut W {
+        self.variant(PWMEN0W::EM0)
     }
     #[doc = "PWM mode is enabled for CT16Bn_MAT0."]
     #[inline]
-    pub fn pwm_mode_is_enabled_(self) -> &'a mut W {
-        self.variant(PWMEN0W::PWM_MODE_IS_ENABLED_)
+    pub fn enabled(self) -> &'a mut W {
+        self.variant(PWMEN0W::ENABLED)
     }
     #[doc = r" Sets the field bit"]
     pub fn set_bit(self) -> &'a mut W {
@@ -291,9 +291,9 @@ impl<'a> _PWMEN0W<'a> {
 #[doc = "Values that can be written to the field `PWMEN1`"]
 pub enum PWMEN1W {
     #[doc = "CT16Bn_MAT01 is controlled by EM1."]
-    CT16BN_MAT01_IS_CONT,
+    EM1,
     #[doc = "PWM mode is enabled for CT16Bn_MAT1."]
-    PWM_MODE_IS_ENABLED_,
+    ENABLED,
 }
 impl PWMEN1W {
     #[allow(missing_docs)]
@@ -301,8 +301,8 @@ impl PWMEN1W {
     #[inline]
     pub fn _bits(&self) -> bool {
         match *self {
-            PWMEN1W::CT16BN_MAT01_IS_CONT => false,
-            PWMEN1W::PWM_MODE_IS_ENABLED_ => true,
+            PWMEN1W::EM1 => false,
+            PWMEN1W::ENABLED => true,
         }
     }
 }
@@ -320,13 +320,13 @@ impl<'a> _PWMEN1W<'a> {
     }
     #[doc = "CT16Bn_MAT01 is controlled by EM1."]
     #[inline]
-    pub fn ct16bn_mat01_is_cont(self) -> &'a mut W {
-        self.variant(PWMEN1W::CT16BN_MAT01_IS_CONT)
+    pub fn em1(self) -> &'a mut W {
+        self.variant(PWMEN1W::EM1)
     }
     #[doc = "PWM mode is enabled for CT16Bn_MAT1."]
     #[inline]
-    pub fn pwm_mode_is_enabled_(self) -> &'a mut W {
-        self.variant(PWMEN1W::PWM_MODE_IS_ENABLED_)
+    pub fn enabled(self) -> &'a mut W {
+        self.variant(PWMEN1W::ENABLED)
     }
     #[doc = r" Sets the field bit"]
     pub fn set_bit(self) -> &'a mut W {
@@ -349,9 +349,9 @@ impl<'a> _PWMEN1W<'a> {
 #[doc = "Values that can be written to the field `PWMEN2`"]
 pub enum PWMEN2W {
     #[doc = "CT16Bn_MAT2 is controlled by EM2."]
-    CT16BN_MAT2_IS_CONTR,
+    EM2,
     #[doc = "PWM mode is enabled for CT16Bn_MAT2."]
-    PWM_MODE_IS_ENABLED_,
+    ENABLED,
 }
 impl PWMEN2W {
     #[allow(missing_docs)]
@@ -359,8 +359,8 @@ impl PWMEN2W {
     #[inline]
     pub fn _bits(&self) -> bool {
         match *self {
-            PWMEN2W::CT16BN_MAT2_IS_CONTR => false,
-            PWMEN2W::PWM_MODE_IS_ENABLED_ => true,
+            PWMEN2W::EM2 => false,
+            PWMEN2W::ENABLED => true,
         }
     }
 }
@@ -378,13 +378,13 @@ impl<'a> _PWMEN2W<'a> {
     }
     #[doc = "CT16Bn_MAT2 is controlled by EM2."]
     #[inline]
-    pub fn ct16bn_mat2_is_contr(self) -> &'a mut W {
-        self.variant(PWMEN2W::CT16BN_MAT2_IS_CONTR)
+    pub fn em2(self) -> &'a mut W {
+        self.variant(PWMEN2W::EM2)
     }
     #[doc = "PWM mode is enabled for CT16Bn_MAT2."]
     #[inline]
-    pub fn pwm_mode_is_enabled_(self) -> &'a mut W {
-        self.variant(PWMEN2W::PWM_MODE_IS_ENABLED_)
+    pub fn enabled(self) -> &'a mut W {
+        self.variant(PWMEN2W::ENABLED)
     }
     #[doc = r" Sets the field bit"]
     pub fn set_bit(self) -> &'a mut W {
@@ -407,9 +407,9 @@ impl<'a> _PWMEN2W<'a> {
 #[doc = "Values that can be written to the field `PWMEN3`"]
 pub enum PWMEN3W {
     #[doc = "CT16Bn_MAT3 is controlled by EM3."]
-    CT16BN_MAT3_IS_CONTR,
+    EM3,
     #[doc = "PWM mode is enabled for CT16Bn_MAT3."]
-    PWM_MODE_IS_ENABLED_,
+    ENABLED,
 }
 impl PWMEN3W {
     #[allow(missing_docs)]
@@ -417,8 +417,8 @@ impl PWMEN3W {
     #[inline]
     pub fn _bits(&self) -> bool {
         match *self {
-            PWMEN3W::CT16BN_MAT3_IS_CONTR => false,
-            PWMEN3W::PWM_MODE_IS_ENABLED_ => true,
+            PWMEN3W::EM3 => false,
+            PWMEN3W::ENABLED => true,
         }
     }
 }
@@ -436,13 +436,13 @@ impl<'a> _PWMEN3W<'a> {
     }
     #[doc = "CT16Bn_MAT3 is controlled by EM3."]
     #[inline]
-    pub fn ct16bn_mat3_is_contr(self) -> &'a mut W {
-        self.variant(PWMEN3W::CT16BN_MAT3_IS_CONTR)
+    pub fn em3(self) -> &'a mut W {
+        self.variant(PWMEN3W::EM3)
     }
     #[doc = "PWM mode is enabled for CT16Bn_MAT3."]
     #[inline]
-    pub fn pwm_mode_is_enabled_(self) -> &'a mut W {
-        self.variant(PWMEN3W::PWM_MODE_IS_ENABLED_)
+    pub fn enabled(self) -> &'a mut W {
+        self.variant(PWMEN3W::ENABLED)
     }
     #[doc = r" Sets the field bit"]
     pub fn set_bit(self) -> &'a mut W {

--- a/lpc11uxx/src/ct16b0/tcr.rs
+++ b/lpc11uxx/src/ct16b0/tcr.rs
@@ -93,9 +93,9 @@ impl CENR {
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum CRSTR {
     #[doc = "Do nothing."]
-    DO_NOTHING_,
+    DO_NOTHING,
     #[doc = "The Timer Counter and the Prescale Counter are synchronously reset on the next positive edge of PCLK. The counters remain reset until TCR\\[1\\] is returned to zero."]
-    THE_TIMER_COUNTER_AN,
+    RESET,
 }
 impl CRSTR {
     #[doc = r" Returns `true` if the bit is clear (0)"]
@@ -112,8 +112,8 @@ impl CRSTR {
     #[inline]
     pub fn bit(&self) -> bool {
         match *self {
-            CRSTR::DO_NOTHING_ => false,
-            CRSTR::THE_TIMER_COUNTER_AN => true,
+            CRSTR::DO_NOTHING => false,
+            CRSTR::RESET => true,
         }
     }
     #[allow(missing_docs)]
@@ -121,19 +121,19 @@ impl CRSTR {
     #[inline]
     pub fn _from(value: bool) -> CRSTR {
         match value {
-            false => CRSTR::DO_NOTHING_,
-            true => CRSTR::THE_TIMER_COUNTER_AN,
+            false => CRSTR::DO_NOTHING,
+            true => CRSTR::RESET,
         }
     }
-    #[doc = "Checks if the value of the field is `DO_NOTHING_`"]
+    #[doc = "Checks if the value of the field is `DO_NOTHING`"]
     #[inline]
-    pub fn is_do_nothing_(&self) -> bool {
-        *self == CRSTR::DO_NOTHING_
+    pub fn is_do_nothing(&self) -> bool {
+        *self == CRSTR::DO_NOTHING
     }
-    #[doc = "Checks if the value of the field is `THE_TIMER_COUNTER_AN`"]
+    #[doc = "Checks if the value of the field is `RESET`"]
     #[inline]
-    pub fn is_the_timer_counter_an(&self) -> bool {
-        *self == CRSTR::THE_TIMER_COUNTER_AN
+    pub fn is_reset(&self) -> bool {
+        *self == CRSTR::RESET
     }
 }
 #[doc = "Values that can be written to the field `CEN`"]
@@ -197,9 +197,9 @@ impl<'a> _CENW<'a> {
 #[doc = "Values that can be written to the field `CRST`"]
 pub enum CRSTW {
     #[doc = "Do nothing."]
-    DO_NOTHING_,
+    DO_NOTHING,
     #[doc = "The Timer Counter and the Prescale Counter are synchronously reset on the next positive edge of PCLK. The counters remain reset until TCR\\[1\\] is returned to zero."]
-    THE_TIMER_COUNTER_AN,
+    RESET,
 }
 impl CRSTW {
     #[allow(missing_docs)]
@@ -207,8 +207,8 @@ impl CRSTW {
     #[inline]
     pub fn _bits(&self) -> bool {
         match *self {
-            CRSTW::DO_NOTHING_ => false,
-            CRSTW::THE_TIMER_COUNTER_AN => true,
+            CRSTW::DO_NOTHING => false,
+            CRSTW::RESET => true,
         }
     }
 }
@@ -226,13 +226,13 @@ impl<'a> _CRSTW<'a> {
     }
     #[doc = "Do nothing."]
     #[inline]
-    pub fn do_nothing_(self) -> &'a mut W {
-        self.variant(CRSTW::DO_NOTHING_)
+    pub fn do_nothing(self) -> &'a mut W {
+        self.variant(CRSTW::DO_NOTHING)
     }
     #[doc = "The Timer Counter and the Prescale Counter are synchronously reset on the next positive edge of PCLK. The counters remain reset until TCR\\[1\\] is returned to zero."]
     #[inline]
-    pub fn the_timer_counter_an(self) -> &'a mut W {
-        self.variant(CRSTW::THE_TIMER_COUNTER_AN)
+    pub fn reset(self) -> &'a mut W {
+        self.variant(CRSTW::RESET)
     }
     #[doc = r" Sets the field bit"]
     pub fn set_bit(self) -> &'a mut W {

--- a/lpc11uxx/src/ct16b1/ccr.rs
+++ b/lpc11uxx/src/ct16b1/ccr.rs
@@ -46,9 +46,9 @@ impl super::CCR {
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum CAP0RER {
     #[doc = "Enabled."]
-    ENABLED_,
+    ENABLED,
     #[doc = "Disabled."]
-    DISABLED_,
+    DISABLED,
 }
 impl CAP0RER {
     #[doc = r" Returns `true` if the bit is clear (0)"]
@@ -65,8 +65,8 @@ impl CAP0RER {
     #[inline]
     pub fn bit(&self) -> bool {
         match *self {
-            CAP0RER::ENABLED_ => true,
-            CAP0RER::DISABLED_ => false,
+            CAP0RER::ENABLED => true,
+            CAP0RER::DISABLED => false,
         }
     }
     #[allow(missing_docs)]
@@ -74,28 +74,28 @@ impl CAP0RER {
     #[inline]
     pub fn _from(value: bool) -> CAP0RER {
         match value {
-            true => CAP0RER::ENABLED_,
-            false => CAP0RER::DISABLED_,
+            true => CAP0RER::ENABLED,
+            false => CAP0RER::DISABLED,
         }
     }
-    #[doc = "Checks if the value of the field is `ENABLED_`"]
+    #[doc = "Checks if the value of the field is `ENABLED`"]
     #[inline]
-    pub fn is_enabled_(&self) -> bool {
-        *self == CAP0RER::ENABLED_
+    pub fn is_enabled(&self) -> bool {
+        *self == CAP0RER::ENABLED
     }
-    #[doc = "Checks if the value of the field is `DISABLED_`"]
+    #[doc = "Checks if the value of the field is `DISABLED`"]
     #[inline]
-    pub fn is_disabled_(&self) -> bool {
-        *self == CAP0RER::DISABLED_
+    pub fn is_disabled(&self) -> bool {
+        *self == CAP0RER::DISABLED
     }
 }
 #[doc = "Possible values of the field `CAP0FE`"]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum CAP0FER {
     #[doc = "Enabled."]
-    ENABLED_,
+    ENABLED,
     #[doc = "Disabled."]
-    DISABLED_,
+    DISABLED,
 }
 impl CAP0FER {
     #[doc = r" Returns `true` if the bit is clear (0)"]
@@ -112,8 +112,8 @@ impl CAP0FER {
     #[inline]
     pub fn bit(&self) -> bool {
         match *self {
-            CAP0FER::ENABLED_ => true,
-            CAP0FER::DISABLED_ => false,
+            CAP0FER::ENABLED => true,
+            CAP0FER::DISABLED => false,
         }
     }
     #[allow(missing_docs)]
@@ -121,28 +121,28 @@ impl CAP0FER {
     #[inline]
     pub fn _from(value: bool) -> CAP0FER {
         match value {
-            true => CAP0FER::ENABLED_,
-            false => CAP0FER::DISABLED_,
+            true => CAP0FER::ENABLED,
+            false => CAP0FER::DISABLED,
         }
     }
-    #[doc = "Checks if the value of the field is `ENABLED_`"]
+    #[doc = "Checks if the value of the field is `ENABLED`"]
     #[inline]
-    pub fn is_enabled_(&self) -> bool {
-        *self == CAP0FER::ENABLED_
+    pub fn is_enabled(&self) -> bool {
+        *self == CAP0FER::ENABLED
     }
-    #[doc = "Checks if the value of the field is `DISABLED_`"]
+    #[doc = "Checks if the value of the field is `DISABLED`"]
     #[inline]
-    pub fn is_disabled_(&self) -> bool {
-        *self == CAP0FER::DISABLED_
+    pub fn is_disabled(&self) -> bool {
+        *self == CAP0FER::DISABLED
     }
 }
 #[doc = "Possible values of the field `CAP0I`"]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum CAP0IR {
     #[doc = "Enabled."]
-    ENABLED_,
+    ENABLED,
     #[doc = "Disabled."]
-    DISABLED_,
+    DISABLED,
 }
 impl CAP0IR {
     #[doc = r" Returns `true` if the bit is clear (0)"]
@@ -159,8 +159,8 @@ impl CAP0IR {
     #[inline]
     pub fn bit(&self) -> bool {
         match *self {
-            CAP0IR::ENABLED_ => true,
-            CAP0IR::DISABLED_ => false,
+            CAP0IR::ENABLED => true,
+            CAP0IR::DISABLED => false,
         }
     }
     #[allow(missing_docs)]
@@ -168,28 +168,28 @@ impl CAP0IR {
     #[inline]
     pub fn _from(value: bool) -> CAP0IR {
         match value {
-            true => CAP0IR::ENABLED_,
-            false => CAP0IR::DISABLED_,
+            true => CAP0IR::ENABLED,
+            false => CAP0IR::DISABLED,
         }
     }
-    #[doc = "Checks if the value of the field is `ENABLED_`"]
+    #[doc = "Checks if the value of the field is `ENABLED`"]
     #[inline]
-    pub fn is_enabled_(&self) -> bool {
-        *self == CAP0IR::ENABLED_
+    pub fn is_enabled(&self) -> bool {
+        *self == CAP0IR::ENABLED
     }
-    #[doc = "Checks if the value of the field is `DISABLED_`"]
+    #[doc = "Checks if the value of the field is `DISABLED`"]
     #[inline]
-    pub fn is_disabled_(&self) -> bool {
-        *self == CAP0IR::DISABLED_
+    pub fn is_disabled(&self) -> bool {
+        *self == CAP0IR::DISABLED
     }
 }
 #[doc = "Possible values of the field `CAP1RE`"]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum CAP1RER {
     #[doc = "Enabled."]
-    ENABLED_,
+    ENABLED,
     #[doc = "Disabled."]
-    DISABLED_,
+    DISABLED,
 }
 impl CAP1RER {
     #[doc = r" Returns `true` if the bit is clear (0)"]
@@ -206,8 +206,8 @@ impl CAP1RER {
     #[inline]
     pub fn bit(&self) -> bool {
         match *self {
-            CAP1RER::ENABLED_ => true,
-            CAP1RER::DISABLED_ => false,
+            CAP1RER::ENABLED => true,
+            CAP1RER::DISABLED => false,
         }
     }
     #[allow(missing_docs)]
@@ -215,28 +215,28 @@ impl CAP1RER {
     #[inline]
     pub fn _from(value: bool) -> CAP1RER {
         match value {
-            true => CAP1RER::ENABLED_,
-            false => CAP1RER::DISABLED_,
+            true => CAP1RER::ENABLED,
+            false => CAP1RER::DISABLED,
         }
     }
-    #[doc = "Checks if the value of the field is `ENABLED_`"]
+    #[doc = "Checks if the value of the field is `ENABLED`"]
     #[inline]
-    pub fn is_enabled_(&self) -> bool {
-        *self == CAP1RER::ENABLED_
+    pub fn is_enabled(&self) -> bool {
+        *self == CAP1RER::ENABLED
     }
-    #[doc = "Checks if the value of the field is `DISABLED_`"]
+    #[doc = "Checks if the value of the field is `DISABLED`"]
     #[inline]
-    pub fn is_disabled_(&self) -> bool {
-        *self == CAP1RER::DISABLED_
+    pub fn is_disabled(&self) -> bool {
+        *self == CAP1RER::DISABLED
     }
 }
 #[doc = "Possible values of the field `CAP1FE`"]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum CAP1FER {
     #[doc = "Enabled."]
-    ENABLED_,
+    ENABLED,
     #[doc = "Disabled."]
-    DISABLED_,
+    DISABLED,
 }
 impl CAP1FER {
     #[doc = r" Returns `true` if the bit is clear (0)"]
@@ -253,8 +253,8 @@ impl CAP1FER {
     #[inline]
     pub fn bit(&self) -> bool {
         match *self {
-            CAP1FER::ENABLED_ => true,
-            CAP1FER::DISABLED_ => false,
+            CAP1FER::ENABLED => true,
+            CAP1FER::DISABLED => false,
         }
     }
     #[allow(missing_docs)]
@@ -262,28 +262,28 @@ impl CAP1FER {
     #[inline]
     pub fn _from(value: bool) -> CAP1FER {
         match value {
-            true => CAP1FER::ENABLED_,
-            false => CAP1FER::DISABLED_,
+            true => CAP1FER::ENABLED,
+            false => CAP1FER::DISABLED,
         }
     }
-    #[doc = "Checks if the value of the field is `ENABLED_`"]
+    #[doc = "Checks if the value of the field is `ENABLED`"]
     #[inline]
-    pub fn is_enabled_(&self) -> bool {
-        *self == CAP1FER::ENABLED_
+    pub fn is_enabled(&self) -> bool {
+        *self == CAP1FER::ENABLED
     }
-    #[doc = "Checks if the value of the field is `DISABLED_`"]
+    #[doc = "Checks if the value of the field is `DISABLED`"]
     #[inline]
-    pub fn is_disabled_(&self) -> bool {
-        *self == CAP1FER::DISABLED_
+    pub fn is_disabled(&self) -> bool {
+        *self == CAP1FER::DISABLED
     }
 }
 #[doc = "Possible values of the field `CAP1I`"]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum CAP1IR {
     #[doc = "Enabled."]
-    ENABLED_,
+    ENABLED,
     #[doc = "Disabled."]
-    DISABLED_,
+    DISABLED,
 }
 impl CAP1IR {
     #[doc = r" Returns `true` if the bit is clear (0)"]
@@ -300,8 +300,8 @@ impl CAP1IR {
     #[inline]
     pub fn bit(&self) -> bool {
         match *self {
-            CAP1IR::ENABLED_ => true,
-            CAP1IR::DISABLED_ => false,
+            CAP1IR::ENABLED => true,
+            CAP1IR::DISABLED => false,
         }
     }
     #[allow(missing_docs)]
@@ -309,27 +309,27 @@ impl CAP1IR {
     #[inline]
     pub fn _from(value: bool) -> CAP1IR {
         match value {
-            true => CAP1IR::ENABLED_,
-            false => CAP1IR::DISABLED_,
+            true => CAP1IR::ENABLED,
+            false => CAP1IR::DISABLED,
         }
     }
-    #[doc = "Checks if the value of the field is `ENABLED_`"]
+    #[doc = "Checks if the value of the field is `ENABLED`"]
     #[inline]
-    pub fn is_enabled_(&self) -> bool {
-        *self == CAP1IR::ENABLED_
+    pub fn is_enabled(&self) -> bool {
+        *self == CAP1IR::ENABLED
     }
-    #[doc = "Checks if the value of the field is `DISABLED_`"]
+    #[doc = "Checks if the value of the field is `DISABLED`"]
     #[inline]
-    pub fn is_disabled_(&self) -> bool {
-        *self == CAP1IR::DISABLED_
+    pub fn is_disabled(&self) -> bool {
+        *self == CAP1IR::DISABLED
     }
 }
 #[doc = "Values that can be written to the field `CAP0RE`"]
 pub enum CAP0REW {
     #[doc = "Enabled."]
-    ENABLED_,
+    ENABLED,
     #[doc = "Disabled."]
-    DISABLED_,
+    DISABLED,
 }
 impl CAP0REW {
     #[allow(missing_docs)]
@@ -337,8 +337,8 @@ impl CAP0REW {
     #[inline]
     pub fn _bits(&self) -> bool {
         match *self {
-            CAP0REW::ENABLED_ => true,
-            CAP0REW::DISABLED_ => false,
+            CAP0REW::ENABLED => true,
+            CAP0REW::DISABLED => false,
         }
     }
 }
@@ -356,13 +356,13 @@ impl<'a> _CAP0REW<'a> {
     }
     #[doc = "Enabled."]
     #[inline]
-    pub fn enabled_(self) -> &'a mut W {
-        self.variant(CAP0REW::ENABLED_)
+    pub fn enabled(self) -> &'a mut W {
+        self.variant(CAP0REW::ENABLED)
     }
     #[doc = "Disabled."]
     #[inline]
-    pub fn disabled_(self) -> &'a mut W {
-        self.variant(CAP0REW::DISABLED_)
+    pub fn disabled(self) -> &'a mut W {
+        self.variant(CAP0REW::DISABLED)
     }
     #[doc = r" Sets the field bit"]
     pub fn set_bit(self) -> &'a mut W {
@@ -385,9 +385,9 @@ impl<'a> _CAP0REW<'a> {
 #[doc = "Values that can be written to the field `CAP0FE`"]
 pub enum CAP0FEW {
     #[doc = "Enabled."]
-    ENABLED_,
+    ENABLED,
     #[doc = "Disabled."]
-    DISABLED_,
+    DISABLED,
 }
 impl CAP0FEW {
     #[allow(missing_docs)]
@@ -395,8 +395,8 @@ impl CAP0FEW {
     #[inline]
     pub fn _bits(&self) -> bool {
         match *self {
-            CAP0FEW::ENABLED_ => true,
-            CAP0FEW::DISABLED_ => false,
+            CAP0FEW::ENABLED => true,
+            CAP0FEW::DISABLED => false,
         }
     }
 }
@@ -414,13 +414,13 @@ impl<'a> _CAP0FEW<'a> {
     }
     #[doc = "Enabled."]
     #[inline]
-    pub fn enabled_(self) -> &'a mut W {
-        self.variant(CAP0FEW::ENABLED_)
+    pub fn enabled(self) -> &'a mut W {
+        self.variant(CAP0FEW::ENABLED)
     }
     #[doc = "Disabled."]
     #[inline]
-    pub fn disabled_(self) -> &'a mut W {
-        self.variant(CAP0FEW::DISABLED_)
+    pub fn disabled(self) -> &'a mut W {
+        self.variant(CAP0FEW::DISABLED)
     }
     #[doc = r" Sets the field bit"]
     pub fn set_bit(self) -> &'a mut W {
@@ -443,9 +443,9 @@ impl<'a> _CAP0FEW<'a> {
 #[doc = "Values that can be written to the field `CAP0I`"]
 pub enum CAP0IW {
     #[doc = "Enabled."]
-    ENABLED_,
+    ENABLED,
     #[doc = "Disabled."]
-    DISABLED_,
+    DISABLED,
 }
 impl CAP0IW {
     #[allow(missing_docs)]
@@ -453,8 +453,8 @@ impl CAP0IW {
     #[inline]
     pub fn _bits(&self) -> bool {
         match *self {
-            CAP0IW::ENABLED_ => true,
-            CAP0IW::DISABLED_ => false,
+            CAP0IW::ENABLED => true,
+            CAP0IW::DISABLED => false,
         }
     }
 }
@@ -472,13 +472,13 @@ impl<'a> _CAP0IW<'a> {
     }
     #[doc = "Enabled."]
     #[inline]
-    pub fn enabled_(self) -> &'a mut W {
-        self.variant(CAP0IW::ENABLED_)
+    pub fn enabled(self) -> &'a mut W {
+        self.variant(CAP0IW::ENABLED)
     }
     #[doc = "Disabled."]
     #[inline]
-    pub fn disabled_(self) -> &'a mut W {
-        self.variant(CAP0IW::DISABLED_)
+    pub fn disabled(self) -> &'a mut W {
+        self.variant(CAP0IW::DISABLED)
     }
     #[doc = r" Sets the field bit"]
     pub fn set_bit(self) -> &'a mut W {
@@ -501,9 +501,9 @@ impl<'a> _CAP0IW<'a> {
 #[doc = "Values that can be written to the field `CAP1RE`"]
 pub enum CAP1REW {
     #[doc = "Enabled."]
-    ENABLED_,
+    ENABLED,
     #[doc = "Disabled."]
-    DISABLED_,
+    DISABLED,
 }
 impl CAP1REW {
     #[allow(missing_docs)]
@@ -511,8 +511,8 @@ impl CAP1REW {
     #[inline]
     pub fn _bits(&self) -> bool {
         match *self {
-            CAP1REW::ENABLED_ => true,
-            CAP1REW::DISABLED_ => false,
+            CAP1REW::ENABLED => true,
+            CAP1REW::DISABLED => false,
         }
     }
 }
@@ -530,13 +530,13 @@ impl<'a> _CAP1REW<'a> {
     }
     #[doc = "Enabled."]
     #[inline]
-    pub fn enabled_(self) -> &'a mut W {
-        self.variant(CAP1REW::ENABLED_)
+    pub fn enabled(self) -> &'a mut W {
+        self.variant(CAP1REW::ENABLED)
     }
     #[doc = "Disabled."]
     #[inline]
-    pub fn disabled_(self) -> &'a mut W {
-        self.variant(CAP1REW::DISABLED_)
+    pub fn disabled(self) -> &'a mut W {
+        self.variant(CAP1REW::DISABLED)
     }
     #[doc = r" Sets the field bit"]
     pub fn set_bit(self) -> &'a mut W {
@@ -559,9 +559,9 @@ impl<'a> _CAP1REW<'a> {
 #[doc = "Values that can be written to the field `CAP1FE`"]
 pub enum CAP1FEW {
     #[doc = "Enabled."]
-    ENABLED_,
+    ENABLED,
     #[doc = "Disabled."]
-    DISABLED_,
+    DISABLED,
 }
 impl CAP1FEW {
     #[allow(missing_docs)]
@@ -569,8 +569,8 @@ impl CAP1FEW {
     #[inline]
     pub fn _bits(&self) -> bool {
         match *self {
-            CAP1FEW::ENABLED_ => true,
-            CAP1FEW::DISABLED_ => false,
+            CAP1FEW::ENABLED => true,
+            CAP1FEW::DISABLED => false,
         }
     }
 }
@@ -588,13 +588,13 @@ impl<'a> _CAP1FEW<'a> {
     }
     #[doc = "Enabled."]
     #[inline]
-    pub fn enabled_(self) -> &'a mut W {
-        self.variant(CAP1FEW::ENABLED_)
+    pub fn enabled(self) -> &'a mut W {
+        self.variant(CAP1FEW::ENABLED)
     }
     #[doc = "Disabled."]
     #[inline]
-    pub fn disabled_(self) -> &'a mut W {
-        self.variant(CAP1FEW::DISABLED_)
+    pub fn disabled(self) -> &'a mut W {
+        self.variant(CAP1FEW::DISABLED)
     }
     #[doc = r" Sets the field bit"]
     pub fn set_bit(self) -> &'a mut W {
@@ -617,9 +617,9 @@ impl<'a> _CAP1FEW<'a> {
 #[doc = "Values that can be written to the field `CAP1I`"]
 pub enum CAP1IW {
     #[doc = "Enabled."]
-    ENABLED_,
+    ENABLED,
     #[doc = "Disabled."]
-    DISABLED_,
+    DISABLED,
 }
 impl CAP1IW {
     #[allow(missing_docs)]
@@ -627,8 +627,8 @@ impl CAP1IW {
     #[inline]
     pub fn _bits(&self) -> bool {
         match *self {
-            CAP1IW::ENABLED_ => true,
-            CAP1IW::DISABLED_ => false,
+            CAP1IW::ENABLED => true,
+            CAP1IW::DISABLED => false,
         }
     }
 }
@@ -646,13 +646,13 @@ impl<'a> _CAP1IW<'a> {
     }
     #[doc = "Enabled."]
     #[inline]
-    pub fn enabled_(self) -> &'a mut W {
-        self.variant(CAP1IW::ENABLED_)
+    pub fn enabled(self) -> &'a mut W {
+        self.variant(CAP1IW::ENABLED)
     }
     #[doc = "Disabled."]
     #[inline]
-    pub fn disabled_(self) -> &'a mut W {
-        self.variant(CAP1IW::DISABLED_)
+    pub fn disabled(self) -> &'a mut W {
+        self.variant(CAP1IW::DISABLED)
     }
     #[doc = r" Sets the field bit"]
     pub fn set_bit(self) -> &'a mut W {

--- a/lpc11uxx/src/ct16b1/ctcr.rs
+++ b/lpc11uxx/src/ct16b1/ctcr.rs
@@ -48,11 +48,11 @@ pub enum CTMR {
     #[doc = "Timer Mode: every rising PCLK edge"]
     TIMER_MODE_EVERY_RI,
     #[doc = "Counter Mode: TC is incremented on rising edges on the CAP input selected by bits 3:2."]
-    COUNTER_MODE_TC_IS_RISING,
+    RISING,
     #[doc = "Counter Mode: TC is incremented on falling edges on the CAP input selected by bits 3:2."]
-    COUNTER_MODE_TC_IS_FALLING,
+    FALLING,
     #[doc = "Counter Mode: TC is incremented on both edges on the CAP input selected by bits 3:2."]
-    COUNTER_MODE_TC_IS_BOTH,
+    BOTH,
 }
 impl CTMR {
     #[doc = r" Value of the field as raw bits"]
@@ -60,9 +60,9 @@ impl CTMR {
     pub fn bits(&self) -> u8 {
         match *self {
             CTMR::TIMER_MODE_EVERY_RI => 0,
-            CTMR::COUNTER_MODE_TC_IS_RISING => 1,
-            CTMR::COUNTER_MODE_TC_IS_FALLING => 2,
-            CTMR::COUNTER_MODE_TC_IS_BOTH => 3,
+            CTMR::RISING => 1,
+            CTMR::FALLING => 2,
+            CTMR::BOTH => 3,
         }
     }
     #[allow(missing_docs)]
@@ -71,9 +71,9 @@ impl CTMR {
     pub fn _from(value: u8) -> CTMR {
         match value {
             0 => CTMR::TIMER_MODE_EVERY_RI,
-            1 => CTMR::COUNTER_MODE_TC_IS_RISING,
-            2 => CTMR::COUNTER_MODE_TC_IS_FALLING,
-            3 => CTMR::COUNTER_MODE_TC_IS_BOTH,
+            1 => CTMR::RISING,
+            2 => CTMR::FALLING,
+            3 => CTMR::BOTH,
             _ => unreachable!(),
         }
     }
@@ -82,29 +82,29 @@ impl CTMR {
     pub fn is_timer_mode_every_ri(&self) -> bool {
         *self == CTMR::TIMER_MODE_EVERY_RI
     }
-    #[doc = "Checks if the value of the field is `COUNTER_MODE_TC_IS_RISING`"]
+    #[doc = "Checks if the value of the field is `RISING`"]
     #[inline]
-    pub fn is_counter_mode_tc_is_rising(&self) -> bool {
-        *self == CTMR::COUNTER_MODE_TC_IS_RISING
+    pub fn is_rising(&self) -> bool {
+        *self == CTMR::RISING
     }
-    #[doc = "Checks if the value of the field is `COUNTER_MODE_TC_IS_FALLING`"]
+    #[doc = "Checks if the value of the field is `FALLING`"]
     #[inline]
-    pub fn is_counter_mode_tc_is_falling(&self) -> bool {
-        *self == CTMR::COUNTER_MODE_TC_IS_FALLING
+    pub fn is_falling(&self) -> bool {
+        *self == CTMR::FALLING
     }
-    #[doc = "Checks if the value of the field is `COUNTER_MODE_TC_IS_BOTH`"]
+    #[doc = "Checks if the value of the field is `BOTH`"]
     #[inline]
-    pub fn is_counter_mode_tc_is_both(&self) -> bool {
-        *self == CTMR::COUNTER_MODE_TC_IS_BOTH
+    pub fn is_both(&self) -> bool {
+        *self == CTMR::BOTH
     }
 }
 #[doc = "Possible values of the field `CIS`"]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum CISR {
     #[doc = "CT16B1_CAP0."]
-    CT16B1_CAP0_,
+    CT16B1_CAP0,
     #[doc = "CT16B1_CAP1."]
-    CT16B1_CAP1_,
+    CT16B1_CAP1,
     #[doc = r" Reserved"]
     _Reserved(u8),
 }
@@ -113,8 +113,8 @@ impl CISR {
     #[inline]
     pub fn bits(&self) -> u8 {
         match *self {
-            CISR::CT16B1_CAP0_ => 0,
-            CISR::CT16B1_CAP1_ => 1,
+            CISR::CT16B1_CAP0 => 0,
+            CISR::CT16B1_CAP1 => 1,
             CISR::_Reserved(bits) => bits,
         }
     }
@@ -123,20 +123,20 @@ impl CISR {
     #[inline]
     pub fn _from(value: u8) -> CISR {
         match value {
-            0 => CISR::CT16B1_CAP0_,
-            1 => CISR::CT16B1_CAP1_,
+            0 => CISR::CT16B1_CAP0,
+            1 => CISR::CT16B1_CAP1,
             i => CISR::_Reserved(i),
         }
     }
-    #[doc = "Checks if the value of the field is `CT16B1_CAP0_`"]
+    #[doc = "Checks if the value of the field is `CT16B1_CAP0`"]
     #[inline]
-    pub fn is_ct16b1_cap0_(&self) -> bool {
-        *self == CISR::CT16B1_CAP0_
+    pub fn is_ct16b1_cap0(&self) -> bool {
+        *self == CISR::CT16B1_CAP0
     }
-    #[doc = "Checks if the value of the field is `CT16B1_CAP1_`"]
+    #[doc = "Checks if the value of the field is `CT16B1_CAP1`"]
     #[inline]
-    pub fn is_ct16b1_cap1_(&self) -> bool {
-        *self == CISR::CT16B1_CAP1_
+    pub fn is_ct16b1_cap1(&self) -> bool {
+        *self == CISR::CT16B1_CAP1
     }
 }
 #[doc = r" Value of the field"]
@@ -242,11 +242,11 @@ pub enum CTMW {
     #[doc = "Timer Mode: every rising PCLK edge"]
     TIMER_MODE_EVERY_RI,
     #[doc = "Counter Mode: TC is incremented on rising edges on the CAP input selected by bits 3:2."]
-    COUNTER_MODE_TC_IS_RISING,
+    RISING,
     #[doc = "Counter Mode: TC is incremented on falling edges on the CAP input selected by bits 3:2."]
-    COUNTER_MODE_TC_IS_FALLING,
+    FALLING,
     #[doc = "Counter Mode: TC is incremented on both edges on the CAP input selected by bits 3:2."]
-    COUNTER_MODE_TC_IS_BOTH,
+    BOTH,
 }
 impl CTMW {
     #[allow(missing_docs)]
@@ -255,9 +255,9 @@ impl CTMW {
     pub fn _bits(&self) -> u8 {
         match *self {
             CTMW::TIMER_MODE_EVERY_RI => 0,
-            CTMW::COUNTER_MODE_TC_IS_RISING => 1,
-            CTMW::COUNTER_MODE_TC_IS_FALLING => 2,
-            CTMW::COUNTER_MODE_TC_IS_BOTH => 3,
+            CTMW::RISING => 1,
+            CTMW::FALLING => 2,
+            CTMW::BOTH => 3,
         }
     }
 }
@@ -280,18 +280,18 @@ impl<'a> _CTMW<'a> {
     }
     #[doc = "Counter Mode: TC is incremented on rising edges on the CAP input selected by bits 3:2."]
     #[inline]
-    pub fn counter_mode_tc_is_rising(self) -> &'a mut W {
-        self.variant(CTMW::COUNTER_MODE_TC_IS_RISING)
+    pub fn rising(self) -> &'a mut W {
+        self.variant(CTMW::RISING)
     }
     #[doc = "Counter Mode: TC is incremented on falling edges on the CAP input selected by bits 3:2."]
     #[inline]
-    pub fn counter_mode_tc_is_falling(self) -> &'a mut W {
-        self.variant(CTMW::COUNTER_MODE_TC_IS_FALLING)
+    pub fn falling(self) -> &'a mut W {
+        self.variant(CTMW::FALLING)
     }
     #[doc = "Counter Mode: TC is incremented on both edges on the CAP input selected by bits 3:2."]
     #[inline]
-    pub fn counter_mode_tc_is_both(self) -> &'a mut W {
-        self.variant(CTMW::COUNTER_MODE_TC_IS_BOTH)
+    pub fn both(self) -> &'a mut W {
+        self.variant(CTMW::BOTH)
     }
     #[doc = r" Writes raw bits to the field"]
     #[inline]
@@ -306,9 +306,9 @@ impl<'a> _CTMW<'a> {
 #[doc = "Values that can be written to the field `CIS`"]
 pub enum CISW {
     #[doc = "CT16B1_CAP0."]
-    CT16B1_CAP0_,
+    CT16B1_CAP0,
     #[doc = "CT16B1_CAP1."]
-    CT16B1_CAP1_,
+    CT16B1_CAP1,
 }
 impl CISW {
     #[allow(missing_docs)]
@@ -316,8 +316,8 @@ impl CISW {
     #[inline]
     pub fn _bits(&self) -> u8 {
         match *self {
-            CISW::CT16B1_CAP0_ => 0,
-            CISW::CT16B1_CAP1_ => 1,
+            CISW::CT16B1_CAP0 => 0,
+            CISW::CT16B1_CAP1 => 1,
         }
     }
 }
@@ -333,13 +333,13 @@ impl<'a> _CISW<'a> {
     }
     #[doc = "CT16B1_CAP0."]
     #[inline]
-    pub fn ct16b1_cap0_(self) -> &'a mut W {
-        self.variant(CISW::CT16B1_CAP0_)
+    pub fn ct16b1_cap0(self) -> &'a mut W {
+        self.variant(CISW::CT16B1_CAP0)
     }
     #[doc = "CT16B1_CAP1."]
     #[inline]
-    pub fn ct16b1_cap1_(self) -> &'a mut W {
-        self.variant(CISW::CT16B1_CAP1_)
+    pub fn ct16b1_cap1(self) -> &'a mut W {
+        self.variant(CISW::CT16B1_CAP1)
     }
     #[doc = r" Writes raw bits to the field"]
     #[inline]

--- a/lpc11uxx/src/ct16b1/emr.rs
+++ b/lpc11uxx/src/ct16b1/emr.rs
@@ -130,23 +130,23 @@ impl EM3R {
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum EMC0R {
     #[doc = "Do Nothing."]
-    DO_NOTHING_,
+    DO_NOTHING,
     #[doc = "Clear the corresponding External Match bit/output to 0 (CT16Bn_MAT0 pin is LOW if pinned out)."]
-    CLEAR_THE_CORRESPOND,
+    CLEAR,
     #[doc = "Set the corresponding External Match bit/output to 1 (CT16Bn_MAT0 pin is HIGH if pinned out)."]
-    SET_THE_CORRESPONDIN,
+    SET,
     #[doc = "Toggle the corresponding External Match bit/output."]
-    TOGGLE_THE_CORRESPON,
+    TOGGLE,
 }
 impl EMC0R {
     #[doc = r" Value of the field as raw bits"]
     #[inline]
     pub fn bits(&self) -> u8 {
         match *self {
-            EMC0R::DO_NOTHING_ => 0,
-            EMC0R::CLEAR_THE_CORRESPOND => 1,
-            EMC0R::SET_THE_CORRESPONDIN => 2,
-            EMC0R::TOGGLE_THE_CORRESPON => 3,
+            EMC0R::DO_NOTHING => 0,
+            EMC0R::CLEAR => 1,
+            EMC0R::SET => 2,
+            EMC0R::TOGGLE => 3,
         }
     }
     #[allow(missing_docs)]
@@ -154,55 +154,55 @@ impl EMC0R {
     #[inline]
     pub fn _from(value: u8) -> EMC0R {
         match value {
-            0 => EMC0R::DO_NOTHING_,
-            1 => EMC0R::CLEAR_THE_CORRESPOND,
-            2 => EMC0R::SET_THE_CORRESPONDIN,
-            3 => EMC0R::TOGGLE_THE_CORRESPON,
+            0 => EMC0R::DO_NOTHING,
+            1 => EMC0R::CLEAR,
+            2 => EMC0R::SET,
+            3 => EMC0R::TOGGLE,
             _ => unreachable!(),
         }
     }
-    #[doc = "Checks if the value of the field is `DO_NOTHING_`"]
+    #[doc = "Checks if the value of the field is `DO_NOTHING`"]
     #[inline]
-    pub fn is_do_nothing_(&self) -> bool {
-        *self == EMC0R::DO_NOTHING_
+    pub fn is_do_nothing(&self) -> bool {
+        *self == EMC0R::DO_NOTHING
     }
-    #[doc = "Checks if the value of the field is `CLEAR_THE_CORRESPOND`"]
+    #[doc = "Checks if the value of the field is `CLEAR`"]
     #[inline]
-    pub fn is_clear_the_correspond(&self) -> bool {
-        *self == EMC0R::CLEAR_THE_CORRESPOND
+    pub fn is_clear(&self) -> bool {
+        *self == EMC0R::CLEAR
     }
-    #[doc = "Checks if the value of the field is `SET_THE_CORRESPONDIN`"]
+    #[doc = "Checks if the value of the field is `SET`"]
     #[inline]
-    pub fn is_set_the_correspondin(&self) -> bool {
-        *self == EMC0R::SET_THE_CORRESPONDIN
+    pub fn is_set(&self) -> bool {
+        *self == EMC0R::SET
     }
-    #[doc = "Checks if the value of the field is `TOGGLE_THE_CORRESPON`"]
+    #[doc = "Checks if the value of the field is `TOGGLE`"]
     #[inline]
-    pub fn is_toggle_the_correspon(&self) -> bool {
-        *self == EMC0R::TOGGLE_THE_CORRESPON
+    pub fn is_toggle(&self) -> bool {
+        *self == EMC0R::TOGGLE
     }
 }
 #[doc = "Possible values of the field `EMC1`"]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum EMC1R {
     #[doc = "Do Nothing."]
-    DO_NOTHING_,
+    DO_NOTHING,
     #[doc = "Clear the corresponding External Match bit/output to 0 (CT16Bn_MAT1 pin is LOW if pinned out)."]
-    CLEAR_THE_CORRESPOND,
+    CLEAR,
     #[doc = "Set the corresponding External Match bit/output to 1 (CT16Bn_MAT1 pin is HIGH if pinned out)."]
-    SET_THE_CORRESPONDIN,
+    SET,
     #[doc = "Toggle the corresponding External Match bit/output."]
-    TOGGLE_THE_CORRESPON,
+    TOGGLE,
 }
 impl EMC1R {
     #[doc = r" Value of the field as raw bits"]
     #[inline]
     pub fn bits(&self) -> u8 {
         match *self {
-            EMC1R::DO_NOTHING_ => 0,
-            EMC1R::CLEAR_THE_CORRESPOND => 1,
-            EMC1R::SET_THE_CORRESPONDIN => 2,
-            EMC1R::TOGGLE_THE_CORRESPON => 3,
+            EMC1R::DO_NOTHING => 0,
+            EMC1R::CLEAR => 1,
+            EMC1R::SET => 2,
+            EMC1R::TOGGLE => 3,
         }
     }
     #[allow(missing_docs)]
@@ -210,55 +210,55 @@ impl EMC1R {
     #[inline]
     pub fn _from(value: u8) -> EMC1R {
         match value {
-            0 => EMC1R::DO_NOTHING_,
-            1 => EMC1R::CLEAR_THE_CORRESPOND,
-            2 => EMC1R::SET_THE_CORRESPONDIN,
-            3 => EMC1R::TOGGLE_THE_CORRESPON,
+            0 => EMC1R::DO_NOTHING,
+            1 => EMC1R::CLEAR,
+            2 => EMC1R::SET,
+            3 => EMC1R::TOGGLE,
             _ => unreachable!(),
         }
     }
-    #[doc = "Checks if the value of the field is `DO_NOTHING_`"]
+    #[doc = "Checks if the value of the field is `DO_NOTHING`"]
     #[inline]
-    pub fn is_do_nothing_(&self) -> bool {
-        *self == EMC1R::DO_NOTHING_
+    pub fn is_do_nothing(&self) -> bool {
+        *self == EMC1R::DO_NOTHING
     }
-    #[doc = "Checks if the value of the field is `CLEAR_THE_CORRESPOND`"]
+    #[doc = "Checks if the value of the field is `CLEAR`"]
     #[inline]
-    pub fn is_clear_the_correspond(&self) -> bool {
-        *self == EMC1R::CLEAR_THE_CORRESPOND
+    pub fn is_clear(&self) -> bool {
+        *self == EMC1R::CLEAR
     }
-    #[doc = "Checks if the value of the field is `SET_THE_CORRESPONDIN`"]
+    #[doc = "Checks if the value of the field is `SET`"]
     #[inline]
-    pub fn is_set_the_correspondin(&self) -> bool {
-        *self == EMC1R::SET_THE_CORRESPONDIN
+    pub fn is_set(&self) -> bool {
+        *self == EMC1R::SET
     }
-    #[doc = "Checks if the value of the field is `TOGGLE_THE_CORRESPON`"]
+    #[doc = "Checks if the value of the field is `TOGGLE`"]
     #[inline]
-    pub fn is_toggle_the_correspon(&self) -> bool {
-        *self == EMC1R::TOGGLE_THE_CORRESPON
+    pub fn is_toggle(&self) -> bool {
+        *self == EMC1R::TOGGLE
     }
 }
 #[doc = "Possible values of the field `EMC2`"]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum EMC2R {
     #[doc = "Do Nothing."]
-    DO_NOTHING_,
+    DO_NOTHING,
     #[doc = "Clear the corresponding External Match bit/output to 0 (CT16Bn_MAT2 pin is LOW if pinned out)."]
-    CLEAR_THE_CORRESPOND,
+    CLEAR,
     #[doc = "Set the corresponding External Match bit/output to 1 (CT16Bn_MAT2 pin is HIGH if pinned out)."]
-    SET_THE_CORRESPONDIN,
+    SET,
     #[doc = "Toggle the corresponding External Match bit/output."]
-    TOGGLE_THE_CORRESPON,
+    TOGGLE,
 }
 impl EMC2R {
     #[doc = r" Value of the field as raw bits"]
     #[inline]
     pub fn bits(&self) -> u8 {
         match *self {
-            EMC2R::DO_NOTHING_ => 0,
-            EMC2R::CLEAR_THE_CORRESPOND => 1,
-            EMC2R::SET_THE_CORRESPONDIN => 2,
-            EMC2R::TOGGLE_THE_CORRESPON => 3,
+            EMC2R::DO_NOTHING => 0,
+            EMC2R::CLEAR => 1,
+            EMC2R::SET => 2,
+            EMC2R::TOGGLE => 3,
         }
     }
     #[allow(missing_docs)]
@@ -266,55 +266,55 @@ impl EMC2R {
     #[inline]
     pub fn _from(value: u8) -> EMC2R {
         match value {
-            0 => EMC2R::DO_NOTHING_,
-            1 => EMC2R::CLEAR_THE_CORRESPOND,
-            2 => EMC2R::SET_THE_CORRESPONDIN,
-            3 => EMC2R::TOGGLE_THE_CORRESPON,
+            0 => EMC2R::DO_NOTHING,
+            1 => EMC2R::CLEAR,
+            2 => EMC2R::SET,
+            3 => EMC2R::TOGGLE,
             _ => unreachable!(),
         }
     }
-    #[doc = "Checks if the value of the field is `DO_NOTHING_`"]
+    #[doc = "Checks if the value of the field is `DO_NOTHING`"]
     #[inline]
-    pub fn is_do_nothing_(&self) -> bool {
-        *self == EMC2R::DO_NOTHING_
+    pub fn is_do_nothing(&self) -> bool {
+        *self == EMC2R::DO_NOTHING
     }
-    #[doc = "Checks if the value of the field is `CLEAR_THE_CORRESPOND`"]
+    #[doc = "Checks if the value of the field is `CLEAR`"]
     #[inline]
-    pub fn is_clear_the_correspond(&self) -> bool {
-        *self == EMC2R::CLEAR_THE_CORRESPOND
+    pub fn is_clear(&self) -> bool {
+        *self == EMC2R::CLEAR
     }
-    #[doc = "Checks if the value of the field is `SET_THE_CORRESPONDIN`"]
+    #[doc = "Checks if the value of the field is `SET`"]
     #[inline]
-    pub fn is_set_the_correspondin(&self) -> bool {
-        *self == EMC2R::SET_THE_CORRESPONDIN
+    pub fn is_set(&self) -> bool {
+        *self == EMC2R::SET
     }
-    #[doc = "Checks if the value of the field is `TOGGLE_THE_CORRESPON`"]
+    #[doc = "Checks if the value of the field is `TOGGLE`"]
     #[inline]
-    pub fn is_toggle_the_correspon(&self) -> bool {
-        *self == EMC2R::TOGGLE_THE_CORRESPON
+    pub fn is_toggle(&self) -> bool {
+        *self == EMC2R::TOGGLE
     }
 }
 #[doc = "Possible values of the field `EMC3`"]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum EMC3R {
     #[doc = "Do Nothing."]
-    DO_NOTHING_,
+    DO_NOTHING,
     #[doc = "Clear the corresponding External Match bit/output to 0 (CT16Bn_MAT3 pin is LOW if pinned out)."]
-    CLEAR_THE_CORRESPOND,
+    CLEAR,
     #[doc = "Set the corresponding External Match bit/output to 1 (CT16Bn_MAT3 pin is HIGH if pinned out)."]
-    SET_THE_CORRESPONDIN,
+    SET,
     #[doc = "Toggle the corresponding External Match bit/output."]
-    TOGGLE_THE_CORRESPON,
+    TOGGLE,
 }
 impl EMC3R {
     #[doc = r" Value of the field as raw bits"]
     #[inline]
     pub fn bits(&self) -> u8 {
         match *self {
-            EMC3R::DO_NOTHING_ => 0,
-            EMC3R::CLEAR_THE_CORRESPOND => 1,
-            EMC3R::SET_THE_CORRESPONDIN => 2,
-            EMC3R::TOGGLE_THE_CORRESPON => 3,
+            EMC3R::DO_NOTHING => 0,
+            EMC3R::CLEAR => 1,
+            EMC3R::SET => 2,
+            EMC3R::TOGGLE => 3,
         }
     }
     #[allow(missing_docs)]
@@ -322,32 +322,32 @@ impl EMC3R {
     #[inline]
     pub fn _from(value: u8) -> EMC3R {
         match value {
-            0 => EMC3R::DO_NOTHING_,
-            1 => EMC3R::CLEAR_THE_CORRESPOND,
-            2 => EMC3R::SET_THE_CORRESPONDIN,
-            3 => EMC3R::TOGGLE_THE_CORRESPON,
+            0 => EMC3R::DO_NOTHING,
+            1 => EMC3R::CLEAR,
+            2 => EMC3R::SET,
+            3 => EMC3R::TOGGLE,
             _ => unreachable!(),
         }
     }
-    #[doc = "Checks if the value of the field is `DO_NOTHING_`"]
+    #[doc = "Checks if the value of the field is `DO_NOTHING`"]
     #[inline]
-    pub fn is_do_nothing_(&self) -> bool {
-        *self == EMC3R::DO_NOTHING_
+    pub fn is_do_nothing(&self) -> bool {
+        *self == EMC3R::DO_NOTHING
     }
-    #[doc = "Checks if the value of the field is `CLEAR_THE_CORRESPOND`"]
+    #[doc = "Checks if the value of the field is `CLEAR`"]
     #[inline]
-    pub fn is_clear_the_correspond(&self) -> bool {
-        *self == EMC3R::CLEAR_THE_CORRESPOND
+    pub fn is_clear(&self) -> bool {
+        *self == EMC3R::CLEAR
     }
-    #[doc = "Checks if the value of the field is `SET_THE_CORRESPONDIN`"]
+    #[doc = "Checks if the value of the field is `SET`"]
     #[inline]
-    pub fn is_set_the_correspondin(&self) -> bool {
-        *self == EMC3R::SET_THE_CORRESPONDIN
+    pub fn is_set(&self) -> bool {
+        *self == EMC3R::SET
     }
-    #[doc = "Checks if the value of the field is `TOGGLE_THE_CORRESPON`"]
+    #[doc = "Checks if the value of the field is `TOGGLE`"]
     #[inline]
-    pub fn is_toggle_the_correspon(&self) -> bool {
-        *self == EMC3R::TOGGLE_THE_CORRESPON
+    pub fn is_toggle(&self) -> bool {
+        *self == EMC3R::TOGGLE
     }
 }
 #[doc = r" Proxy"]
@@ -445,13 +445,13 @@ impl<'a> _EM3W<'a> {
 #[doc = "Values that can be written to the field `EMC0`"]
 pub enum EMC0W {
     #[doc = "Do Nothing."]
-    DO_NOTHING_,
+    DO_NOTHING,
     #[doc = "Clear the corresponding External Match bit/output to 0 (CT16Bn_MAT0 pin is LOW if pinned out)."]
-    CLEAR_THE_CORRESPOND,
+    CLEAR,
     #[doc = "Set the corresponding External Match bit/output to 1 (CT16Bn_MAT0 pin is HIGH if pinned out)."]
-    SET_THE_CORRESPONDIN,
+    SET,
     #[doc = "Toggle the corresponding External Match bit/output."]
-    TOGGLE_THE_CORRESPON,
+    TOGGLE,
 }
 impl EMC0W {
     #[allow(missing_docs)]
@@ -459,10 +459,10 @@ impl EMC0W {
     #[inline]
     pub fn _bits(&self) -> u8 {
         match *self {
-            EMC0W::DO_NOTHING_ => 0,
-            EMC0W::CLEAR_THE_CORRESPOND => 1,
-            EMC0W::SET_THE_CORRESPONDIN => 2,
-            EMC0W::TOGGLE_THE_CORRESPON => 3,
+            EMC0W::DO_NOTHING => 0,
+            EMC0W::CLEAR => 1,
+            EMC0W::SET => 2,
+            EMC0W::TOGGLE => 3,
         }
     }
 }
@@ -480,23 +480,23 @@ impl<'a> _EMC0W<'a> {
     }
     #[doc = "Do Nothing."]
     #[inline]
-    pub fn do_nothing_(self) -> &'a mut W {
-        self.variant(EMC0W::DO_NOTHING_)
+    pub fn do_nothing(self) -> &'a mut W {
+        self.variant(EMC0W::DO_NOTHING)
     }
     #[doc = "Clear the corresponding External Match bit/output to 0 (CT16Bn_MAT0 pin is LOW if pinned out)."]
     #[inline]
-    pub fn clear_the_correspond(self) -> &'a mut W {
-        self.variant(EMC0W::CLEAR_THE_CORRESPOND)
+    pub fn clear(self) -> &'a mut W {
+        self.variant(EMC0W::CLEAR)
     }
     #[doc = "Set the corresponding External Match bit/output to 1 (CT16Bn_MAT0 pin is HIGH if pinned out)."]
     #[inline]
-    pub fn set_the_correspondin(self) -> &'a mut W {
-        self.variant(EMC0W::SET_THE_CORRESPONDIN)
+    pub fn set(self) -> &'a mut W {
+        self.variant(EMC0W::SET)
     }
     #[doc = "Toggle the corresponding External Match bit/output."]
     #[inline]
-    pub fn toggle_the_correspon(self) -> &'a mut W {
-        self.variant(EMC0W::TOGGLE_THE_CORRESPON)
+    pub fn toggle(self) -> &'a mut W {
+        self.variant(EMC0W::TOGGLE)
     }
     #[doc = r" Writes raw bits to the field"]
     #[inline]
@@ -511,13 +511,13 @@ impl<'a> _EMC0W<'a> {
 #[doc = "Values that can be written to the field `EMC1`"]
 pub enum EMC1W {
     #[doc = "Do Nothing."]
-    DO_NOTHING_,
+    DO_NOTHING,
     #[doc = "Clear the corresponding External Match bit/output to 0 (CT16Bn_MAT1 pin is LOW if pinned out)."]
-    CLEAR_THE_CORRESPOND,
+    CLEAR,
     #[doc = "Set the corresponding External Match bit/output to 1 (CT16Bn_MAT1 pin is HIGH if pinned out)."]
-    SET_THE_CORRESPONDIN,
+    SET,
     #[doc = "Toggle the corresponding External Match bit/output."]
-    TOGGLE_THE_CORRESPON,
+    TOGGLE,
 }
 impl EMC1W {
     #[allow(missing_docs)]
@@ -525,10 +525,10 @@ impl EMC1W {
     #[inline]
     pub fn _bits(&self) -> u8 {
         match *self {
-            EMC1W::DO_NOTHING_ => 0,
-            EMC1W::CLEAR_THE_CORRESPOND => 1,
-            EMC1W::SET_THE_CORRESPONDIN => 2,
-            EMC1W::TOGGLE_THE_CORRESPON => 3,
+            EMC1W::DO_NOTHING => 0,
+            EMC1W::CLEAR => 1,
+            EMC1W::SET => 2,
+            EMC1W::TOGGLE => 3,
         }
     }
 }
@@ -546,23 +546,23 @@ impl<'a> _EMC1W<'a> {
     }
     #[doc = "Do Nothing."]
     #[inline]
-    pub fn do_nothing_(self) -> &'a mut W {
-        self.variant(EMC1W::DO_NOTHING_)
+    pub fn do_nothing(self) -> &'a mut W {
+        self.variant(EMC1W::DO_NOTHING)
     }
     #[doc = "Clear the corresponding External Match bit/output to 0 (CT16Bn_MAT1 pin is LOW if pinned out)."]
     #[inline]
-    pub fn clear_the_correspond(self) -> &'a mut W {
-        self.variant(EMC1W::CLEAR_THE_CORRESPOND)
+    pub fn clear(self) -> &'a mut W {
+        self.variant(EMC1W::CLEAR)
     }
     #[doc = "Set the corresponding External Match bit/output to 1 (CT16Bn_MAT1 pin is HIGH if pinned out)."]
     #[inline]
-    pub fn set_the_correspondin(self) -> &'a mut W {
-        self.variant(EMC1W::SET_THE_CORRESPONDIN)
+    pub fn set(self) -> &'a mut W {
+        self.variant(EMC1W::SET)
     }
     #[doc = "Toggle the corresponding External Match bit/output."]
     #[inline]
-    pub fn toggle_the_correspon(self) -> &'a mut W {
-        self.variant(EMC1W::TOGGLE_THE_CORRESPON)
+    pub fn toggle(self) -> &'a mut W {
+        self.variant(EMC1W::TOGGLE)
     }
     #[doc = r" Writes raw bits to the field"]
     #[inline]
@@ -577,13 +577,13 @@ impl<'a> _EMC1W<'a> {
 #[doc = "Values that can be written to the field `EMC2`"]
 pub enum EMC2W {
     #[doc = "Do Nothing."]
-    DO_NOTHING_,
+    DO_NOTHING,
     #[doc = "Clear the corresponding External Match bit/output to 0 (CT16Bn_MAT2 pin is LOW if pinned out)."]
-    CLEAR_THE_CORRESPOND,
+    CLEAR,
     #[doc = "Set the corresponding External Match bit/output to 1 (CT16Bn_MAT2 pin is HIGH if pinned out)."]
-    SET_THE_CORRESPONDIN,
+    SET,
     #[doc = "Toggle the corresponding External Match bit/output."]
-    TOGGLE_THE_CORRESPON,
+    TOGGLE,
 }
 impl EMC2W {
     #[allow(missing_docs)]
@@ -591,10 +591,10 @@ impl EMC2W {
     #[inline]
     pub fn _bits(&self) -> u8 {
         match *self {
-            EMC2W::DO_NOTHING_ => 0,
-            EMC2W::CLEAR_THE_CORRESPOND => 1,
-            EMC2W::SET_THE_CORRESPONDIN => 2,
-            EMC2W::TOGGLE_THE_CORRESPON => 3,
+            EMC2W::DO_NOTHING => 0,
+            EMC2W::CLEAR => 1,
+            EMC2W::SET => 2,
+            EMC2W::TOGGLE => 3,
         }
     }
 }
@@ -612,23 +612,23 @@ impl<'a> _EMC2W<'a> {
     }
     #[doc = "Do Nothing."]
     #[inline]
-    pub fn do_nothing_(self) -> &'a mut W {
-        self.variant(EMC2W::DO_NOTHING_)
+    pub fn do_nothing(self) -> &'a mut W {
+        self.variant(EMC2W::DO_NOTHING)
     }
     #[doc = "Clear the corresponding External Match bit/output to 0 (CT16Bn_MAT2 pin is LOW if pinned out)."]
     #[inline]
-    pub fn clear_the_correspond(self) -> &'a mut W {
-        self.variant(EMC2W::CLEAR_THE_CORRESPOND)
+    pub fn clear(self) -> &'a mut W {
+        self.variant(EMC2W::CLEAR)
     }
     #[doc = "Set the corresponding External Match bit/output to 1 (CT16Bn_MAT2 pin is HIGH if pinned out)."]
     #[inline]
-    pub fn set_the_correspondin(self) -> &'a mut W {
-        self.variant(EMC2W::SET_THE_CORRESPONDIN)
+    pub fn set(self) -> &'a mut W {
+        self.variant(EMC2W::SET)
     }
     #[doc = "Toggle the corresponding External Match bit/output."]
     #[inline]
-    pub fn toggle_the_correspon(self) -> &'a mut W {
-        self.variant(EMC2W::TOGGLE_THE_CORRESPON)
+    pub fn toggle(self) -> &'a mut W {
+        self.variant(EMC2W::TOGGLE)
     }
     #[doc = r" Writes raw bits to the field"]
     #[inline]
@@ -643,13 +643,13 @@ impl<'a> _EMC2W<'a> {
 #[doc = "Values that can be written to the field `EMC3`"]
 pub enum EMC3W {
     #[doc = "Do Nothing."]
-    DO_NOTHING_,
+    DO_NOTHING,
     #[doc = "Clear the corresponding External Match bit/output to 0 (CT16Bn_MAT3 pin is LOW if pinned out)."]
-    CLEAR_THE_CORRESPOND,
+    CLEAR,
     #[doc = "Set the corresponding External Match bit/output to 1 (CT16Bn_MAT3 pin is HIGH if pinned out)."]
-    SET_THE_CORRESPONDIN,
+    SET,
     #[doc = "Toggle the corresponding External Match bit/output."]
-    TOGGLE_THE_CORRESPON,
+    TOGGLE,
 }
 impl EMC3W {
     #[allow(missing_docs)]
@@ -657,10 +657,10 @@ impl EMC3W {
     #[inline]
     pub fn _bits(&self) -> u8 {
         match *self {
-            EMC3W::DO_NOTHING_ => 0,
-            EMC3W::CLEAR_THE_CORRESPOND => 1,
-            EMC3W::SET_THE_CORRESPONDIN => 2,
-            EMC3W::TOGGLE_THE_CORRESPON => 3,
+            EMC3W::DO_NOTHING => 0,
+            EMC3W::CLEAR => 1,
+            EMC3W::SET => 2,
+            EMC3W::TOGGLE => 3,
         }
     }
 }
@@ -678,23 +678,23 @@ impl<'a> _EMC3W<'a> {
     }
     #[doc = "Do Nothing."]
     #[inline]
-    pub fn do_nothing_(self) -> &'a mut W {
-        self.variant(EMC3W::DO_NOTHING_)
+    pub fn do_nothing(self) -> &'a mut W {
+        self.variant(EMC3W::DO_NOTHING)
     }
     #[doc = "Clear the corresponding External Match bit/output to 0 (CT16Bn_MAT3 pin is LOW if pinned out)."]
     #[inline]
-    pub fn clear_the_correspond(self) -> &'a mut W {
-        self.variant(EMC3W::CLEAR_THE_CORRESPOND)
+    pub fn clear(self) -> &'a mut W {
+        self.variant(EMC3W::CLEAR)
     }
     #[doc = "Set the corresponding External Match bit/output to 1 (CT16Bn_MAT3 pin is HIGH if pinned out)."]
     #[inline]
-    pub fn set_the_correspondin(self) -> &'a mut W {
-        self.variant(EMC3W::SET_THE_CORRESPONDIN)
+    pub fn set(self) -> &'a mut W {
+        self.variant(EMC3W::SET)
     }
     #[doc = "Toggle the corresponding External Match bit/output."]
     #[inline]
-    pub fn toggle_the_correspon(self) -> &'a mut W {
-        self.variant(EMC3W::TOGGLE_THE_CORRESPON)
+    pub fn toggle(self) -> &'a mut W {
+        self.variant(EMC3W::TOGGLE)
     }
     #[doc = r" Writes raw bits to the field"]
     #[inline]

--- a/lpc11uxx/src/ct16b1/pwmc.rs
+++ b/lpc11uxx/src/ct16b1/pwmc.rs
@@ -46,9 +46,9 @@ impl super::PWMC {
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum PWMEN0R {
     #[doc = "CT16Bn_MAT0 is controlled by EM0."]
-    CT16BN_MAT0_IS_CONTR,
+    EM0,
     #[doc = "PWM mode is enabled for CT16Bn_MAT0."]
-    PWM_MODE_IS_ENABLED_,
+    ENABLED,
 }
 impl PWMEN0R {
     #[doc = r" Returns `true` if the bit is clear (0)"]
@@ -65,8 +65,8 @@ impl PWMEN0R {
     #[inline]
     pub fn bit(&self) -> bool {
         match *self {
-            PWMEN0R::CT16BN_MAT0_IS_CONTR => false,
-            PWMEN0R::PWM_MODE_IS_ENABLED_ => true,
+            PWMEN0R::EM0 => false,
+            PWMEN0R::ENABLED => true,
         }
     }
     #[allow(missing_docs)]
@@ -74,28 +74,28 @@ impl PWMEN0R {
     #[inline]
     pub fn _from(value: bool) -> PWMEN0R {
         match value {
-            false => PWMEN0R::CT16BN_MAT0_IS_CONTR,
-            true => PWMEN0R::PWM_MODE_IS_ENABLED_,
+            false => PWMEN0R::EM0,
+            true => PWMEN0R::ENABLED,
         }
     }
-    #[doc = "Checks if the value of the field is `CT16BN_MAT0_IS_CONTR`"]
+    #[doc = "Checks if the value of the field is `EM0`"]
     #[inline]
-    pub fn is_ct16bn_mat0_is_contr(&self) -> bool {
-        *self == PWMEN0R::CT16BN_MAT0_IS_CONTR
+    pub fn is_em0(&self) -> bool {
+        *self == PWMEN0R::EM0
     }
-    #[doc = "Checks if the value of the field is `PWM_MODE_IS_ENABLED_`"]
+    #[doc = "Checks if the value of the field is `ENABLED`"]
     #[inline]
-    pub fn is_pwm_mode_is_enabled_(&self) -> bool {
-        *self == PWMEN0R::PWM_MODE_IS_ENABLED_
+    pub fn is_enabled(&self) -> bool {
+        *self == PWMEN0R::ENABLED
     }
 }
 #[doc = "Possible values of the field `PWMEN1`"]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum PWMEN1R {
     #[doc = "CT16Bn_MAT01 is controlled by EM1."]
-    CT16BN_MAT01_IS_CONT,
+    EM1,
     #[doc = "PWM mode is enabled for CT16Bn_MAT1."]
-    PWM_MODE_IS_ENABLED_,
+    ENABLED,
 }
 impl PWMEN1R {
     #[doc = r" Returns `true` if the bit is clear (0)"]
@@ -112,8 +112,8 @@ impl PWMEN1R {
     #[inline]
     pub fn bit(&self) -> bool {
         match *self {
-            PWMEN1R::CT16BN_MAT01_IS_CONT => false,
-            PWMEN1R::PWM_MODE_IS_ENABLED_ => true,
+            PWMEN1R::EM1 => false,
+            PWMEN1R::ENABLED => true,
         }
     }
     #[allow(missing_docs)]
@@ -121,28 +121,28 @@ impl PWMEN1R {
     #[inline]
     pub fn _from(value: bool) -> PWMEN1R {
         match value {
-            false => PWMEN1R::CT16BN_MAT01_IS_CONT,
-            true => PWMEN1R::PWM_MODE_IS_ENABLED_,
+            false => PWMEN1R::EM1,
+            true => PWMEN1R::ENABLED,
         }
     }
-    #[doc = "Checks if the value of the field is `CT16BN_MAT01_IS_CONT`"]
+    #[doc = "Checks if the value of the field is `EM1`"]
     #[inline]
-    pub fn is_ct16bn_mat01_is_cont(&self) -> bool {
-        *self == PWMEN1R::CT16BN_MAT01_IS_CONT
+    pub fn is_em1(&self) -> bool {
+        *self == PWMEN1R::EM1
     }
-    #[doc = "Checks if the value of the field is `PWM_MODE_IS_ENABLED_`"]
+    #[doc = "Checks if the value of the field is `ENABLED`"]
     #[inline]
-    pub fn is_pwm_mode_is_enabled_(&self) -> bool {
-        *self == PWMEN1R::PWM_MODE_IS_ENABLED_
+    pub fn is_enabled(&self) -> bool {
+        *self == PWMEN1R::ENABLED
     }
 }
 #[doc = "Possible values of the field `PWMEN2`"]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum PWMEN2R {
     #[doc = "CT16Bn_MAT2 is controlled by EM2."]
-    CT16BN_MAT2_IS_CONTR,
+    EM2,
     #[doc = "PWM mode is enabled for CT16Bn_MAT2."]
-    PWM_MODE_IS_ENABLED_,
+    ENABLED,
 }
 impl PWMEN2R {
     #[doc = r" Returns `true` if the bit is clear (0)"]
@@ -159,8 +159,8 @@ impl PWMEN2R {
     #[inline]
     pub fn bit(&self) -> bool {
         match *self {
-            PWMEN2R::CT16BN_MAT2_IS_CONTR => false,
-            PWMEN2R::PWM_MODE_IS_ENABLED_ => true,
+            PWMEN2R::EM2 => false,
+            PWMEN2R::ENABLED => true,
         }
     }
     #[allow(missing_docs)]
@@ -168,28 +168,28 @@ impl PWMEN2R {
     #[inline]
     pub fn _from(value: bool) -> PWMEN2R {
         match value {
-            false => PWMEN2R::CT16BN_MAT2_IS_CONTR,
-            true => PWMEN2R::PWM_MODE_IS_ENABLED_,
+            false => PWMEN2R::EM2,
+            true => PWMEN2R::ENABLED,
         }
     }
-    #[doc = "Checks if the value of the field is `CT16BN_MAT2_IS_CONTR`"]
+    #[doc = "Checks if the value of the field is `EM2`"]
     #[inline]
-    pub fn is_ct16bn_mat2_is_contr(&self) -> bool {
-        *self == PWMEN2R::CT16BN_MAT2_IS_CONTR
+    pub fn is_em2(&self) -> bool {
+        *self == PWMEN2R::EM2
     }
-    #[doc = "Checks if the value of the field is `PWM_MODE_IS_ENABLED_`"]
+    #[doc = "Checks if the value of the field is `ENABLED`"]
     #[inline]
-    pub fn is_pwm_mode_is_enabled_(&self) -> bool {
-        *self == PWMEN2R::PWM_MODE_IS_ENABLED_
+    pub fn is_enabled(&self) -> bool {
+        *self == PWMEN2R::ENABLED
     }
 }
 #[doc = "Possible values of the field `PWMEN3`"]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum PWMEN3R {
     #[doc = "CT16Bn_MAT3 is controlled by EM3."]
-    CT16BN_MAT3_IS_CONTR,
+    EM3,
     #[doc = "PWM mode is enabled for CT16Bn_MAT3."]
-    PWM_MODE_IS_ENABLED_,
+    ENABLED,
 }
 impl PWMEN3R {
     #[doc = r" Returns `true` if the bit is clear (0)"]
@@ -206,8 +206,8 @@ impl PWMEN3R {
     #[inline]
     pub fn bit(&self) -> bool {
         match *self {
-            PWMEN3R::CT16BN_MAT3_IS_CONTR => false,
-            PWMEN3R::PWM_MODE_IS_ENABLED_ => true,
+            PWMEN3R::EM3 => false,
+            PWMEN3R::ENABLED => true,
         }
     }
     #[allow(missing_docs)]
@@ -215,27 +215,27 @@ impl PWMEN3R {
     #[inline]
     pub fn _from(value: bool) -> PWMEN3R {
         match value {
-            false => PWMEN3R::CT16BN_MAT3_IS_CONTR,
-            true => PWMEN3R::PWM_MODE_IS_ENABLED_,
+            false => PWMEN3R::EM3,
+            true => PWMEN3R::ENABLED,
         }
     }
-    #[doc = "Checks if the value of the field is `CT16BN_MAT3_IS_CONTR`"]
+    #[doc = "Checks if the value of the field is `EM3`"]
     #[inline]
-    pub fn is_ct16bn_mat3_is_contr(&self) -> bool {
-        *self == PWMEN3R::CT16BN_MAT3_IS_CONTR
+    pub fn is_em3(&self) -> bool {
+        *self == PWMEN3R::EM3
     }
-    #[doc = "Checks if the value of the field is `PWM_MODE_IS_ENABLED_`"]
+    #[doc = "Checks if the value of the field is `ENABLED`"]
     #[inline]
-    pub fn is_pwm_mode_is_enabled_(&self) -> bool {
-        *self == PWMEN3R::PWM_MODE_IS_ENABLED_
+    pub fn is_enabled(&self) -> bool {
+        *self == PWMEN3R::ENABLED
     }
 }
 #[doc = "Values that can be written to the field `PWMEN0`"]
 pub enum PWMEN0W {
     #[doc = "CT16Bn_MAT0 is controlled by EM0."]
-    CT16BN_MAT0_IS_CONTR,
+    EM0,
     #[doc = "PWM mode is enabled for CT16Bn_MAT0."]
-    PWM_MODE_IS_ENABLED_,
+    ENABLED,
 }
 impl PWMEN0W {
     #[allow(missing_docs)]
@@ -243,8 +243,8 @@ impl PWMEN0W {
     #[inline]
     pub fn _bits(&self) -> bool {
         match *self {
-            PWMEN0W::CT16BN_MAT0_IS_CONTR => false,
-            PWMEN0W::PWM_MODE_IS_ENABLED_ => true,
+            PWMEN0W::EM0 => false,
+            PWMEN0W::ENABLED => true,
         }
     }
 }
@@ -262,13 +262,13 @@ impl<'a> _PWMEN0W<'a> {
     }
     #[doc = "CT16Bn_MAT0 is controlled by EM0."]
     #[inline]
-    pub fn ct16bn_mat0_is_contr(self) -> &'a mut W {
-        self.variant(PWMEN0W::CT16BN_MAT0_IS_CONTR)
+    pub fn em0(self) -> &'a mut W {
+        self.variant(PWMEN0W::EM0)
     }
     #[doc = "PWM mode is enabled for CT16Bn_MAT0."]
     #[inline]
-    pub fn pwm_mode_is_enabled_(self) -> &'a mut W {
-        self.variant(PWMEN0W::PWM_MODE_IS_ENABLED_)
+    pub fn enabled(self) -> &'a mut W {
+        self.variant(PWMEN0W::ENABLED)
     }
     #[doc = r" Sets the field bit"]
     pub fn set_bit(self) -> &'a mut W {
@@ -291,9 +291,9 @@ impl<'a> _PWMEN0W<'a> {
 #[doc = "Values that can be written to the field `PWMEN1`"]
 pub enum PWMEN1W {
     #[doc = "CT16Bn_MAT01 is controlled by EM1."]
-    CT16BN_MAT01_IS_CONT,
+    EM1,
     #[doc = "PWM mode is enabled for CT16Bn_MAT1."]
-    PWM_MODE_IS_ENABLED_,
+    ENABLED,
 }
 impl PWMEN1W {
     #[allow(missing_docs)]
@@ -301,8 +301,8 @@ impl PWMEN1W {
     #[inline]
     pub fn _bits(&self) -> bool {
         match *self {
-            PWMEN1W::CT16BN_MAT01_IS_CONT => false,
-            PWMEN1W::PWM_MODE_IS_ENABLED_ => true,
+            PWMEN1W::EM1 => false,
+            PWMEN1W::ENABLED => true,
         }
     }
 }
@@ -320,13 +320,13 @@ impl<'a> _PWMEN1W<'a> {
     }
     #[doc = "CT16Bn_MAT01 is controlled by EM1."]
     #[inline]
-    pub fn ct16bn_mat01_is_cont(self) -> &'a mut W {
-        self.variant(PWMEN1W::CT16BN_MAT01_IS_CONT)
+    pub fn em1(self) -> &'a mut W {
+        self.variant(PWMEN1W::EM1)
     }
     #[doc = "PWM mode is enabled for CT16Bn_MAT1."]
     #[inline]
-    pub fn pwm_mode_is_enabled_(self) -> &'a mut W {
-        self.variant(PWMEN1W::PWM_MODE_IS_ENABLED_)
+    pub fn enabled(self) -> &'a mut W {
+        self.variant(PWMEN1W::ENABLED)
     }
     #[doc = r" Sets the field bit"]
     pub fn set_bit(self) -> &'a mut W {
@@ -349,9 +349,9 @@ impl<'a> _PWMEN1W<'a> {
 #[doc = "Values that can be written to the field `PWMEN2`"]
 pub enum PWMEN2W {
     #[doc = "CT16Bn_MAT2 is controlled by EM2."]
-    CT16BN_MAT2_IS_CONTR,
+    EM2,
     #[doc = "PWM mode is enabled for CT16Bn_MAT2."]
-    PWM_MODE_IS_ENABLED_,
+    ENABLED,
 }
 impl PWMEN2W {
     #[allow(missing_docs)]
@@ -359,8 +359,8 @@ impl PWMEN2W {
     #[inline]
     pub fn _bits(&self) -> bool {
         match *self {
-            PWMEN2W::CT16BN_MAT2_IS_CONTR => false,
-            PWMEN2W::PWM_MODE_IS_ENABLED_ => true,
+            PWMEN2W::EM2 => false,
+            PWMEN2W::ENABLED => true,
         }
     }
 }
@@ -378,13 +378,13 @@ impl<'a> _PWMEN2W<'a> {
     }
     #[doc = "CT16Bn_MAT2 is controlled by EM2."]
     #[inline]
-    pub fn ct16bn_mat2_is_contr(self) -> &'a mut W {
-        self.variant(PWMEN2W::CT16BN_MAT2_IS_CONTR)
+    pub fn em2(self) -> &'a mut W {
+        self.variant(PWMEN2W::EM2)
     }
     #[doc = "PWM mode is enabled for CT16Bn_MAT2."]
     #[inline]
-    pub fn pwm_mode_is_enabled_(self) -> &'a mut W {
-        self.variant(PWMEN2W::PWM_MODE_IS_ENABLED_)
+    pub fn enabled(self) -> &'a mut W {
+        self.variant(PWMEN2W::ENABLED)
     }
     #[doc = r" Sets the field bit"]
     pub fn set_bit(self) -> &'a mut W {
@@ -407,9 +407,9 @@ impl<'a> _PWMEN2W<'a> {
 #[doc = "Values that can be written to the field `PWMEN3`"]
 pub enum PWMEN3W {
     #[doc = "CT16Bn_MAT3 is controlled by EM3."]
-    CT16BN_MAT3_IS_CONTR,
+    EM3,
     #[doc = "PWM mode is enabled for CT16Bn_MAT3."]
-    PWM_MODE_IS_ENABLED_,
+    ENABLED,
 }
 impl PWMEN3W {
     #[allow(missing_docs)]
@@ -417,8 +417,8 @@ impl PWMEN3W {
     #[inline]
     pub fn _bits(&self) -> bool {
         match *self {
-            PWMEN3W::CT16BN_MAT3_IS_CONTR => false,
-            PWMEN3W::PWM_MODE_IS_ENABLED_ => true,
+            PWMEN3W::EM3 => false,
+            PWMEN3W::ENABLED => true,
         }
     }
 }
@@ -436,13 +436,13 @@ impl<'a> _PWMEN3W<'a> {
     }
     #[doc = "CT16Bn_MAT3 is controlled by EM3."]
     #[inline]
-    pub fn ct16bn_mat3_is_contr(self) -> &'a mut W {
-        self.variant(PWMEN3W::CT16BN_MAT3_IS_CONTR)
+    pub fn em3(self) -> &'a mut W {
+        self.variant(PWMEN3W::EM3)
     }
     #[doc = "PWM mode is enabled for CT16Bn_MAT3."]
     #[inline]
-    pub fn pwm_mode_is_enabled_(self) -> &'a mut W {
-        self.variant(PWMEN3W::PWM_MODE_IS_ENABLED_)
+    pub fn enabled(self) -> &'a mut W {
+        self.variant(PWMEN3W::ENABLED)
     }
     #[doc = r" Sets the field bit"]
     pub fn set_bit(self) -> &'a mut W {

--- a/lpc11uxx/src/ct16b1/tcr.rs
+++ b/lpc11uxx/src/ct16b1/tcr.rs
@@ -93,9 +93,9 @@ impl CENR {
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum CRSTR {
     #[doc = "Do nothing."]
-    DO_NOTHING_,
+    DO_NOTHING,
     #[doc = "The Timer Counter and the Prescale Counter are synchronously reset on the next positive edge of PCLK. The counters remain reset until TCR\\[1\\] is returned to zero."]
-    THE_TIMER_COUNTER_AN,
+    RESET,
 }
 impl CRSTR {
     #[doc = r" Returns `true` if the bit is clear (0)"]
@@ -112,8 +112,8 @@ impl CRSTR {
     #[inline]
     pub fn bit(&self) -> bool {
         match *self {
-            CRSTR::DO_NOTHING_ => false,
-            CRSTR::THE_TIMER_COUNTER_AN => true,
+            CRSTR::DO_NOTHING => false,
+            CRSTR::RESET => true,
         }
     }
     #[allow(missing_docs)]
@@ -121,19 +121,19 @@ impl CRSTR {
     #[inline]
     pub fn _from(value: bool) -> CRSTR {
         match value {
-            false => CRSTR::DO_NOTHING_,
-            true => CRSTR::THE_TIMER_COUNTER_AN,
+            false => CRSTR::DO_NOTHING,
+            true => CRSTR::RESET,
         }
     }
-    #[doc = "Checks if the value of the field is `DO_NOTHING_`"]
+    #[doc = "Checks if the value of the field is `DO_NOTHING`"]
     #[inline]
-    pub fn is_do_nothing_(&self) -> bool {
-        *self == CRSTR::DO_NOTHING_
+    pub fn is_do_nothing(&self) -> bool {
+        *self == CRSTR::DO_NOTHING
     }
-    #[doc = "Checks if the value of the field is `THE_TIMER_COUNTER_AN`"]
+    #[doc = "Checks if the value of the field is `RESET`"]
     #[inline]
-    pub fn is_the_timer_counter_an(&self) -> bool {
-        *self == CRSTR::THE_TIMER_COUNTER_AN
+    pub fn is_reset(&self) -> bool {
+        *self == CRSTR::RESET
     }
 }
 #[doc = "Values that can be written to the field `CEN`"]
@@ -197,9 +197,9 @@ impl<'a> _CENW<'a> {
 #[doc = "Values that can be written to the field `CRST`"]
 pub enum CRSTW {
     #[doc = "Do nothing."]
-    DO_NOTHING_,
+    DO_NOTHING,
     #[doc = "The Timer Counter and the Prescale Counter are synchronously reset on the next positive edge of PCLK. The counters remain reset until TCR\\[1\\] is returned to zero."]
-    THE_TIMER_COUNTER_AN,
+    RESET,
 }
 impl CRSTW {
     #[allow(missing_docs)]
@@ -207,8 +207,8 @@ impl CRSTW {
     #[inline]
     pub fn _bits(&self) -> bool {
         match *self {
-            CRSTW::DO_NOTHING_ => false,
-            CRSTW::THE_TIMER_COUNTER_AN => true,
+            CRSTW::DO_NOTHING => false,
+            CRSTW::RESET => true,
         }
     }
 }
@@ -226,13 +226,13 @@ impl<'a> _CRSTW<'a> {
     }
     #[doc = "Do nothing."]
     #[inline]
-    pub fn do_nothing_(self) -> &'a mut W {
-        self.variant(CRSTW::DO_NOTHING_)
+    pub fn do_nothing(self) -> &'a mut W {
+        self.variant(CRSTW::DO_NOTHING)
     }
     #[doc = "The Timer Counter and the Prescale Counter are synchronously reset on the next positive edge of PCLK. The counters remain reset until TCR\\[1\\] is returned to zero."]
     #[inline]
-    pub fn the_timer_counter_an(self) -> &'a mut W {
-        self.variant(CRSTW::THE_TIMER_COUNTER_AN)
+    pub fn reset(self) -> &'a mut W {
+        self.variant(CRSTW::RESET)
     }
     #[doc = r" Sets the field bit"]
     pub fn set_bit(self) -> &'a mut W {

--- a/lpc11uxx/src/ct32b0/ccr.rs
+++ b/lpc11uxx/src/ct32b0/ccr.rs
@@ -46,9 +46,9 @@ impl super::CCR {
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum CAP0RER {
     #[doc = "Enabled."]
-    ENABLED_,
+    ENABLED,
     #[doc = "Disabled."]
-    DISABLED_,
+    DISABLED,
 }
 impl CAP0RER {
     #[doc = r" Returns `true` if the bit is clear (0)"]
@@ -65,8 +65,8 @@ impl CAP0RER {
     #[inline]
     pub fn bit(&self) -> bool {
         match *self {
-            CAP0RER::ENABLED_ => true,
-            CAP0RER::DISABLED_ => false,
+            CAP0RER::ENABLED => true,
+            CAP0RER::DISABLED => false,
         }
     }
     #[allow(missing_docs)]
@@ -74,28 +74,28 @@ impl CAP0RER {
     #[inline]
     pub fn _from(value: bool) -> CAP0RER {
         match value {
-            true => CAP0RER::ENABLED_,
-            false => CAP0RER::DISABLED_,
+            true => CAP0RER::ENABLED,
+            false => CAP0RER::DISABLED,
         }
     }
-    #[doc = "Checks if the value of the field is `ENABLED_`"]
+    #[doc = "Checks if the value of the field is `ENABLED`"]
     #[inline]
-    pub fn is_enabled_(&self) -> bool {
-        *self == CAP0RER::ENABLED_
+    pub fn is_enabled(&self) -> bool {
+        *self == CAP0RER::ENABLED
     }
-    #[doc = "Checks if the value of the field is `DISABLED_`"]
+    #[doc = "Checks if the value of the field is `DISABLED`"]
     #[inline]
-    pub fn is_disabled_(&self) -> bool {
-        *self == CAP0RER::DISABLED_
+    pub fn is_disabled(&self) -> bool {
+        *self == CAP0RER::DISABLED
     }
 }
 #[doc = "Possible values of the field `CAP0FE`"]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum CAP0FER {
     #[doc = "Enabled."]
-    ENABLED_,
+    ENABLED,
     #[doc = "Disabled."]
-    DISABLED_,
+    DISABLED,
 }
 impl CAP0FER {
     #[doc = r" Returns `true` if the bit is clear (0)"]
@@ -112,8 +112,8 @@ impl CAP0FER {
     #[inline]
     pub fn bit(&self) -> bool {
         match *self {
-            CAP0FER::ENABLED_ => true,
-            CAP0FER::DISABLED_ => false,
+            CAP0FER::ENABLED => true,
+            CAP0FER::DISABLED => false,
         }
     }
     #[allow(missing_docs)]
@@ -121,28 +121,28 @@ impl CAP0FER {
     #[inline]
     pub fn _from(value: bool) -> CAP0FER {
         match value {
-            true => CAP0FER::ENABLED_,
-            false => CAP0FER::DISABLED_,
+            true => CAP0FER::ENABLED,
+            false => CAP0FER::DISABLED,
         }
     }
-    #[doc = "Checks if the value of the field is `ENABLED_`"]
+    #[doc = "Checks if the value of the field is `ENABLED`"]
     #[inline]
-    pub fn is_enabled_(&self) -> bool {
-        *self == CAP0FER::ENABLED_
+    pub fn is_enabled(&self) -> bool {
+        *self == CAP0FER::ENABLED
     }
-    #[doc = "Checks if the value of the field is `DISABLED_`"]
+    #[doc = "Checks if the value of the field is `DISABLED`"]
     #[inline]
-    pub fn is_disabled_(&self) -> bool {
-        *self == CAP0FER::DISABLED_
+    pub fn is_disabled(&self) -> bool {
+        *self == CAP0FER::DISABLED
     }
 }
 #[doc = "Possible values of the field `CAP0I`"]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum CAP0IR {
     #[doc = "Enabled."]
-    ENABLED_,
+    ENABLED,
     #[doc = "Disabled."]
-    DISABLED_,
+    DISABLED,
 }
 impl CAP0IR {
     #[doc = r" Returns `true` if the bit is clear (0)"]
@@ -159,8 +159,8 @@ impl CAP0IR {
     #[inline]
     pub fn bit(&self) -> bool {
         match *self {
-            CAP0IR::ENABLED_ => true,
-            CAP0IR::DISABLED_ => false,
+            CAP0IR::ENABLED => true,
+            CAP0IR::DISABLED => false,
         }
     }
     #[allow(missing_docs)]
@@ -168,28 +168,28 @@ impl CAP0IR {
     #[inline]
     pub fn _from(value: bool) -> CAP0IR {
         match value {
-            true => CAP0IR::ENABLED_,
-            false => CAP0IR::DISABLED_,
+            true => CAP0IR::ENABLED,
+            false => CAP0IR::DISABLED,
         }
     }
-    #[doc = "Checks if the value of the field is `ENABLED_`"]
+    #[doc = "Checks if the value of the field is `ENABLED`"]
     #[inline]
-    pub fn is_enabled_(&self) -> bool {
-        *self == CAP0IR::ENABLED_
+    pub fn is_enabled(&self) -> bool {
+        *self == CAP0IR::ENABLED
     }
-    #[doc = "Checks if the value of the field is `DISABLED_`"]
+    #[doc = "Checks if the value of the field is `DISABLED`"]
     #[inline]
-    pub fn is_disabled_(&self) -> bool {
-        *self == CAP0IR::DISABLED_
+    pub fn is_disabled(&self) -> bool {
+        *self == CAP0IR::DISABLED
     }
 }
 #[doc = "Possible values of the field `CAP1RE`"]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum CAP1RER {
     #[doc = "Enabled."]
-    ENABLED_,
+    ENABLED,
     #[doc = "Disabled."]
-    DISABLED_,
+    DISABLED,
 }
 impl CAP1RER {
     #[doc = r" Returns `true` if the bit is clear (0)"]
@@ -206,8 +206,8 @@ impl CAP1RER {
     #[inline]
     pub fn bit(&self) -> bool {
         match *self {
-            CAP1RER::ENABLED_ => true,
-            CAP1RER::DISABLED_ => false,
+            CAP1RER::ENABLED => true,
+            CAP1RER::DISABLED => false,
         }
     }
     #[allow(missing_docs)]
@@ -215,28 +215,28 @@ impl CAP1RER {
     #[inline]
     pub fn _from(value: bool) -> CAP1RER {
         match value {
-            true => CAP1RER::ENABLED_,
-            false => CAP1RER::DISABLED_,
+            true => CAP1RER::ENABLED,
+            false => CAP1RER::DISABLED,
         }
     }
-    #[doc = "Checks if the value of the field is `ENABLED_`"]
+    #[doc = "Checks if the value of the field is `ENABLED`"]
     #[inline]
-    pub fn is_enabled_(&self) -> bool {
-        *self == CAP1RER::ENABLED_
+    pub fn is_enabled(&self) -> bool {
+        *self == CAP1RER::ENABLED
     }
-    #[doc = "Checks if the value of the field is `DISABLED_`"]
+    #[doc = "Checks if the value of the field is `DISABLED`"]
     #[inline]
-    pub fn is_disabled_(&self) -> bool {
-        *self == CAP1RER::DISABLED_
+    pub fn is_disabled(&self) -> bool {
+        *self == CAP1RER::DISABLED
     }
 }
 #[doc = "Possible values of the field `CAP1FE`"]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum CAP1FER {
     #[doc = "Enabled."]
-    ENABLED_,
+    ENABLED,
     #[doc = "Disabled."]
-    DISABLED_,
+    DISABLED,
 }
 impl CAP1FER {
     #[doc = r" Returns `true` if the bit is clear (0)"]
@@ -253,8 +253,8 @@ impl CAP1FER {
     #[inline]
     pub fn bit(&self) -> bool {
         match *self {
-            CAP1FER::ENABLED_ => true,
-            CAP1FER::DISABLED_ => false,
+            CAP1FER::ENABLED => true,
+            CAP1FER::DISABLED => false,
         }
     }
     #[allow(missing_docs)]
@@ -262,28 +262,28 @@ impl CAP1FER {
     #[inline]
     pub fn _from(value: bool) -> CAP1FER {
         match value {
-            true => CAP1FER::ENABLED_,
-            false => CAP1FER::DISABLED_,
+            true => CAP1FER::ENABLED,
+            false => CAP1FER::DISABLED,
         }
     }
-    #[doc = "Checks if the value of the field is `ENABLED_`"]
+    #[doc = "Checks if the value of the field is `ENABLED`"]
     #[inline]
-    pub fn is_enabled_(&self) -> bool {
-        *self == CAP1FER::ENABLED_
+    pub fn is_enabled(&self) -> bool {
+        *self == CAP1FER::ENABLED
     }
-    #[doc = "Checks if the value of the field is `DISABLED_`"]
+    #[doc = "Checks if the value of the field is `DISABLED`"]
     #[inline]
-    pub fn is_disabled_(&self) -> bool {
-        *self == CAP1FER::DISABLED_
+    pub fn is_disabled(&self) -> bool {
+        *self == CAP1FER::DISABLED
     }
 }
 #[doc = "Possible values of the field `CAP1I`"]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum CAP1IR {
     #[doc = "Enabled."]
-    ENABLED_,
+    ENABLED,
     #[doc = "Disabled."]
-    DISABLED_,
+    DISABLED,
 }
 impl CAP1IR {
     #[doc = r" Returns `true` if the bit is clear (0)"]
@@ -300,8 +300,8 @@ impl CAP1IR {
     #[inline]
     pub fn bit(&self) -> bool {
         match *self {
-            CAP1IR::ENABLED_ => true,
-            CAP1IR::DISABLED_ => false,
+            CAP1IR::ENABLED => true,
+            CAP1IR::DISABLED => false,
         }
     }
     #[allow(missing_docs)]
@@ -309,27 +309,27 @@ impl CAP1IR {
     #[inline]
     pub fn _from(value: bool) -> CAP1IR {
         match value {
-            true => CAP1IR::ENABLED_,
-            false => CAP1IR::DISABLED_,
+            true => CAP1IR::ENABLED,
+            false => CAP1IR::DISABLED,
         }
     }
-    #[doc = "Checks if the value of the field is `ENABLED_`"]
+    #[doc = "Checks if the value of the field is `ENABLED`"]
     #[inline]
-    pub fn is_enabled_(&self) -> bool {
-        *self == CAP1IR::ENABLED_
+    pub fn is_enabled(&self) -> bool {
+        *self == CAP1IR::ENABLED
     }
-    #[doc = "Checks if the value of the field is `DISABLED_`"]
+    #[doc = "Checks if the value of the field is `DISABLED`"]
     #[inline]
-    pub fn is_disabled_(&self) -> bool {
-        *self == CAP1IR::DISABLED_
+    pub fn is_disabled(&self) -> bool {
+        *self == CAP1IR::DISABLED
     }
 }
 #[doc = "Values that can be written to the field `CAP0RE`"]
 pub enum CAP0REW {
     #[doc = "Enabled."]
-    ENABLED_,
+    ENABLED,
     #[doc = "Disabled."]
-    DISABLED_,
+    DISABLED,
 }
 impl CAP0REW {
     #[allow(missing_docs)]
@@ -337,8 +337,8 @@ impl CAP0REW {
     #[inline]
     pub fn _bits(&self) -> bool {
         match *self {
-            CAP0REW::ENABLED_ => true,
-            CAP0REW::DISABLED_ => false,
+            CAP0REW::ENABLED => true,
+            CAP0REW::DISABLED => false,
         }
     }
 }
@@ -356,13 +356,13 @@ impl<'a> _CAP0REW<'a> {
     }
     #[doc = "Enabled."]
     #[inline]
-    pub fn enabled_(self) -> &'a mut W {
-        self.variant(CAP0REW::ENABLED_)
+    pub fn enabled(self) -> &'a mut W {
+        self.variant(CAP0REW::ENABLED)
     }
     #[doc = "Disabled."]
     #[inline]
-    pub fn disabled_(self) -> &'a mut W {
-        self.variant(CAP0REW::DISABLED_)
+    pub fn disabled(self) -> &'a mut W {
+        self.variant(CAP0REW::DISABLED)
     }
     #[doc = r" Sets the field bit"]
     pub fn set_bit(self) -> &'a mut W {
@@ -385,9 +385,9 @@ impl<'a> _CAP0REW<'a> {
 #[doc = "Values that can be written to the field `CAP0FE`"]
 pub enum CAP0FEW {
     #[doc = "Enabled."]
-    ENABLED_,
+    ENABLED,
     #[doc = "Disabled."]
-    DISABLED_,
+    DISABLED,
 }
 impl CAP0FEW {
     #[allow(missing_docs)]
@@ -395,8 +395,8 @@ impl CAP0FEW {
     #[inline]
     pub fn _bits(&self) -> bool {
         match *self {
-            CAP0FEW::ENABLED_ => true,
-            CAP0FEW::DISABLED_ => false,
+            CAP0FEW::ENABLED => true,
+            CAP0FEW::DISABLED => false,
         }
     }
 }
@@ -414,13 +414,13 @@ impl<'a> _CAP0FEW<'a> {
     }
     #[doc = "Enabled."]
     #[inline]
-    pub fn enabled_(self) -> &'a mut W {
-        self.variant(CAP0FEW::ENABLED_)
+    pub fn enabled(self) -> &'a mut W {
+        self.variant(CAP0FEW::ENABLED)
     }
     #[doc = "Disabled."]
     #[inline]
-    pub fn disabled_(self) -> &'a mut W {
-        self.variant(CAP0FEW::DISABLED_)
+    pub fn disabled(self) -> &'a mut W {
+        self.variant(CAP0FEW::DISABLED)
     }
     #[doc = r" Sets the field bit"]
     pub fn set_bit(self) -> &'a mut W {
@@ -443,9 +443,9 @@ impl<'a> _CAP0FEW<'a> {
 #[doc = "Values that can be written to the field `CAP0I`"]
 pub enum CAP0IW {
     #[doc = "Enabled."]
-    ENABLED_,
+    ENABLED,
     #[doc = "Disabled."]
-    DISABLED_,
+    DISABLED,
 }
 impl CAP0IW {
     #[allow(missing_docs)]
@@ -453,8 +453,8 @@ impl CAP0IW {
     #[inline]
     pub fn _bits(&self) -> bool {
         match *self {
-            CAP0IW::ENABLED_ => true,
-            CAP0IW::DISABLED_ => false,
+            CAP0IW::ENABLED => true,
+            CAP0IW::DISABLED => false,
         }
     }
 }
@@ -472,13 +472,13 @@ impl<'a> _CAP0IW<'a> {
     }
     #[doc = "Enabled."]
     #[inline]
-    pub fn enabled_(self) -> &'a mut W {
-        self.variant(CAP0IW::ENABLED_)
+    pub fn enabled(self) -> &'a mut W {
+        self.variant(CAP0IW::ENABLED)
     }
     #[doc = "Disabled."]
     #[inline]
-    pub fn disabled_(self) -> &'a mut W {
-        self.variant(CAP0IW::DISABLED_)
+    pub fn disabled(self) -> &'a mut W {
+        self.variant(CAP0IW::DISABLED)
     }
     #[doc = r" Sets the field bit"]
     pub fn set_bit(self) -> &'a mut W {
@@ -501,9 +501,9 @@ impl<'a> _CAP0IW<'a> {
 #[doc = "Values that can be written to the field `CAP1RE`"]
 pub enum CAP1REW {
     #[doc = "Enabled."]
-    ENABLED_,
+    ENABLED,
     #[doc = "Disabled."]
-    DISABLED_,
+    DISABLED,
 }
 impl CAP1REW {
     #[allow(missing_docs)]
@@ -511,8 +511,8 @@ impl CAP1REW {
     #[inline]
     pub fn _bits(&self) -> bool {
         match *self {
-            CAP1REW::ENABLED_ => true,
-            CAP1REW::DISABLED_ => false,
+            CAP1REW::ENABLED => true,
+            CAP1REW::DISABLED => false,
         }
     }
 }
@@ -530,13 +530,13 @@ impl<'a> _CAP1REW<'a> {
     }
     #[doc = "Enabled."]
     #[inline]
-    pub fn enabled_(self) -> &'a mut W {
-        self.variant(CAP1REW::ENABLED_)
+    pub fn enabled(self) -> &'a mut W {
+        self.variant(CAP1REW::ENABLED)
     }
     #[doc = "Disabled."]
     #[inline]
-    pub fn disabled_(self) -> &'a mut W {
-        self.variant(CAP1REW::DISABLED_)
+    pub fn disabled(self) -> &'a mut W {
+        self.variant(CAP1REW::DISABLED)
     }
     #[doc = r" Sets the field bit"]
     pub fn set_bit(self) -> &'a mut W {
@@ -559,9 +559,9 @@ impl<'a> _CAP1REW<'a> {
 #[doc = "Values that can be written to the field `CAP1FE`"]
 pub enum CAP1FEW {
     #[doc = "Enabled."]
-    ENABLED_,
+    ENABLED,
     #[doc = "Disabled."]
-    DISABLED_,
+    DISABLED,
 }
 impl CAP1FEW {
     #[allow(missing_docs)]
@@ -569,8 +569,8 @@ impl CAP1FEW {
     #[inline]
     pub fn _bits(&self) -> bool {
         match *self {
-            CAP1FEW::ENABLED_ => true,
-            CAP1FEW::DISABLED_ => false,
+            CAP1FEW::ENABLED => true,
+            CAP1FEW::DISABLED => false,
         }
     }
 }
@@ -588,13 +588,13 @@ impl<'a> _CAP1FEW<'a> {
     }
     #[doc = "Enabled."]
     #[inline]
-    pub fn enabled_(self) -> &'a mut W {
-        self.variant(CAP1FEW::ENABLED_)
+    pub fn enabled(self) -> &'a mut W {
+        self.variant(CAP1FEW::ENABLED)
     }
     #[doc = "Disabled."]
     #[inline]
-    pub fn disabled_(self) -> &'a mut W {
-        self.variant(CAP1FEW::DISABLED_)
+    pub fn disabled(self) -> &'a mut W {
+        self.variant(CAP1FEW::DISABLED)
     }
     #[doc = r" Sets the field bit"]
     pub fn set_bit(self) -> &'a mut W {
@@ -617,9 +617,9 @@ impl<'a> _CAP1FEW<'a> {
 #[doc = "Values that can be written to the field `CAP1I`"]
 pub enum CAP1IW {
     #[doc = "Enabled."]
-    ENABLED_,
+    ENABLED,
     #[doc = "Disabled."]
-    DISABLED_,
+    DISABLED,
 }
 impl CAP1IW {
     #[allow(missing_docs)]
@@ -627,8 +627,8 @@ impl CAP1IW {
     #[inline]
     pub fn _bits(&self) -> bool {
         match *self {
-            CAP1IW::ENABLED_ => true,
-            CAP1IW::DISABLED_ => false,
+            CAP1IW::ENABLED => true,
+            CAP1IW::DISABLED => false,
         }
     }
 }
@@ -646,13 +646,13 @@ impl<'a> _CAP1IW<'a> {
     }
     #[doc = "Enabled."]
     #[inline]
-    pub fn enabled_(self) -> &'a mut W {
-        self.variant(CAP1IW::ENABLED_)
+    pub fn enabled(self) -> &'a mut W {
+        self.variant(CAP1IW::ENABLED)
     }
     #[doc = "Disabled."]
     #[inline]
-    pub fn disabled_(self) -> &'a mut W {
-        self.variant(CAP1IW::DISABLED_)
+    pub fn disabled(self) -> &'a mut W {
+        self.variant(CAP1IW::DISABLED)
     }
     #[doc = r" Sets the field bit"]
     pub fn set_bit(self) -> &'a mut W {

--- a/lpc11uxx/src/ct32b0/ctcr.rs
+++ b/lpc11uxx/src/ct32b0/ctcr.rs
@@ -48,11 +48,11 @@ pub enum CTMR {
     #[doc = "Timer Mode: every rising PCLK edge"]
     TIMER_MODE_EVERY_RI,
     #[doc = "Counter Mode: TC is incremented on rising edges on the CAP input selected by bits 3:2."]
-    COUNTER_MODE_TC_IS_RISING,
+    RISING,
     #[doc = "Counter Mode: TC is incremented on falling edges on the CAP input selected by bits 3:2."]
-    COUNTER_MODE_TC_IS_FALLING,
+    FALLING,
     #[doc = "Counter Mode: TC is incremented on both edges on the CAP input selected by bits 3:2."]
-    COUNTER_MODE_TC_IS_BOTH,
+    BOTH,
 }
 impl CTMR {
     #[doc = r" Value of the field as raw bits"]
@@ -60,9 +60,9 @@ impl CTMR {
     pub fn bits(&self) -> u8 {
         match *self {
             CTMR::TIMER_MODE_EVERY_RI => 0,
-            CTMR::COUNTER_MODE_TC_IS_RISING => 1,
-            CTMR::COUNTER_MODE_TC_IS_FALLING => 2,
-            CTMR::COUNTER_MODE_TC_IS_BOTH => 3,
+            CTMR::RISING => 1,
+            CTMR::FALLING => 2,
+            CTMR::BOTH => 3,
         }
     }
     #[allow(missing_docs)]
@@ -71,9 +71,9 @@ impl CTMR {
     pub fn _from(value: u8) -> CTMR {
         match value {
             0 => CTMR::TIMER_MODE_EVERY_RI,
-            1 => CTMR::COUNTER_MODE_TC_IS_RISING,
-            2 => CTMR::COUNTER_MODE_TC_IS_FALLING,
-            3 => CTMR::COUNTER_MODE_TC_IS_BOTH,
+            1 => CTMR::RISING,
+            2 => CTMR::FALLING,
+            3 => CTMR::BOTH,
             _ => unreachable!(),
         }
     }
@@ -82,20 +82,20 @@ impl CTMR {
     pub fn is_timer_mode_every_ri(&self) -> bool {
         *self == CTMR::TIMER_MODE_EVERY_RI
     }
-    #[doc = "Checks if the value of the field is `COUNTER_MODE_TC_IS_RISING`"]
+    #[doc = "Checks if the value of the field is `RISING`"]
     #[inline]
-    pub fn is_counter_mode_tc_is_rising(&self) -> bool {
-        *self == CTMR::COUNTER_MODE_TC_IS_RISING
+    pub fn is_rising(&self) -> bool {
+        *self == CTMR::RISING
     }
-    #[doc = "Checks if the value of the field is `COUNTER_MODE_TC_IS_FALLING`"]
+    #[doc = "Checks if the value of the field is `FALLING`"]
     #[inline]
-    pub fn is_counter_mode_tc_is_falling(&self) -> bool {
-        *self == CTMR::COUNTER_MODE_TC_IS_FALLING
+    pub fn is_falling(&self) -> bool {
+        *self == CTMR::FALLING
     }
-    #[doc = "Checks if the value of the field is `COUNTER_MODE_TC_IS_BOTH`"]
+    #[doc = "Checks if the value of the field is `BOTH`"]
     #[inline]
-    pub fn is_counter_mode_tc_is_both(&self) -> bool {
-        *self == CTMR::COUNTER_MODE_TC_IS_BOTH
+    pub fn is_both(&self) -> bool {
+        *self == CTMR::BOTH
     }
 }
 #[doc = "Possible values of the field `CIS`"]
@@ -251,11 +251,11 @@ pub enum CTMW {
     #[doc = "Timer Mode: every rising PCLK edge"]
     TIMER_MODE_EVERY_RI,
     #[doc = "Counter Mode: TC is incremented on rising edges on the CAP input selected by bits 3:2."]
-    COUNTER_MODE_TC_IS_RISING,
+    RISING,
     #[doc = "Counter Mode: TC is incremented on falling edges on the CAP input selected by bits 3:2."]
-    COUNTER_MODE_TC_IS_FALLING,
+    FALLING,
     #[doc = "Counter Mode: TC is incremented on both edges on the CAP input selected by bits 3:2."]
-    COUNTER_MODE_TC_IS_BOTH,
+    BOTH,
 }
 impl CTMW {
     #[allow(missing_docs)]
@@ -264,9 +264,9 @@ impl CTMW {
     pub fn _bits(&self) -> u8 {
         match *self {
             CTMW::TIMER_MODE_EVERY_RI => 0,
-            CTMW::COUNTER_MODE_TC_IS_RISING => 1,
-            CTMW::COUNTER_MODE_TC_IS_FALLING => 2,
-            CTMW::COUNTER_MODE_TC_IS_BOTH => 3,
+            CTMW::RISING => 1,
+            CTMW::FALLING => 2,
+            CTMW::BOTH => 3,
         }
     }
 }
@@ -289,18 +289,18 @@ impl<'a> _CTMW<'a> {
     }
     #[doc = "Counter Mode: TC is incremented on rising edges on the CAP input selected by bits 3:2."]
     #[inline]
-    pub fn counter_mode_tc_is_rising(self) -> &'a mut W {
-        self.variant(CTMW::COUNTER_MODE_TC_IS_RISING)
+    pub fn rising(self) -> &'a mut W {
+        self.variant(CTMW::RISING)
     }
     #[doc = "Counter Mode: TC is incremented on falling edges on the CAP input selected by bits 3:2."]
     #[inline]
-    pub fn counter_mode_tc_is_falling(self) -> &'a mut W {
-        self.variant(CTMW::COUNTER_MODE_TC_IS_FALLING)
+    pub fn falling(self) -> &'a mut W {
+        self.variant(CTMW::FALLING)
     }
     #[doc = "Counter Mode: TC is incremented on both edges on the CAP input selected by bits 3:2."]
     #[inline]
-    pub fn counter_mode_tc_is_both(self) -> &'a mut W {
-        self.variant(CTMW::COUNTER_MODE_TC_IS_BOTH)
+    pub fn both(self) -> &'a mut W {
+        self.variant(CTMW::BOTH)
     }
     #[doc = r" Writes raw bits to the field"]
     #[inline]

--- a/lpc11uxx/src/ct32b0/emr.rs
+++ b/lpc11uxx/src/ct32b0/emr.rs
@@ -130,23 +130,23 @@ impl EM3R {
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum EMC0R {
     #[doc = "Do Nothing."]
-    DO_NOTHING_,
+    DO_NOTHING,
     #[doc = "Clear the corresponding External Match bit/output to 0 (CT32Bi_MAT0 pin is LOW if pinned out)."]
-    CLEAR_THE_CORRESPOND,
+    CLEAR,
     #[doc = "Set the corresponding External Match bit/output to 1 (CT32Bi_MAT0 pin is HIGH if pinned out)."]
-    SET_THE_CORRESPONDIN,
+    SET,
     #[doc = "Toggle the corresponding External Match bit/output."]
-    TOGGLE_THE_CORRESPON,
+    TOGGLE,
 }
 impl EMC0R {
     #[doc = r" Value of the field as raw bits"]
     #[inline]
     pub fn bits(&self) -> u8 {
         match *self {
-            EMC0R::DO_NOTHING_ => 0,
-            EMC0R::CLEAR_THE_CORRESPOND => 1,
-            EMC0R::SET_THE_CORRESPONDIN => 2,
-            EMC0R::TOGGLE_THE_CORRESPON => 3,
+            EMC0R::DO_NOTHING => 0,
+            EMC0R::CLEAR => 1,
+            EMC0R::SET => 2,
+            EMC0R::TOGGLE => 3,
         }
     }
     #[allow(missing_docs)]
@@ -154,55 +154,55 @@ impl EMC0R {
     #[inline]
     pub fn _from(value: u8) -> EMC0R {
         match value {
-            0 => EMC0R::DO_NOTHING_,
-            1 => EMC0R::CLEAR_THE_CORRESPOND,
-            2 => EMC0R::SET_THE_CORRESPONDIN,
-            3 => EMC0R::TOGGLE_THE_CORRESPON,
+            0 => EMC0R::DO_NOTHING,
+            1 => EMC0R::CLEAR,
+            2 => EMC0R::SET,
+            3 => EMC0R::TOGGLE,
             _ => unreachable!(),
         }
     }
-    #[doc = "Checks if the value of the field is `DO_NOTHING_`"]
+    #[doc = "Checks if the value of the field is `DO_NOTHING`"]
     #[inline]
-    pub fn is_do_nothing_(&self) -> bool {
-        *self == EMC0R::DO_NOTHING_
+    pub fn is_do_nothing(&self) -> bool {
+        *self == EMC0R::DO_NOTHING
     }
-    #[doc = "Checks if the value of the field is `CLEAR_THE_CORRESPOND`"]
+    #[doc = "Checks if the value of the field is `CLEAR`"]
     #[inline]
-    pub fn is_clear_the_correspond(&self) -> bool {
-        *self == EMC0R::CLEAR_THE_CORRESPOND
+    pub fn is_clear(&self) -> bool {
+        *self == EMC0R::CLEAR
     }
-    #[doc = "Checks if the value of the field is `SET_THE_CORRESPONDIN`"]
+    #[doc = "Checks if the value of the field is `SET`"]
     #[inline]
-    pub fn is_set_the_correspondin(&self) -> bool {
-        *self == EMC0R::SET_THE_CORRESPONDIN
+    pub fn is_set(&self) -> bool {
+        *self == EMC0R::SET
     }
-    #[doc = "Checks if the value of the field is `TOGGLE_THE_CORRESPON`"]
+    #[doc = "Checks if the value of the field is `TOGGLE`"]
     #[inline]
-    pub fn is_toggle_the_correspon(&self) -> bool {
-        *self == EMC0R::TOGGLE_THE_CORRESPON
+    pub fn is_toggle(&self) -> bool {
+        *self == EMC0R::TOGGLE
     }
 }
 #[doc = "Possible values of the field `EMC1`"]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum EMC1R {
     #[doc = "Do Nothing."]
-    DO_NOTHING_,
+    DO_NOTHING,
     #[doc = "Clear the corresponding External Match bit/output to 0 (CT32Bi_MAT1 pin is LOW if pinned out)."]
-    CLEAR_THE_CORRESPOND,
+    CLEAR,
     #[doc = "Set the corresponding External Match bit/output to 1 (CT32Bi_MAT1 pin is HIGH if pinned out)."]
-    SET_THE_CORRESPONDIN,
+    SET,
     #[doc = "Toggle the corresponding External Match bit/output."]
-    TOGGLE_THE_CORRESPON,
+    TOGGLE,
 }
 impl EMC1R {
     #[doc = r" Value of the field as raw bits"]
     #[inline]
     pub fn bits(&self) -> u8 {
         match *self {
-            EMC1R::DO_NOTHING_ => 0,
-            EMC1R::CLEAR_THE_CORRESPOND => 1,
-            EMC1R::SET_THE_CORRESPONDIN => 2,
-            EMC1R::TOGGLE_THE_CORRESPON => 3,
+            EMC1R::DO_NOTHING => 0,
+            EMC1R::CLEAR => 1,
+            EMC1R::SET => 2,
+            EMC1R::TOGGLE => 3,
         }
     }
     #[allow(missing_docs)]
@@ -210,55 +210,55 @@ impl EMC1R {
     #[inline]
     pub fn _from(value: u8) -> EMC1R {
         match value {
-            0 => EMC1R::DO_NOTHING_,
-            1 => EMC1R::CLEAR_THE_CORRESPOND,
-            2 => EMC1R::SET_THE_CORRESPONDIN,
-            3 => EMC1R::TOGGLE_THE_CORRESPON,
+            0 => EMC1R::DO_NOTHING,
+            1 => EMC1R::CLEAR,
+            2 => EMC1R::SET,
+            3 => EMC1R::TOGGLE,
             _ => unreachable!(),
         }
     }
-    #[doc = "Checks if the value of the field is `DO_NOTHING_`"]
+    #[doc = "Checks if the value of the field is `DO_NOTHING`"]
     #[inline]
-    pub fn is_do_nothing_(&self) -> bool {
-        *self == EMC1R::DO_NOTHING_
+    pub fn is_do_nothing(&self) -> bool {
+        *self == EMC1R::DO_NOTHING
     }
-    #[doc = "Checks if the value of the field is `CLEAR_THE_CORRESPOND`"]
+    #[doc = "Checks if the value of the field is `CLEAR`"]
     #[inline]
-    pub fn is_clear_the_correspond(&self) -> bool {
-        *self == EMC1R::CLEAR_THE_CORRESPOND
+    pub fn is_clear(&self) -> bool {
+        *self == EMC1R::CLEAR
     }
-    #[doc = "Checks if the value of the field is `SET_THE_CORRESPONDIN`"]
+    #[doc = "Checks if the value of the field is `SET`"]
     #[inline]
-    pub fn is_set_the_correspondin(&self) -> bool {
-        *self == EMC1R::SET_THE_CORRESPONDIN
+    pub fn is_set(&self) -> bool {
+        *self == EMC1R::SET
     }
-    #[doc = "Checks if the value of the field is `TOGGLE_THE_CORRESPON`"]
+    #[doc = "Checks if the value of the field is `TOGGLE`"]
     #[inline]
-    pub fn is_toggle_the_correspon(&self) -> bool {
-        *self == EMC1R::TOGGLE_THE_CORRESPON
+    pub fn is_toggle(&self) -> bool {
+        *self == EMC1R::TOGGLE
     }
 }
 #[doc = "Possible values of the field `EMC2`"]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum EMC2R {
     #[doc = "Do Nothing."]
-    DO_NOTHING_,
+    DO_NOTHING,
     #[doc = "Clear the corresponding External Match bit/output to 0 (CT32Bi_MAT2 pin is LOW if pinned out)."]
-    CLEAR_THE_CORRESPOND,
+    CLEAR,
     #[doc = "Set the corresponding External Match bit/output to 1 (CT32Bi_MAT2 pin is HIGH if pinned out)."]
-    SET_THE_CORRESPONDIN,
+    SET,
     #[doc = "Toggle the corresponding External Match bit/output."]
-    TOGGLE_THE_CORRESPON,
+    TOGGLE,
 }
 impl EMC2R {
     #[doc = r" Value of the field as raw bits"]
     #[inline]
     pub fn bits(&self) -> u8 {
         match *self {
-            EMC2R::DO_NOTHING_ => 0,
-            EMC2R::CLEAR_THE_CORRESPOND => 1,
-            EMC2R::SET_THE_CORRESPONDIN => 2,
-            EMC2R::TOGGLE_THE_CORRESPON => 3,
+            EMC2R::DO_NOTHING => 0,
+            EMC2R::CLEAR => 1,
+            EMC2R::SET => 2,
+            EMC2R::TOGGLE => 3,
         }
     }
     #[allow(missing_docs)]
@@ -266,55 +266,55 @@ impl EMC2R {
     #[inline]
     pub fn _from(value: u8) -> EMC2R {
         match value {
-            0 => EMC2R::DO_NOTHING_,
-            1 => EMC2R::CLEAR_THE_CORRESPOND,
-            2 => EMC2R::SET_THE_CORRESPONDIN,
-            3 => EMC2R::TOGGLE_THE_CORRESPON,
+            0 => EMC2R::DO_NOTHING,
+            1 => EMC2R::CLEAR,
+            2 => EMC2R::SET,
+            3 => EMC2R::TOGGLE,
             _ => unreachable!(),
         }
     }
-    #[doc = "Checks if the value of the field is `DO_NOTHING_`"]
+    #[doc = "Checks if the value of the field is `DO_NOTHING`"]
     #[inline]
-    pub fn is_do_nothing_(&self) -> bool {
-        *self == EMC2R::DO_NOTHING_
+    pub fn is_do_nothing(&self) -> bool {
+        *self == EMC2R::DO_NOTHING
     }
-    #[doc = "Checks if the value of the field is `CLEAR_THE_CORRESPOND`"]
+    #[doc = "Checks if the value of the field is `CLEAR`"]
     #[inline]
-    pub fn is_clear_the_correspond(&self) -> bool {
-        *self == EMC2R::CLEAR_THE_CORRESPOND
+    pub fn is_clear(&self) -> bool {
+        *self == EMC2R::CLEAR
     }
-    #[doc = "Checks if the value of the field is `SET_THE_CORRESPONDIN`"]
+    #[doc = "Checks if the value of the field is `SET`"]
     #[inline]
-    pub fn is_set_the_correspondin(&self) -> bool {
-        *self == EMC2R::SET_THE_CORRESPONDIN
+    pub fn is_set(&self) -> bool {
+        *self == EMC2R::SET
     }
-    #[doc = "Checks if the value of the field is `TOGGLE_THE_CORRESPON`"]
+    #[doc = "Checks if the value of the field is `TOGGLE`"]
     #[inline]
-    pub fn is_toggle_the_correspon(&self) -> bool {
-        *self == EMC2R::TOGGLE_THE_CORRESPON
+    pub fn is_toggle(&self) -> bool {
+        *self == EMC2R::TOGGLE
     }
 }
 #[doc = "Possible values of the field `EMC3`"]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum EMC3R {
     #[doc = "Do Nothing."]
-    DO_NOTHING_,
+    DO_NOTHING,
     #[doc = "Clear the corresponding External Match bit/output to 0 (CT32Bi_MAT3 pin is LOW if pinned out)."]
-    CLEAR_THE_CORRESPOND,
+    CLEAR,
     #[doc = "Set the corresponding External Match bit/output to 1 (CT32Bi_MAT3 pin is HIGH if pinned out)."]
-    SET_THE_CORRESPONDIN,
+    SET,
     #[doc = "Toggle the corresponding External Match bit/output."]
-    TOGGLE_THE_CORRESPON,
+    TOGGLE,
 }
 impl EMC3R {
     #[doc = r" Value of the field as raw bits"]
     #[inline]
     pub fn bits(&self) -> u8 {
         match *self {
-            EMC3R::DO_NOTHING_ => 0,
-            EMC3R::CLEAR_THE_CORRESPOND => 1,
-            EMC3R::SET_THE_CORRESPONDIN => 2,
-            EMC3R::TOGGLE_THE_CORRESPON => 3,
+            EMC3R::DO_NOTHING => 0,
+            EMC3R::CLEAR => 1,
+            EMC3R::SET => 2,
+            EMC3R::TOGGLE => 3,
         }
     }
     #[allow(missing_docs)]
@@ -322,32 +322,32 @@ impl EMC3R {
     #[inline]
     pub fn _from(value: u8) -> EMC3R {
         match value {
-            0 => EMC3R::DO_NOTHING_,
-            1 => EMC3R::CLEAR_THE_CORRESPOND,
-            2 => EMC3R::SET_THE_CORRESPONDIN,
-            3 => EMC3R::TOGGLE_THE_CORRESPON,
+            0 => EMC3R::DO_NOTHING,
+            1 => EMC3R::CLEAR,
+            2 => EMC3R::SET,
+            3 => EMC3R::TOGGLE,
             _ => unreachable!(),
         }
     }
-    #[doc = "Checks if the value of the field is `DO_NOTHING_`"]
+    #[doc = "Checks if the value of the field is `DO_NOTHING`"]
     #[inline]
-    pub fn is_do_nothing_(&self) -> bool {
-        *self == EMC3R::DO_NOTHING_
+    pub fn is_do_nothing(&self) -> bool {
+        *self == EMC3R::DO_NOTHING
     }
-    #[doc = "Checks if the value of the field is `CLEAR_THE_CORRESPOND`"]
+    #[doc = "Checks if the value of the field is `CLEAR`"]
     #[inline]
-    pub fn is_clear_the_correspond(&self) -> bool {
-        *self == EMC3R::CLEAR_THE_CORRESPOND
+    pub fn is_clear(&self) -> bool {
+        *self == EMC3R::CLEAR
     }
-    #[doc = "Checks if the value of the field is `SET_THE_CORRESPONDIN`"]
+    #[doc = "Checks if the value of the field is `SET`"]
     #[inline]
-    pub fn is_set_the_correspondin(&self) -> bool {
-        *self == EMC3R::SET_THE_CORRESPONDIN
+    pub fn is_set(&self) -> bool {
+        *self == EMC3R::SET
     }
-    #[doc = "Checks if the value of the field is `TOGGLE_THE_CORRESPON`"]
+    #[doc = "Checks if the value of the field is `TOGGLE`"]
     #[inline]
-    pub fn is_toggle_the_correspon(&self) -> bool {
-        *self == EMC3R::TOGGLE_THE_CORRESPON
+    pub fn is_toggle(&self) -> bool {
+        *self == EMC3R::TOGGLE
     }
 }
 #[doc = r" Proxy"]
@@ -445,13 +445,13 @@ impl<'a> _EM3W<'a> {
 #[doc = "Values that can be written to the field `EMC0`"]
 pub enum EMC0W {
     #[doc = "Do Nothing."]
-    DO_NOTHING_,
+    DO_NOTHING,
     #[doc = "Clear the corresponding External Match bit/output to 0 (CT32Bi_MAT0 pin is LOW if pinned out)."]
-    CLEAR_THE_CORRESPOND,
+    CLEAR,
     #[doc = "Set the corresponding External Match bit/output to 1 (CT32Bi_MAT0 pin is HIGH if pinned out)."]
-    SET_THE_CORRESPONDIN,
+    SET,
     #[doc = "Toggle the corresponding External Match bit/output."]
-    TOGGLE_THE_CORRESPON,
+    TOGGLE,
 }
 impl EMC0W {
     #[allow(missing_docs)]
@@ -459,10 +459,10 @@ impl EMC0W {
     #[inline]
     pub fn _bits(&self) -> u8 {
         match *self {
-            EMC0W::DO_NOTHING_ => 0,
-            EMC0W::CLEAR_THE_CORRESPOND => 1,
-            EMC0W::SET_THE_CORRESPONDIN => 2,
-            EMC0W::TOGGLE_THE_CORRESPON => 3,
+            EMC0W::DO_NOTHING => 0,
+            EMC0W::CLEAR => 1,
+            EMC0W::SET => 2,
+            EMC0W::TOGGLE => 3,
         }
     }
 }
@@ -480,23 +480,23 @@ impl<'a> _EMC0W<'a> {
     }
     #[doc = "Do Nothing."]
     #[inline]
-    pub fn do_nothing_(self) -> &'a mut W {
-        self.variant(EMC0W::DO_NOTHING_)
+    pub fn do_nothing(self) -> &'a mut W {
+        self.variant(EMC0W::DO_NOTHING)
     }
     #[doc = "Clear the corresponding External Match bit/output to 0 (CT32Bi_MAT0 pin is LOW if pinned out)."]
     #[inline]
-    pub fn clear_the_correspond(self) -> &'a mut W {
-        self.variant(EMC0W::CLEAR_THE_CORRESPOND)
+    pub fn clear(self) -> &'a mut W {
+        self.variant(EMC0W::CLEAR)
     }
     #[doc = "Set the corresponding External Match bit/output to 1 (CT32Bi_MAT0 pin is HIGH if pinned out)."]
     #[inline]
-    pub fn set_the_correspondin(self) -> &'a mut W {
-        self.variant(EMC0W::SET_THE_CORRESPONDIN)
+    pub fn set(self) -> &'a mut W {
+        self.variant(EMC0W::SET)
     }
     #[doc = "Toggle the corresponding External Match bit/output."]
     #[inline]
-    pub fn toggle_the_correspon(self) -> &'a mut W {
-        self.variant(EMC0W::TOGGLE_THE_CORRESPON)
+    pub fn toggle(self) -> &'a mut W {
+        self.variant(EMC0W::TOGGLE)
     }
     #[doc = r" Writes raw bits to the field"]
     #[inline]
@@ -511,13 +511,13 @@ impl<'a> _EMC0W<'a> {
 #[doc = "Values that can be written to the field `EMC1`"]
 pub enum EMC1W {
     #[doc = "Do Nothing."]
-    DO_NOTHING_,
+    DO_NOTHING,
     #[doc = "Clear the corresponding External Match bit/output to 0 (CT32Bi_MAT1 pin is LOW if pinned out)."]
-    CLEAR_THE_CORRESPOND,
+    CLEAR,
     #[doc = "Set the corresponding External Match bit/output to 1 (CT32Bi_MAT1 pin is HIGH if pinned out)."]
-    SET_THE_CORRESPONDIN,
+    SET,
     #[doc = "Toggle the corresponding External Match bit/output."]
-    TOGGLE_THE_CORRESPON,
+    TOGGLE,
 }
 impl EMC1W {
     #[allow(missing_docs)]
@@ -525,10 +525,10 @@ impl EMC1W {
     #[inline]
     pub fn _bits(&self) -> u8 {
         match *self {
-            EMC1W::DO_NOTHING_ => 0,
-            EMC1W::CLEAR_THE_CORRESPOND => 1,
-            EMC1W::SET_THE_CORRESPONDIN => 2,
-            EMC1W::TOGGLE_THE_CORRESPON => 3,
+            EMC1W::DO_NOTHING => 0,
+            EMC1W::CLEAR => 1,
+            EMC1W::SET => 2,
+            EMC1W::TOGGLE => 3,
         }
     }
 }
@@ -546,23 +546,23 @@ impl<'a> _EMC1W<'a> {
     }
     #[doc = "Do Nothing."]
     #[inline]
-    pub fn do_nothing_(self) -> &'a mut W {
-        self.variant(EMC1W::DO_NOTHING_)
+    pub fn do_nothing(self) -> &'a mut W {
+        self.variant(EMC1W::DO_NOTHING)
     }
     #[doc = "Clear the corresponding External Match bit/output to 0 (CT32Bi_MAT1 pin is LOW if pinned out)."]
     #[inline]
-    pub fn clear_the_correspond(self) -> &'a mut W {
-        self.variant(EMC1W::CLEAR_THE_CORRESPOND)
+    pub fn clear(self) -> &'a mut W {
+        self.variant(EMC1W::CLEAR)
     }
     #[doc = "Set the corresponding External Match bit/output to 1 (CT32Bi_MAT1 pin is HIGH if pinned out)."]
     #[inline]
-    pub fn set_the_correspondin(self) -> &'a mut W {
-        self.variant(EMC1W::SET_THE_CORRESPONDIN)
+    pub fn set(self) -> &'a mut W {
+        self.variant(EMC1W::SET)
     }
     #[doc = "Toggle the corresponding External Match bit/output."]
     #[inline]
-    pub fn toggle_the_correspon(self) -> &'a mut W {
-        self.variant(EMC1W::TOGGLE_THE_CORRESPON)
+    pub fn toggle(self) -> &'a mut W {
+        self.variant(EMC1W::TOGGLE)
     }
     #[doc = r" Writes raw bits to the field"]
     #[inline]
@@ -577,13 +577,13 @@ impl<'a> _EMC1W<'a> {
 #[doc = "Values that can be written to the field `EMC2`"]
 pub enum EMC2W {
     #[doc = "Do Nothing."]
-    DO_NOTHING_,
+    DO_NOTHING,
     #[doc = "Clear the corresponding External Match bit/output to 0 (CT32Bi_MAT2 pin is LOW if pinned out)."]
-    CLEAR_THE_CORRESPOND,
+    CLEAR,
     #[doc = "Set the corresponding External Match bit/output to 1 (CT32Bi_MAT2 pin is HIGH if pinned out)."]
-    SET_THE_CORRESPONDIN,
+    SET,
     #[doc = "Toggle the corresponding External Match bit/output."]
-    TOGGLE_THE_CORRESPON,
+    TOGGLE,
 }
 impl EMC2W {
     #[allow(missing_docs)]
@@ -591,10 +591,10 @@ impl EMC2W {
     #[inline]
     pub fn _bits(&self) -> u8 {
         match *self {
-            EMC2W::DO_NOTHING_ => 0,
-            EMC2W::CLEAR_THE_CORRESPOND => 1,
-            EMC2W::SET_THE_CORRESPONDIN => 2,
-            EMC2W::TOGGLE_THE_CORRESPON => 3,
+            EMC2W::DO_NOTHING => 0,
+            EMC2W::CLEAR => 1,
+            EMC2W::SET => 2,
+            EMC2W::TOGGLE => 3,
         }
     }
 }
@@ -612,23 +612,23 @@ impl<'a> _EMC2W<'a> {
     }
     #[doc = "Do Nothing."]
     #[inline]
-    pub fn do_nothing_(self) -> &'a mut W {
-        self.variant(EMC2W::DO_NOTHING_)
+    pub fn do_nothing(self) -> &'a mut W {
+        self.variant(EMC2W::DO_NOTHING)
     }
     #[doc = "Clear the corresponding External Match bit/output to 0 (CT32Bi_MAT2 pin is LOW if pinned out)."]
     #[inline]
-    pub fn clear_the_correspond(self) -> &'a mut W {
-        self.variant(EMC2W::CLEAR_THE_CORRESPOND)
+    pub fn clear(self) -> &'a mut W {
+        self.variant(EMC2W::CLEAR)
     }
     #[doc = "Set the corresponding External Match bit/output to 1 (CT32Bi_MAT2 pin is HIGH if pinned out)."]
     #[inline]
-    pub fn set_the_correspondin(self) -> &'a mut W {
-        self.variant(EMC2W::SET_THE_CORRESPONDIN)
+    pub fn set(self) -> &'a mut W {
+        self.variant(EMC2W::SET)
     }
     #[doc = "Toggle the corresponding External Match bit/output."]
     #[inline]
-    pub fn toggle_the_correspon(self) -> &'a mut W {
-        self.variant(EMC2W::TOGGLE_THE_CORRESPON)
+    pub fn toggle(self) -> &'a mut W {
+        self.variant(EMC2W::TOGGLE)
     }
     #[doc = r" Writes raw bits to the field"]
     #[inline]
@@ -643,13 +643,13 @@ impl<'a> _EMC2W<'a> {
 #[doc = "Values that can be written to the field `EMC3`"]
 pub enum EMC3W {
     #[doc = "Do Nothing."]
-    DO_NOTHING_,
+    DO_NOTHING,
     #[doc = "Clear the corresponding External Match bit/output to 0 (CT32Bi_MAT3 pin is LOW if pinned out)."]
-    CLEAR_THE_CORRESPOND,
+    CLEAR,
     #[doc = "Set the corresponding External Match bit/output to 1 (CT32Bi_MAT3 pin is HIGH if pinned out)."]
-    SET_THE_CORRESPONDIN,
+    SET,
     #[doc = "Toggle the corresponding External Match bit/output."]
-    TOGGLE_THE_CORRESPON,
+    TOGGLE,
 }
 impl EMC3W {
     #[allow(missing_docs)]
@@ -657,10 +657,10 @@ impl EMC3W {
     #[inline]
     pub fn _bits(&self) -> u8 {
         match *self {
-            EMC3W::DO_NOTHING_ => 0,
-            EMC3W::CLEAR_THE_CORRESPOND => 1,
-            EMC3W::SET_THE_CORRESPONDIN => 2,
-            EMC3W::TOGGLE_THE_CORRESPON => 3,
+            EMC3W::DO_NOTHING => 0,
+            EMC3W::CLEAR => 1,
+            EMC3W::SET => 2,
+            EMC3W::TOGGLE => 3,
         }
     }
 }
@@ -678,23 +678,23 @@ impl<'a> _EMC3W<'a> {
     }
     #[doc = "Do Nothing."]
     #[inline]
-    pub fn do_nothing_(self) -> &'a mut W {
-        self.variant(EMC3W::DO_NOTHING_)
+    pub fn do_nothing(self) -> &'a mut W {
+        self.variant(EMC3W::DO_NOTHING)
     }
     #[doc = "Clear the corresponding External Match bit/output to 0 (CT32Bi_MAT3 pin is LOW if pinned out)."]
     #[inline]
-    pub fn clear_the_correspond(self) -> &'a mut W {
-        self.variant(EMC3W::CLEAR_THE_CORRESPOND)
+    pub fn clear(self) -> &'a mut W {
+        self.variant(EMC3W::CLEAR)
     }
     #[doc = "Set the corresponding External Match bit/output to 1 (CT32Bi_MAT3 pin is HIGH if pinned out)."]
     #[inline]
-    pub fn set_the_correspondin(self) -> &'a mut W {
-        self.variant(EMC3W::SET_THE_CORRESPONDIN)
+    pub fn set(self) -> &'a mut W {
+        self.variant(EMC3W::SET)
     }
     #[doc = "Toggle the corresponding External Match bit/output."]
     #[inline]
-    pub fn toggle_the_correspon(self) -> &'a mut W {
-        self.variant(EMC3W::TOGGLE_THE_CORRESPON)
+    pub fn toggle(self) -> &'a mut W {
+        self.variant(EMC3W::TOGGLE)
     }
     #[doc = r" Writes raw bits to the field"]
     #[inline]

--- a/lpc11uxx/src/ct32b0/pwmc.rs
+++ b/lpc11uxx/src/ct32b0/pwmc.rs
@@ -46,9 +46,9 @@ impl super::PWMC {
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum PWMEN0R {
     #[doc = "CT32Bn_MAT0 is controlled by EM0."]
-    CT32BN_MAT0_IS_CONTR,
+    EM0,
     #[doc = "PWM mode is enabled for CT32Bn_MAT0."]
-    PWM_MODE_IS_ENABLED_,
+    ENABLED,
 }
 impl PWMEN0R {
     #[doc = r" Returns `true` if the bit is clear (0)"]
@@ -65,8 +65,8 @@ impl PWMEN0R {
     #[inline]
     pub fn bit(&self) -> bool {
         match *self {
-            PWMEN0R::CT32BN_MAT0_IS_CONTR => false,
-            PWMEN0R::PWM_MODE_IS_ENABLED_ => true,
+            PWMEN0R::EM0 => false,
+            PWMEN0R::ENABLED => true,
         }
     }
     #[allow(missing_docs)]
@@ -74,28 +74,28 @@ impl PWMEN0R {
     #[inline]
     pub fn _from(value: bool) -> PWMEN0R {
         match value {
-            false => PWMEN0R::CT32BN_MAT0_IS_CONTR,
-            true => PWMEN0R::PWM_MODE_IS_ENABLED_,
+            false => PWMEN0R::EM0,
+            true => PWMEN0R::ENABLED,
         }
     }
-    #[doc = "Checks if the value of the field is `CT32BN_MAT0_IS_CONTR`"]
+    #[doc = "Checks if the value of the field is `EM0`"]
     #[inline]
-    pub fn is_ct32bn_mat0_is_contr(&self) -> bool {
-        *self == PWMEN0R::CT32BN_MAT0_IS_CONTR
+    pub fn is_em0(&self) -> bool {
+        *self == PWMEN0R::EM0
     }
-    #[doc = "Checks if the value of the field is `PWM_MODE_IS_ENABLED_`"]
+    #[doc = "Checks if the value of the field is `ENABLED`"]
     #[inline]
-    pub fn is_pwm_mode_is_enabled_(&self) -> bool {
-        *self == PWMEN0R::PWM_MODE_IS_ENABLED_
+    pub fn is_enabled(&self) -> bool {
+        *self == PWMEN0R::ENABLED
     }
 }
 #[doc = "Possible values of the field `PWMEN1`"]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum PWMEN1R {
     #[doc = "CT32Bn_MAT01 is controlled by EM1."]
-    CT32BN_MAT01_IS_CONT,
+    EM1,
     #[doc = "PWM mode is enabled for CT32Bn_MAT1."]
-    PWM_MODE_IS_ENABLED_,
+    ENABLED,
 }
 impl PWMEN1R {
     #[doc = r" Returns `true` if the bit is clear (0)"]
@@ -112,8 +112,8 @@ impl PWMEN1R {
     #[inline]
     pub fn bit(&self) -> bool {
         match *self {
-            PWMEN1R::CT32BN_MAT01_IS_CONT => false,
-            PWMEN1R::PWM_MODE_IS_ENABLED_ => true,
+            PWMEN1R::EM1 => false,
+            PWMEN1R::ENABLED => true,
         }
     }
     #[allow(missing_docs)]
@@ -121,28 +121,28 @@ impl PWMEN1R {
     #[inline]
     pub fn _from(value: bool) -> PWMEN1R {
         match value {
-            false => PWMEN1R::CT32BN_MAT01_IS_CONT,
-            true => PWMEN1R::PWM_MODE_IS_ENABLED_,
+            false => PWMEN1R::EM1,
+            true => PWMEN1R::ENABLED,
         }
     }
-    #[doc = "Checks if the value of the field is `CT32BN_MAT01_IS_CONT`"]
+    #[doc = "Checks if the value of the field is `EM1`"]
     #[inline]
-    pub fn is_ct32bn_mat01_is_cont(&self) -> bool {
-        *self == PWMEN1R::CT32BN_MAT01_IS_CONT
+    pub fn is_em1(&self) -> bool {
+        *self == PWMEN1R::EM1
     }
-    #[doc = "Checks if the value of the field is `PWM_MODE_IS_ENABLED_`"]
+    #[doc = "Checks if the value of the field is `ENABLED`"]
     #[inline]
-    pub fn is_pwm_mode_is_enabled_(&self) -> bool {
-        *self == PWMEN1R::PWM_MODE_IS_ENABLED_
+    pub fn is_enabled(&self) -> bool {
+        *self == PWMEN1R::ENABLED
     }
 }
 #[doc = "Possible values of the field `PWMEN2`"]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum PWMEN2R {
     #[doc = "CT32Bn_MAT2 is controlled by EM2."]
-    CT32BN_MAT2_IS_CONTR,
+    EM2,
     #[doc = "PWM mode is enabled for CT32Bn_MAT2."]
-    PWM_MODE_IS_ENABLED_,
+    ENABLED,
 }
 impl PWMEN2R {
     #[doc = r" Returns `true` if the bit is clear (0)"]
@@ -159,8 +159,8 @@ impl PWMEN2R {
     #[inline]
     pub fn bit(&self) -> bool {
         match *self {
-            PWMEN2R::CT32BN_MAT2_IS_CONTR => false,
-            PWMEN2R::PWM_MODE_IS_ENABLED_ => true,
+            PWMEN2R::EM2 => false,
+            PWMEN2R::ENABLED => true,
         }
     }
     #[allow(missing_docs)]
@@ -168,28 +168,28 @@ impl PWMEN2R {
     #[inline]
     pub fn _from(value: bool) -> PWMEN2R {
         match value {
-            false => PWMEN2R::CT32BN_MAT2_IS_CONTR,
-            true => PWMEN2R::PWM_MODE_IS_ENABLED_,
+            false => PWMEN2R::EM2,
+            true => PWMEN2R::ENABLED,
         }
     }
-    #[doc = "Checks if the value of the field is `CT32BN_MAT2_IS_CONTR`"]
+    #[doc = "Checks if the value of the field is `EM2`"]
     #[inline]
-    pub fn is_ct32bn_mat2_is_contr(&self) -> bool {
-        *self == PWMEN2R::CT32BN_MAT2_IS_CONTR
+    pub fn is_em2(&self) -> bool {
+        *self == PWMEN2R::EM2
     }
-    #[doc = "Checks if the value of the field is `PWM_MODE_IS_ENABLED_`"]
+    #[doc = "Checks if the value of the field is `ENABLED`"]
     #[inline]
-    pub fn is_pwm_mode_is_enabled_(&self) -> bool {
-        *self == PWMEN2R::PWM_MODE_IS_ENABLED_
+    pub fn is_enabled(&self) -> bool {
+        *self == PWMEN2R::ENABLED
     }
 }
 #[doc = "Possible values of the field `PWMEN3`"]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum PWMEN3R {
     #[doc = "CT32Bn_MAT3 is controlled by EM3."]
-    CT32BN_MAT3_IS_CONTR,
+    EM3,
     #[doc = "PWM mode is enabled for CT132Bn_MAT3."]
-    PWM_MODE_IS_ENABLED_,
+    ENABLED,
 }
 impl PWMEN3R {
     #[doc = r" Returns `true` if the bit is clear (0)"]
@@ -206,8 +206,8 @@ impl PWMEN3R {
     #[inline]
     pub fn bit(&self) -> bool {
         match *self {
-            PWMEN3R::CT32BN_MAT3_IS_CONTR => false,
-            PWMEN3R::PWM_MODE_IS_ENABLED_ => true,
+            PWMEN3R::EM3 => false,
+            PWMEN3R::ENABLED => true,
         }
     }
     #[allow(missing_docs)]
@@ -215,27 +215,27 @@ impl PWMEN3R {
     #[inline]
     pub fn _from(value: bool) -> PWMEN3R {
         match value {
-            false => PWMEN3R::CT32BN_MAT3_IS_CONTR,
-            true => PWMEN3R::PWM_MODE_IS_ENABLED_,
+            false => PWMEN3R::EM3,
+            true => PWMEN3R::ENABLED,
         }
     }
-    #[doc = "Checks if the value of the field is `CT32BN_MAT3_IS_CONTR`"]
+    #[doc = "Checks if the value of the field is `EM3`"]
     #[inline]
-    pub fn is_ct32bn_mat3_is_contr(&self) -> bool {
-        *self == PWMEN3R::CT32BN_MAT3_IS_CONTR
+    pub fn is_em3(&self) -> bool {
+        *self == PWMEN3R::EM3
     }
-    #[doc = "Checks if the value of the field is `PWM_MODE_IS_ENABLED_`"]
+    #[doc = "Checks if the value of the field is `ENABLED`"]
     #[inline]
-    pub fn is_pwm_mode_is_enabled_(&self) -> bool {
-        *self == PWMEN3R::PWM_MODE_IS_ENABLED_
+    pub fn is_enabled(&self) -> bool {
+        *self == PWMEN3R::ENABLED
     }
 }
 #[doc = "Values that can be written to the field `PWMEN0`"]
 pub enum PWMEN0W {
     #[doc = "CT32Bn_MAT0 is controlled by EM0."]
-    CT32BN_MAT0_IS_CONTR,
+    EM0,
     #[doc = "PWM mode is enabled for CT32Bn_MAT0."]
-    PWM_MODE_IS_ENABLED_,
+    ENABLED,
 }
 impl PWMEN0W {
     #[allow(missing_docs)]
@@ -243,8 +243,8 @@ impl PWMEN0W {
     #[inline]
     pub fn _bits(&self) -> bool {
         match *self {
-            PWMEN0W::CT32BN_MAT0_IS_CONTR => false,
-            PWMEN0W::PWM_MODE_IS_ENABLED_ => true,
+            PWMEN0W::EM0 => false,
+            PWMEN0W::ENABLED => true,
         }
     }
 }
@@ -262,13 +262,13 @@ impl<'a> _PWMEN0W<'a> {
     }
     #[doc = "CT32Bn_MAT0 is controlled by EM0."]
     #[inline]
-    pub fn ct32bn_mat0_is_contr(self) -> &'a mut W {
-        self.variant(PWMEN0W::CT32BN_MAT0_IS_CONTR)
+    pub fn em0(self) -> &'a mut W {
+        self.variant(PWMEN0W::EM0)
     }
     #[doc = "PWM mode is enabled for CT32Bn_MAT0."]
     #[inline]
-    pub fn pwm_mode_is_enabled_(self) -> &'a mut W {
-        self.variant(PWMEN0W::PWM_MODE_IS_ENABLED_)
+    pub fn enabled(self) -> &'a mut W {
+        self.variant(PWMEN0W::ENABLED)
     }
     #[doc = r" Sets the field bit"]
     pub fn set_bit(self) -> &'a mut W {
@@ -291,9 +291,9 @@ impl<'a> _PWMEN0W<'a> {
 #[doc = "Values that can be written to the field `PWMEN1`"]
 pub enum PWMEN1W {
     #[doc = "CT32Bn_MAT01 is controlled by EM1."]
-    CT32BN_MAT01_IS_CONT,
+    EM1,
     #[doc = "PWM mode is enabled for CT32Bn_MAT1."]
-    PWM_MODE_IS_ENABLED_,
+    ENABLED,
 }
 impl PWMEN1W {
     #[allow(missing_docs)]
@@ -301,8 +301,8 @@ impl PWMEN1W {
     #[inline]
     pub fn _bits(&self) -> bool {
         match *self {
-            PWMEN1W::CT32BN_MAT01_IS_CONT => false,
-            PWMEN1W::PWM_MODE_IS_ENABLED_ => true,
+            PWMEN1W::EM1 => false,
+            PWMEN1W::ENABLED => true,
         }
     }
 }
@@ -320,13 +320,13 @@ impl<'a> _PWMEN1W<'a> {
     }
     #[doc = "CT32Bn_MAT01 is controlled by EM1."]
     #[inline]
-    pub fn ct32bn_mat01_is_cont(self) -> &'a mut W {
-        self.variant(PWMEN1W::CT32BN_MAT01_IS_CONT)
+    pub fn em1(self) -> &'a mut W {
+        self.variant(PWMEN1W::EM1)
     }
     #[doc = "PWM mode is enabled for CT32Bn_MAT1."]
     #[inline]
-    pub fn pwm_mode_is_enabled_(self) -> &'a mut W {
-        self.variant(PWMEN1W::PWM_MODE_IS_ENABLED_)
+    pub fn enabled(self) -> &'a mut W {
+        self.variant(PWMEN1W::ENABLED)
     }
     #[doc = r" Sets the field bit"]
     pub fn set_bit(self) -> &'a mut W {
@@ -349,9 +349,9 @@ impl<'a> _PWMEN1W<'a> {
 #[doc = "Values that can be written to the field `PWMEN2`"]
 pub enum PWMEN2W {
     #[doc = "CT32Bn_MAT2 is controlled by EM2."]
-    CT32BN_MAT2_IS_CONTR,
+    EM2,
     #[doc = "PWM mode is enabled for CT32Bn_MAT2."]
-    PWM_MODE_IS_ENABLED_,
+    ENABLED,
 }
 impl PWMEN2W {
     #[allow(missing_docs)]
@@ -359,8 +359,8 @@ impl PWMEN2W {
     #[inline]
     pub fn _bits(&self) -> bool {
         match *self {
-            PWMEN2W::CT32BN_MAT2_IS_CONTR => false,
-            PWMEN2W::PWM_MODE_IS_ENABLED_ => true,
+            PWMEN2W::EM2 => false,
+            PWMEN2W::ENABLED => true,
         }
     }
 }
@@ -378,13 +378,13 @@ impl<'a> _PWMEN2W<'a> {
     }
     #[doc = "CT32Bn_MAT2 is controlled by EM2."]
     #[inline]
-    pub fn ct32bn_mat2_is_contr(self) -> &'a mut W {
-        self.variant(PWMEN2W::CT32BN_MAT2_IS_CONTR)
+    pub fn em2(self) -> &'a mut W {
+        self.variant(PWMEN2W::EM2)
     }
     #[doc = "PWM mode is enabled for CT32Bn_MAT2."]
     #[inline]
-    pub fn pwm_mode_is_enabled_(self) -> &'a mut W {
-        self.variant(PWMEN2W::PWM_MODE_IS_ENABLED_)
+    pub fn enabled(self) -> &'a mut W {
+        self.variant(PWMEN2W::ENABLED)
     }
     #[doc = r" Sets the field bit"]
     pub fn set_bit(self) -> &'a mut W {
@@ -407,9 +407,9 @@ impl<'a> _PWMEN2W<'a> {
 #[doc = "Values that can be written to the field `PWMEN3`"]
 pub enum PWMEN3W {
     #[doc = "CT32Bn_MAT3 is controlled by EM3."]
-    CT32BN_MAT3_IS_CONTR,
+    EM3,
     #[doc = "PWM mode is enabled for CT132Bn_MAT3."]
-    PWM_MODE_IS_ENABLED_,
+    ENABLED,
 }
 impl PWMEN3W {
     #[allow(missing_docs)]
@@ -417,8 +417,8 @@ impl PWMEN3W {
     #[inline]
     pub fn _bits(&self) -> bool {
         match *self {
-            PWMEN3W::CT32BN_MAT3_IS_CONTR => false,
-            PWMEN3W::PWM_MODE_IS_ENABLED_ => true,
+            PWMEN3W::EM3 => false,
+            PWMEN3W::ENABLED => true,
         }
     }
 }
@@ -436,13 +436,13 @@ impl<'a> _PWMEN3W<'a> {
     }
     #[doc = "CT32Bn_MAT3 is controlled by EM3."]
     #[inline]
-    pub fn ct32bn_mat3_is_contr(self) -> &'a mut W {
-        self.variant(PWMEN3W::CT32BN_MAT3_IS_CONTR)
+    pub fn em3(self) -> &'a mut W {
+        self.variant(PWMEN3W::EM3)
     }
     #[doc = "PWM mode is enabled for CT132Bn_MAT3."]
     #[inline]
-    pub fn pwm_mode_is_enabled_(self) -> &'a mut W {
-        self.variant(PWMEN3W::PWM_MODE_IS_ENABLED_)
+    pub fn enabled(self) -> &'a mut W {
+        self.variant(PWMEN3W::ENABLED)
     }
     #[doc = r" Sets the field bit"]
     pub fn set_bit(self) -> &'a mut W {

--- a/lpc11uxx/src/ct32b0/tcr.rs
+++ b/lpc11uxx/src/ct32b0/tcr.rs
@@ -93,9 +93,9 @@ impl CENR {
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum CRSTR {
     #[doc = "Do nothing."]
-    DO_NOTHING_,
+    DO_NOTHING,
     #[doc = "The Timer Counter and the Prescale Counter are synchronously reset on the next positive edge of PCLK. The counters remain reset until TCR\\[1\\] is returned to zero."]
-    THE_TIMER_COUNTER_AN,
+    RESET,
 }
 impl CRSTR {
     #[doc = r" Returns `true` if the bit is clear (0)"]
@@ -112,8 +112,8 @@ impl CRSTR {
     #[inline]
     pub fn bit(&self) -> bool {
         match *self {
-            CRSTR::DO_NOTHING_ => false,
-            CRSTR::THE_TIMER_COUNTER_AN => true,
+            CRSTR::DO_NOTHING => false,
+            CRSTR::RESET => true,
         }
     }
     #[allow(missing_docs)]
@@ -121,19 +121,19 @@ impl CRSTR {
     #[inline]
     pub fn _from(value: bool) -> CRSTR {
         match value {
-            false => CRSTR::DO_NOTHING_,
-            true => CRSTR::THE_TIMER_COUNTER_AN,
+            false => CRSTR::DO_NOTHING,
+            true => CRSTR::RESET,
         }
     }
-    #[doc = "Checks if the value of the field is `DO_NOTHING_`"]
+    #[doc = "Checks if the value of the field is `DO_NOTHING`"]
     #[inline]
-    pub fn is_do_nothing_(&self) -> bool {
-        *self == CRSTR::DO_NOTHING_
+    pub fn is_do_nothing(&self) -> bool {
+        *self == CRSTR::DO_NOTHING
     }
-    #[doc = "Checks if the value of the field is `THE_TIMER_COUNTER_AN`"]
+    #[doc = "Checks if the value of the field is `RESET`"]
     #[inline]
-    pub fn is_the_timer_counter_an(&self) -> bool {
-        *self == CRSTR::THE_TIMER_COUNTER_AN
+    pub fn is_reset(&self) -> bool {
+        *self == CRSTR::RESET
     }
 }
 #[doc = "Values that can be written to the field `CEN`"]
@@ -197,9 +197,9 @@ impl<'a> _CENW<'a> {
 #[doc = "Values that can be written to the field `CRST`"]
 pub enum CRSTW {
     #[doc = "Do nothing."]
-    DO_NOTHING_,
+    DO_NOTHING,
     #[doc = "The Timer Counter and the Prescale Counter are synchronously reset on the next positive edge of PCLK. The counters remain reset until TCR\\[1\\] is returned to zero."]
-    THE_TIMER_COUNTER_AN,
+    RESET,
 }
 impl CRSTW {
     #[allow(missing_docs)]
@@ -207,8 +207,8 @@ impl CRSTW {
     #[inline]
     pub fn _bits(&self) -> bool {
         match *self {
-            CRSTW::DO_NOTHING_ => false,
-            CRSTW::THE_TIMER_COUNTER_AN => true,
+            CRSTW::DO_NOTHING => false,
+            CRSTW::RESET => true,
         }
     }
 }
@@ -226,13 +226,13 @@ impl<'a> _CRSTW<'a> {
     }
     #[doc = "Do nothing."]
     #[inline]
-    pub fn do_nothing_(self) -> &'a mut W {
-        self.variant(CRSTW::DO_NOTHING_)
+    pub fn do_nothing(self) -> &'a mut W {
+        self.variant(CRSTW::DO_NOTHING)
     }
     #[doc = "The Timer Counter and the Prescale Counter are synchronously reset on the next positive edge of PCLK. The counters remain reset until TCR\\[1\\] is returned to zero."]
     #[inline]
-    pub fn the_timer_counter_an(self) -> &'a mut W {
-        self.variant(CRSTW::THE_TIMER_COUNTER_AN)
+    pub fn reset(self) -> &'a mut W {
+        self.variant(CRSTW::RESET)
     }
     #[doc = r" Sets the field bit"]
     pub fn set_bit(self) -> &'a mut W {

--- a/lpc11uxx/src/ct32b1/ccr.rs
+++ b/lpc11uxx/src/ct32b1/ccr.rs
@@ -46,9 +46,9 @@ impl super::CCR {
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum CAP0RER {
     #[doc = "Enabled."]
-    ENABLED_,
+    ENABLED,
     #[doc = "Disabled."]
-    DISABLED_,
+    DISABLED,
 }
 impl CAP0RER {
     #[doc = r" Returns `true` if the bit is clear (0)"]
@@ -65,8 +65,8 @@ impl CAP0RER {
     #[inline]
     pub fn bit(&self) -> bool {
         match *self {
-            CAP0RER::ENABLED_ => true,
-            CAP0RER::DISABLED_ => false,
+            CAP0RER::ENABLED => true,
+            CAP0RER::DISABLED => false,
         }
     }
     #[allow(missing_docs)]
@@ -74,28 +74,28 @@ impl CAP0RER {
     #[inline]
     pub fn _from(value: bool) -> CAP0RER {
         match value {
-            true => CAP0RER::ENABLED_,
-            false => CAP0RER::DISABLED_,
+            true => CAP0RER::ENABLED,
+            false => CAP0RER::DISABLED,
         }
     }
-    #[doc = "Checks if the value of the field is `ENABLED_`"]
+    #[doc = "Checks if the value of the field is `ENABLED`"]
     #[inline]
-    pub fn is_enabled_(&self) -> bool {
-        *self == CAP0RER::ENABLED_
+    pub fn is_enabled(&self) -> bool {
+        *self == CAP0RER::ENABLED
     }
-    #[doc = "Checks if the value of the field is `DISABLED_`"]
+    #[doc = "Checks if the value of the field is `DISABLED`"]
     #[inline]
-    pub fn is_disabled_(&self) -> bool {
-        *self == CAP0RER::DISABLED_
+    pub fn is_disabled(&self) -> bool {
+        *self == CAP0RER::DISABLED
     }
 }
 #[doc = "Possible values of the field `CAP0FE`"]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum CAP0FER {
     #[doc = "Enabled."]
-    ENABLED_,
+    ENABLED,
     #[doc = "Disabled."]
-    DISABLED_,
+    DISABLED,
 }
 impl CAP0FER {
     #[doc = r" Returns `true` if the bit is clear (0)"]
@@ -112,8 +112,8 @@ impl CAP0FER {
     #[inline]
     pub fn bit(&self) -> bool {
         match *self {
-            CAP0FER::ENABLED_ => true,
-            CAP0FER::DISABLED_ => false,
+            CAP0FER::ENABLED => true,
+            CAP0FER::DISABLED => false,
         }
     }
     #[allow(missing_docs)]
@@ -121,28 +121,28 @@ impl CAP0FER {
     #[inline]
     pub fn _from(value: bool) -> CAP0FER {
         match value {
-            true => CAP0FER::ENABLED_,
-            false => CAP0FER::DISABLED_,
+            true => CAP0FER::ENABLED,
+            false => CAP0FER::DISABLED,
         }
     }
-    #[doc = "Checks if the value of the field is `ENABLED_`"]
+    #[doc = "Checks if the value of the field is `ENABLED`"]
     #[inline]
-    pub fn is_enabled_(&self) -> bool {
-        *self == CAP0FER::ENABLED_
+    pub fn is_enabled(&self) -> bool {
+        *self == CAP0FER::ENABLED
     }
-    #[doc = "Checks if the value of the field is `DISABLED_`"]
+    #[doc = "Checks if the value of the field is `DISABLED`"]
     #[inline]
-    pub fn is_disabled_(&self) -> bool {
-        *self == CAP0FER::DISABLED_
+    pub fn is_disabled(&self) -> bool {
+        *self == CAP0FER::DISABLED
     }
 }
 #[doc = "Possible values of the field `CAP0I`"]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum CAP0IR {
     #[doc = "Enabled."]
-    ENABLED_,
+    ENABLED,
     #[doc = "Disabled."]
-    DISABLED_,
+    DISABLED,
 }
 impl CAP0IR {
     #[doc = r" Returns `true` if the bit is clear (0)"]
@@ -159,8 +159,8 @@ impl CAP0IR {
     #[inline]
     pub fn bit(&self) -> bool {
         match *self {
-            CAP0IR::ENABLED_ => true,
-            CAP0IR::DISABLED_ => false,
+            CAP0IR::ENABLED => true,
+            CAP0IR::DISABLED => false,
         }
     }
     #[allow(missing_docs)]
@@ -168,28 +168,28 @@ impl CAP0IR {
     #[inline]
     pub fn _from(value: bool) -> CAP0IR {
         match value {
-            true => CAP0IR::ENABLED_,
-            false => CAP0IR::DISABLED_,
+            true => CAP0IR::ENABLED,
+            false => CAP0IR::DISABLED,
         }
     }
-    #[doc = "Checks if the value of the field is `ENABLED_`"]
+    #[doc = "Checks if the value of the field is `ENABLED`"]
     #[inline]
-    pub fn is_enabled_(&self) -> bool {
-        *self == CAP0IR::ENABLED_
+    pub fn is_enabled(&self) -> bool {
+        *self == CAP0IR::ENABLED
     }
-    #[doc = "Checks if the value of the field is `DISABLED_`"]
+    #[doc = "Checks if the value of the field is `DISABLED`"]
     #[inline]
-    pub fn is_disabled_(&self) -> bool {
-        *self == CAP0IR::DISABLED_
+    pub fn is_disabled(&self) -> bool {
+        *self == CAP0IR::DISABLED
     }
 }
 #[doc = "Possible values of the field `CAP1RE`"]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum CAP1RER {
     #[doc = "Enabled."]
-    ENABLED_,
+    ENABLED,
     #[doc = "Disabled."]
-    DISABLED_,
+    DISABLED,
 }
 impl CAP1RER {
     #[doc = r" Returns `true` if the bit is clear (0)"]
@@ -206,8 +206,8 @@ impl CAP1RER {
     #[inline]
     pub fn bit(&self) -> bool {
         match *self {
-            CAP1RER::ENABLED_ => true,
-            CAP1RER::DISABLED_ => false,
+            CAP1RER::ENABLED => true,
+            CAP1RER::DISABLED => false,
         }
     }
     #[allow(missing_docs)]
@@ -215,28 +215,28 @@ impl CAP1RER {
     #[inline]
     pub fn _from(value: bool) -> CAP1RER {
         match value {
-            true => CAP1RER::ENABLED_,
-            false => CAP1RER::DISABLED_,
+            true => CAP1RER::ENABLED,
+            false => CAP1RER::DISABLED,
         }
     }
-    #[doc = "Checks if the value of the field is `ENABLED_`"]
+    #[doc = "Checks if the value of the field is `ENABLED`"]
     #[inline]
-    pub fn is_enabled_(&self) -> bool {
-        *self == CAP1RER::ENABLED_
+    pub fn is_enabled(&self) -> bool {
+        *self == CAP1RER::ENABLED
     }
-    #[doc = "Checks if the value of the field is `DISABLED_`"]
+    #[doc = "Checks if the value of the field is `DISABLED`"]
     #[inline]
-    pub fn is_disabled_(&self) -> bool {
-        *self == CAP1RER::DISABLED_
+    pub fn is_disabled(&self) -> bool {
+        *self == CAP1RER::DISABLED
     }
 }
 #[doc = "Possible values of the field `CAP1FE`"]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum CAP1FER {
     #[doc = "Enabled."]
-    ENABLED_,
+    ENABLED,
     #[doc = "Disabled."]
-    DISABLED_,
+    DISABLED,
 }
 impl CAP1FER {
     #[doc = r" Returns `true` if the bit is clear (0)"]
@@ -253,8 +253,8 @@ impl CAP1FER {
     #[inline]
     pub fn bit(&self) -> bool {
         match *self {
-            CAP1FER::ENABLED_ => true,
-            CAP1FER::DISABLED_ => false,
+            CAP1FER::ENABLED => true,
+            CAP1FER::DISABLED => false,
         }
     }
     #[allow(missing_docs)]
@@ -262,28 +262,28 @@ impl CAP1FER {
     #[inline]
     pub fn _from(value: bool) -> CAP1FER {
         match value {
-            true => CAP1FER::ENABLED_,
-            false => CAP1FER::DISABLED_,
+            true => CAP1FER::ENABLED,
+            false => CAP1FER::DISABLED,
         }
     }
-    #[doc = "Checks if the value of the field is `ENABLED_`"]
+    #[doc = "Checks if the value of the field is `ENABLED`"]
     #[inline]
-    pub fn is_enabled_(&self) -> bool {
-        *self == CAP1FER::ENABLED_
+    pub fn is_enabled(&self) -> bool {
+        *self == CAP1FER::ENABLED
     }
-    #[doc = "Checks if the value of the field is `DISABLED_`"]
+    #[doc = "Checks if the value of the field is `DISABLED`"]
     #[inline]
-    pub fn is_disabled_(&self) -> bool {
-        *self == CAP1FER::DISABLED_
+    pub fn is_disabled(&self) -> bool {
+        *self == CAP1FER::DISABLED
     }
 }
 #[doc = "Possible values of the field `CAP1I`"]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum CAP1IR {
     #[doc = "Enabled."]
-    ENABLED_,
+    ENABLED,
     #[doc = "Disabled."]
-    DISABLED_,
+    DISABLED,
 }
 impl CAP1IR {
     #[doc = r" Returns `true` if the bit is clear (0)"]
@@ -300,8 +300,8 @@ impl CAP1IR {
     #[inline]
     pub fn bit(&self) -> bool {
         match *self {
-            CAP1IR::ENABLED_ => true,
-            CAP1IR::DISABLED_ => false,
+            CAP1IR::ENABLED => true,
+            CAP1IR::DISABLED => false,
         }
     }
     #[allow(missing_docs)]
@@ -309,27 +309,27 @@ impl CAP1IR {
     #[inline]
     pub fn _from(value: bool) -> CAP1IR {
         match value {
-            true => CAP1IR::ENABLED_,
-            false => CAP1IR::DISABLED_,
+            true => CAP1IR::ENABLED,
+            false => CAP1IR::DISABLED,
         }
     }
-    #[doc = "Checks if the value of the field is `ENABLED_`"]
+    #[doc = "Checks if the value of the field is `ENABLED`"]
     #[inline]
-    pub fn is_enabled_(&self) -> bool {
-        *self == CAP1IR::ENABLED_
+    pub fn is_enabled(&self) -> bool {
+        *self == CAP1IR::ENABLED
     }
-    #[doc = "Checks if the value of the field is `DISABLED_`"]
+    #[doc = "Checks if the value of the field is `DISABLED`"]
     #[inline]
-    pub fn is_disabled_(&self) -> bool {
-        *self == CAP1IR::DISABLED_
+    pub fn is_disabled(&self) -> bool {
+        *self == CAP1IR::DISABLED
     }
 }
 #[doc = "Values that can be written to the field `CAP0RE`"]
 pub enum CAP0REW {
     #[doc = "Enabled."]
-    ENABLED_,
+    ENABLED,
     #[doc = "Disabled."]
-    DISABLED_,
+    DISABLED,
 }
 impl CAP0REW {
     #[allow(missing_docs)]
@@ -337,8 +337,8 @@ impl CAP0REW {
     #[inline]
     pub fn _bits(&self) -> bool {
         match *self {
-            CAP0REW::ENABLED_ => true,
-            CAP0REW::DISABLED_ => false,
+            CAP0REW::ENABLED => true,
+            CAP0REW::DISABLED => false,
         }
     }
 }
@@ -356,13 +356,13 @@ impl<'a> _CAP0REW<'a> {
     }
     #[doc = "Enabled."]
     #[inline]
-    pub fn enabled_(self) -> &'a mut W {
-        self.variant(CAP0REW::ENABLED_)
+    pub fn enabled(self) -> &'a mut W {
+        self.variant(CAP0REW::ENABLED)
     }
     #[doc = "Disabled."]
     #[inline]
-    pub fn disabled_(self) -> &'a mut W {
-        self.variant(CAP0REW::DISABLED_)
+    pub fn disabled(self) -> &'a mut W {
+        self.variant(CAP0REW::DISABLED)
     }
     #[doc = r" Sets the field bit"]
     pub fn set_bit(self) -> &'a mut W {
@@ -385,9 +385,9 @@ impl<'a> _CAP0REW<'a> {
 #[doc = "Values that can be written to the field `CAP0FE`"]
 pub enum CAP0FEW {
     #[doc = "Enabled."]
-    ENABLED_,
+    ENABLED,
     #[doc = "Disabled."]
-    DISABLED_,
+    DISABLED,
 }
 impl CAP0FEW {
     #[allow(missing_docs)]
@@ -395,8 +395,8 @@ impl CAP0FEW {
     #[inline]
     pub fn _bits(&self) -> bool {
         match *self {
-            CAP0FEW::ENABLED_ => true,
-            CAP0FEW::DISABLED_ => false,
+            CAP0FEW::ENABLED => true,
+            CAP0FEW::DISABLED => false,
         }
     }
 }
@@ -414,13 +414,13 @@ impl<'a> _CAP0FEW<'a> {
     }
     #[doc = "Enabled."]
     #[inline]
-    pub fn enabled_(self) -> &'a mut W {
-        self.variant(CAP0FEW::ENABLED_)
+    pub fn enabled(self) -> &'a mut W {
+        self.variant(CAP0FEW::ENABLED)
     }
     #[doc = "Disabled."]
     #[inline]
-    pub fn disabled_(self) -> &'a mut W {
-        self.variant(CAP0FEW::DISABLED_)
+    pub fn disabled(self) -> &'a mut W {
+        self.variant(CAP0FEW::DISABLED)
     }
     #[doc = r" Sets the field bit"]
     pub fn set_bit(self) -> &'a mut W {
@@ -443,9 +443,9 @@ impl<'a> _CAP0FEW<'a> {
 #[doc = "Values that can be written to the field `CAP0I`"]
 pub enum CAP0IW {
     #[doc = "Enabled."]
-    ENABLED_,
+    ENABLED,
     #[doc = "Disabled."]
-    DISABLED_,
+    DISABLED,
 }
 impl CAP0IW {
     #[allow(missing_docs)]
@@ -453,8 +453,8 @@ impl CAP0IW {
     #[inline]
     pub fn _bits(&self) -> bool {
         match *self {
-            CAP0IW::ENABLED_ => true,
-            CAP0IW::DISABLED_ => false,
+            CAP0IW::ENABLED => true,
+            CAP0IW::DISABLED => false,
         }
     }
 }
@@ -472,13 +472,13 @@ impl<'a> _CAP0IW<'a> {
     }
     #[doc = "Enabled."]
     #[inline]
-    pub fn enabled_(self) -> &'a mut W {
-        self.variant(CAP0IW::ENABLED_)
+    pub fn enabled(self) -> &'a mut W {
+        self.variant(CAP0IW::ENABLED)
     }
     #[doc = "Disabled."]
     #[inline]
-    pub fn disabled_(self) -> &'a mut W {
-        self.variant(CAP0IW::DISABLED_)
+    pub fn disabled(self) -> &'a mut W {
+        self.variant(CAP0IW::DISABLED)
     }
     #[doc = r" Sets the field bit"]
     pub fn set_bit(self) -> &'a mut W {
@@ -501,9 +501,9 @@ impl<'a> _CAP0IW<'a> {
 #[doc = "Values that can be written to the field `CAP1RE`"]
 pub enum CAP1REW {
     #[doc = "Enabled."]
-    ENABLED_,
+    ENABLED,
     #[doc = "Disabled."]
-    DISABLED_,
+    DISABLED,
 }
 impl CAP1REW {
     #[allow(missing_docs)]
@@ -511,8 +511,8 @@ impl CAP1REW {
     #[inline]
     pub fn _bits(&self) -> bool {
         match *self {
-            CAP1REW::ENABLED_ => true,
-            CAP1REW::DISABLED_ => false,
+            CAP1REW::ENABLED => true,
+            CAP1REW::DISABLED => false,
         }
     }
 }
@@ -530,13 +530,13 @@ impl<'a> _CAP1REW<'a> {
     }
     #[doc = "Enabled."]
     #[inline]
-    pub fn enabled_(self) -> &'a mut W {
-        self.variant(CAP1REW::ENABLED_)
+    pub fn enabled(self) -> &'a mut W {
+        self.variant(CAP1REW::ENABLED)
     }
     #[doc = "Disabled."]
     #[inline]
-    pub fn disabled_(self) -> &'a mut W {
-        self.variant(CAP1REW::DISABLED_)
+    pub fn disabled(self) -> &'a mut W {
+        self.variant(CAP1REW::DISABLED)
     }
     #[doc = r" Sets the field bit"]
     pub fn set_bit(self) -> &'a mut W {
@@ -559,9 +559,9 @@ impl<'a> _CAP1REW<'a> {
 #[doc = "Values that can be written to the field `CAP1FE`"]
 pub enum CAP1FEW {
     #[doc = "Enabled."]
-    ENABLED_,
+    ENABLED,
     #[doc = "Disabled."]
-    DISABLED_,
+    DISABLED,
 }
 impl CAP1FEW {
     #[allow(missing_docs)]
@@ -569,8 +569,8 @@ impl CAP1FEW {
     #[inline]
     pub fn _bits(&self) -> bool {
         match *self {
-            CAP1FEW::ENABLED_ => true,
-            CAP1FEW::DISABLED_ => false,
+            CAP1FEW::ENABLED => true,
+            CAP1FEW::DISABLED => false,
         }
     }
 }
@@ -588,13 +588,13 @@ impl<'a> _CAP1FEW<'a> {
     }
     #[doc = "Enabled."]
     #[inline]
-    pub fn enabled_(self) -> &'a mut W {
-        self.variant(CAP1FEW::ENABLED_)
+    pub fn enabled(self) -> &'a mut W {
+        self.variant(CAP1FEW::ENABLED)
     }
     #[doc = "Disabled."]
     #[inline]
-    pub fn disabled_(self) -> &'a mut W {
-        self.variant(CAP1FEW::DISABLED_)
+    pub fn disabled(self) -> &'a mut W {
+        self.variant(CAP1FEW::DISABLED)
     }
     #[doc = r" Sets the field bit"]
     pub fn set_bit(self) -> &'a mut W {
@@ -617,9 +617,9 @@ impl<'a> _CAP1FEW<'a> {
 #[doc = "Values that can be written to the field `CAP1I`"]
 pub enum CAP1IW {
     #[doc = "Enabled."]
-    ENABLED_,
+    ENABLED,
     #[doc = "Disabled."]
-    DISABLED_,
+    DISABLED,
 }
 impl CAP1IW {
     #[allow(missing_docs)]
@@ -627,8 +627,8 @@ impl CAP1IW {
     #[inline]
     pub fn _bits(&self) -> bool {
         match *self {
-            CAP1IW::ENABLED_ => true,
-            CAP1IW::DISABLED_ => false,
+            CAP1IW::ENABLED => true,
+            CAP1IW::DISABLED => false,
         }
     }
 }
@@ -646,13 +646,13 @@ impl<'a> _CAP1IW<'a> {
     }
     #[doc = "Enabled."]
     #[inline]
-    pub fn enabled_(self) -> &'a mut W {
-        self.variant(CAP1IW::ENABLED_)
+    pub fn enabled(self) -> &'a mut W {
+        self.variant(CAP1IW::ENABLED)
     }
     #[doc = "Disabled."]
     #[inline]
-    pub fn disabled_(self) -> &'a mut W {
-        self.variant(CAP1IW::DISABLED_)
+    pub fn disabled(self) -> &'a mut W {
+        self.variant(CAP1IW::DISABLED)
     }
     #[doc = r" Sets the field bit"]
     pub fn set_bit(self) -> &'a mut W {

--- a/lpc11uxx/src/ct32b1/ctcr.rs
+++ b/lpc11uxx/src/ct32b1/ctcr.rs
@@ -48,11 +48,11 @@ pub enum CTMR {
     #[doc = "Timer Mode: every rising PCLK edge"]
     TIMER_MODE_EVERY_RI,
     #[doc = "Counter Mode: TC is incremented on rising edges on the CAP input selected by bits 3:2."]
-    COUNTER_MODE_TC_IS_RISING,
+    RISING,
     #[doc = "Counter Mode: TC is incremented on falling edges on the CAP input selected by bits 3:2."]
-    COUNTER_MODE_TC_IS_FALLING,
+    FALLING,
     #[doc = "Counter Mode: TC is incremented on both edges on the CAP input selected by bits 3:2."]
-    COUNTER_MODE_TC_IS_BOTH,
+    BOTH,
 }
 impl CTMR {
     #[doc = r" Value of the field as raw bits"]
@@ -60,9 +60,9 @@ impl CTMR {
     pub fn bits(&self) -> u8 {
         match *self {
             CTMR::TIMER_MODE_EVERY_RI => 0,
-            CTMR::COUNTER_MODE_TC_IS_RISING => 1,
-            CTMR::COUNTER_MODE_TC_IS_FALLING => 2,
-            CTMR::COUNTER_MODE_TC_IS_BOTH => 3,
+            CTMR::RISING => 1,
+            CTMR::FALLING => 2,
+            CTMR::BOTH => 3,
         }
     }
     #[allow(missing_docs)]
@@ -71,9 +71,9 @@ impl CTMR {
     pub fn _from(value: u8) -> CTMR {
         match value {
             0 => CTMR::TIMER_MODE_EVERY_RI,
-            1 => CTMR::COUNTER_MODE_TC_IS_RISING,
-            2 => CTMR::COUNTER_MODE_TC_IS_FALLING,
-            3 => CTMR::COUNTER_MODE_TC_IS_BOTH,
+            1 => CTMR::RISING,
+            2 => CTMR::FALLING,
+            3 => CTMR::BOTH,
             _ => unreachable!(),
         }
     }
@@ -82,20 +82,20 @@ impl CTMR {
     pub fn is_timer_mode_every_ri(&self) -> bool {
         *self == CTMR::TIMER_MODE_EVERY_RI
     }
-    #[doc = "Checks if the value of the field is `COUNTER_MODE_TC_IS_RISING`"]
+    #[doc = "Checks if the value of the field is `RISING`"]
     #[inline]
-    pub fn is_counter_mode_tc_is_rising(&self) -> bool {
-        *self == CTMR::COUNTER_MODE_TC_IS_RISING
+    pub fn is_rising(&self) -> bool {
+        *self == CTMR::RISING
     }
-    #[doc = "Checks if the value of the field is `COUNTER_MODE_TC_IS_FALLING`"]
+    #[doc = "Checks if the value of the field is `FALLING`"]
     #[inline]
-    pub fn is_counter_mode_tc_is_falling(&self) -> bool {
-        *self == CTMR::COUNTER_MODE_TC_IS_FALLING
+    pub fn is_falling(&self) -> bool {
+        *self == CTMR::FALLING
     }
-    #[doc = "Checks if the value of the field is `COUNTER_MODE_TC_IS_BOTH`"]
+    #[doc = "Checks if the value of the field is `BOTH`"]
     #[inline]
-    pub fn is_counter_mode_tc_is_both(&self) -> bool {
-        *self == CTMR::COUNTER_MODE_TC_IS_BOTH
+    pub fn is_both(&self) -> bool {
+        *self == CTMR::BOTH
     }
 }
 #[doc = "Possible values of the field `CIS`"]
@@ -224,11 +224,11 @@ pub enum CTMW {
     #[doc = "Timer Mode: every rising PCLK edge"]
     TIMER_MODE_EVERY_RI,
     #[doc = "Counter Mode: TC is incremented on rising edges on the CAP input selected by bits 3:2."]
-    COUNTER_MODE_TC_IS_RISING,
+    RISING,
     #[doc = "Counter Mode: TC is incremented on falling edges on the CAP input selected by bits 3:2."]
-    COUNTER_MODE_TC_IS_FALLING,
+    FALLING,
     #[doc = "Counter Mode: TC is incremented on both edges on the CAP input selected by bits 3:2."]
-    COUNTER_MODE_TC_IS_BOTH,
+    BOTH,
 }
 impl CTMW {
     #[allow(missing_docs)]
@@ -237,9 +237,9 @@ impl CTMW {
     pub fn _bits(&self) -> u8 {
         match *self {
             CTMW::TIMER_MODE_EVERY_RI => 0,
-            CTMW::COUNTER_MODE_TC_IS_RISING => 1,
-            CTMW::COUNTER_MODE_TC_IS_FALLING => 2,
-            CTMW::COUNTER_MODE_TC_IS_BOTH => 3,
+            CTMW::RISING => 1,
+            CTMW::FALLING => 2,
+            CTMW::BOTH => 3,
         }
     }
 }
@@ -262,18 +262,18 @@ impl<'a> _CTMW<'a> {
     }
     #[doc = "Counter Mode: TC is incremented on rising edges on the CAP input selected by bits 3:2."]
     #[inline]
-    pub fn counter_mode_tc_is_rising(self) -> &'a mut W {
-        self.variant(CTMW::COUNTER_MODE_TC_IS_RISING)
+    pub fn rising(self) -> &'a mut W {
+        self.variant(CTMW::RISING)
     }
     #[doc = "Counter Mode: TC is incremented on falling edges on the CAP input selected by bits 3:2."]
     #[inline]
-    pub fn counter_mode_tc_is_falling(self) -> &'a mut W {
-        self.variant(CTMW::COUNTER_MODE_TC_IS_FALLING)
+    pub fn falling(self) -> &'a mut W {
+        self.variant(CTMW::FALLING)
     }
     #[doc = "Counter Mode: TC is incremented on both edges on the CAP input selected by bits 3:2."]
     #[inline]
-    pub fn counter_mode_tc_is_both(self) -> &'a mut W {
-        self.variant(CTMW::COUNTER_MODE_TC_IS_BOTH)
+    pub fn both(self) -> &'a mut W {
+        self.variant(CTMW::BOTH)
     }
     #[doc = r" Writes raw bits to the field"]
     #[inline]

--- a/lpc11uxx/src/ct32b1/emr.rs
+++ b/lpc11uxx/src/ct32b1/emr.rs
@@ -130,23 +130,23 @@ impl EM3R {
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum EMC0R {
     #[doc = "Do Nothing."]
-    DO_NOTHING_,
+    DO_NOTHING,
     #[doc = "Clear the corresponding External Match bit/output to 0 (CT32Bi_MAT0 pin is LOW if pinned out)."]
-    CLEAR_THE_CORRESPOND,
+    CLEAR,
     #[doc = "Set the corresponding External Match bit/output to 1 (CT32Bi_MAT0 pin is HIGH if pinned out)."]
-    SET_THE_CORRESPONDIN,
+    SET,
     #[doc = "Toggle the corresponding External Match bit/output."]
-    TOGGLE_THE_CORRESPON,
+    TOGGLE,
 }
 impl EMC0R {
     #[doc = r" Value of the field as raw bits"]
     #[inline]
     pub fn bits(&self) -> u8 {
         match *self {
-            EMC0R::DO_NOTHING_ => 0,
-            EMC0R::CLEAR_THE_CORRESPOND => 1,
-            EMC0R::SET_THE_CORRESPONDIN => 2,
-            EMC0R::TOGGLE_THE_CORRESPON => 3,
+            EMC0R::DO_NOTHING => 0,
+            EMC0R::CLEAR => 1,
+            EMC0R::SET => 2,
+            EMC0R::TOGGLE => 3,
         }
     }
     #[allow(missing_docs)]
@@ -154,55 +154,55 @@ impl EMC0R {
     #[inline]
     pub fn _from(value: u8) -> EMC0R {
         match value {
-            0 => EMC0R::DO_NOTHING_,
-            1 => EMC0R::CLEAR_THE_CORRESPOND,
-            2 => EMC0R::SET_THE_CORRESPONDIN,
-            3 => EMC0R::TOGGLE_THE_CORRESPON,
+            0 => EMC0R::DO_NOTHING,
+            1 => EMC0R::CLEAR,
+            2 => EMC0R::SET,
+            3 => EMC0R::TOGGLE,
             _ => unreachable!(),
         }
     }
-    #[doc = "Checks if the value of the field is `DO_NOTHING_`"]
+    #[doc = "Checks if the value of the field is `DO_NOTHING`"]
     #[inline]
-    pub fn is_do_nothing_(&self) -> bool {
-        *self == EMC0R::DO_NOTHING_
+    pub fn is_do_nothing(&self) -> bool {
+        *self == EMC0R::DO_NOTHING
     }
-    #[doc = "Checks if the value of the field is `CLEAR_THE_CORRESPOND`"]
+    #[doc = "Checks if the value of the field is `CLEAR`"]
     #[inline]
-    pub fn is_clear_the_correspond(&self) -> bool {
-        *self == EMC0R::CLEAR_THE_CORRESPOND
+    pub fn is_clear(&self) -> bool {
+        *self == EMC0R::CLEAR
     }
-    #[doc = "Checks if the value of the field is `SET_THE_CORRESPONDIN`"]
+    #[doc = "Checks if the value of the field is `SET`"]
     #[inline]
-    pub fn is_set_the_correspondin(&self) -> bool {
-        *self == EMC0R::SET_THE_CORRESPONDIN
+    pub fn is_set(&self) -> bool {
+        *self == EMC0R::SET
     }
-    #[doc = "Checks if the value of the field is `TOGGLE_THE_CORRESPON`"]
+    #[doc = "Checks if the value of the field is `TOGGLE`"]
     #[inline]
-    pub fn is_toggle_the_correspon(&self) -> bool {
-        *self == EMC0R::TOGGLE_THE_CORRESPON
+    pub fn is_toggle(&self) -> bool {
+        *self == EMC0R::TOGGLE
     }
 }
 #[doc = "Possible values of the field `EMC1`"]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum EMC1R {
     #[doc = "Do Nothing."]
-    DO_NOTHING_,
+    DO_NOTHING,
     #[doc = "Clear the corresponding External Match bit/output to 0 (CT32Bi_MAT1 pin is LOW if pinned out)."]
-    CLEAR_THE_CORRESPOND,
+    CLEAR,
     #[doc = "Set the corresponding External Match bit/output to 1 (CT32Bi_MAT1 pin is HIGH if pinned out)."]
-    SET_THE_CORRESPONDIN,
+    SET,
     #[doc = "Toggle the corresponding External Match bit/output."]
-    TOGGLE_THE_CORRESPON,
+    TOGGLE,
 }
 impl EMC1R {
     #[doc = r" Value of the field as raw bits"]
     #[inline]
     pub fn bits(&self) -> u8 {
         match *self {
-            EMC1R::DO_NOTHING_ => 0,
-            EMC1R::CLEAR_THE_CORRESPOND => 1,
-            EMC1R::SET_THE_CORRESPONDIN => 2,
-            EMC1R::TOGGLE_THE_CORRESPON => 3,
+            EMC1R::DO_NOTHING => 0,
+            EMC1R::CLEAR => 1,
+            EMC1R::SET => 2,
+            EMC1R::TOGGLE => 3,
         }
     }
     #[allow(missing_docs)]
@@ -210,55 +210,55 @@ impl EMC1R {
     #[inline]
     pub fn _from(value: u8) -> EMC1R {
         match value {
-            0 => EMC1R::DO_NOTHING_,
-            1 => EMC1R::CLEAR_THE_CORRESPOND,
-            2 => EMC1R::SET_THE_CORRESPONDIN,
-            3 => EMC1R::TOGGLE_THE_CORRESPON,
+            0 => EMC1R::DO_NOTHING,
+            1 => EMC1R::CLEAR,
+            2 => EMC1R::SET,
+            3 => EMC1R::TOGGLE,
             _ => unreachable!(),
         }
     }
-    #[doc = "Checks if the value of the field is `DO_NOTHING_`"]
+    #[doc = "Checks if the value of the field is `DO_NOTHING`"]
     #[inline]
-    pub fn is_do_nothing_(&self) -> bool {
-        *self == EMC1R::DO_NOTHING_
+    pub fn is_do_nothing(&self) -> bool {
+        *self == EMC1R::DO_NOTHING
     }
-    #[doc = "Checks if the value of the field is `CLEAR_THE_CORRESPOND`"]
+    #[doc = "Checks if the value of the field is `CLEAR`"]
     #[inline]
-    pub fn is_clear_the_correspond(&self) -> bool {
-        *self == EMC1R::CLEAR_THE_CORRESPOND
+    pub fn is_clear(&self) -> bool {
+        *self == EMC1R::CLEAR
     }
-    #[doc = "Checks if the value of the field is `SET_THE_CORRESPONDIN`"]
+    #[doc = "Checks if the value of the field is `SET`"]
     #[inline]
-    pub fn is_set_the_correspondin(&self) -> bool {
-        *self == EMC1R::SET_THE_CORRESPONDIN
+    pub fn is_set(&self) -> bool {
+        *self == EMC1R::SET
     }
-    #[doc = "Checks if the value of the field is `TOGGLE_THE_CORRESPON`"]
+    #[doc = "Checks if the value of the field is `TOGGLE`"]
     #[inline]
-    pub fn is_toggle_the_correspon(&self) -> bool {
-        *self == EMC1R::TOGGLE_THE_CORRESPON
+    pub fn is_toggle(&self) -> bool {
+        *self == EMC1R::TOGGLE
     }
 }
 #[doc = "Possible values of the field `EMC2`"]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum EMC2R {
     #[doc = "Do Nothing."]
-    DO_NOTHING_,
+    DO_NOTHING,
     #[doc = "Clear the corresponding External Match bit/output to 0 (CT32Bi_MAT2 pin is LOW if pinned out)."]
-    CLEAR_THE_CORRESPOND,
+    CLEAR,
     #[doc = "Set the corresponding External Match bit/output to 1 (CT32Bi_MAT2 pin is HIGH if pinned out)."]
-    SET_THE_CORRESPONDIN,
+    SET,
     #[doc = "Toggle the corresponding External Match bit/output."]
-    TOGGLE_THE_CORRESPON,
+    TOGGLE,
 }
 impl EMC2R {
     #[doc = r" Value of the field as raw bits"]
     #[inline]
     pub fn bits(&self) -> u8 {
         match *self {
-            EMC2R::DO_NOTHING_ => 0,
-            EMC2R::CLEAR_THE_CORRESPOND => 1,
-            EMC2R::SET_THE_CORRESPONDIN => 2,
-            EMC2R::TOGGLE_THE_CORRESPON => 3,
+            EMC2R::DO_NOTHING => 0,
+            EMC2R::CLEAR => 1,
+            EMC2R::SET => 2,
+            EMC2R::TOGGLE => 3,
         }
     }
     #[allow(missing_docs)]
@@ -266,55 +266,55 @@ impl EMC2R {
     #[inline]
     pub fn _from(value: u8) -> EMC2R {
         match value {
-            0 => EMC2R::DO_NOTHING_,
-            1 => EMC2R::CLEAR_THE_CORRESPOND,
-            2 => EMC2R::SET_THE_CORRESPONDIN,
-            3 => EMC2R::TOGGLE_THE_CORRESPON,
+            0 => EMC2R::DO_NOTHING,
+            1 => EMC2R::CLEAR,
+            2 => EMC2R::SET,
+            3 => EMC2R::TOGGLE,
             _ => unreachable!(),
         }
     }
-    #[doc = "Checks if the value of the field is `DO_NOTHING_`"]
+    #[doc = "Checks if the value of the field is `DO_NOTHING`"]
     #[inline]
-    pub fn is_do_nothing_(&self) -> bool {
-        *self == EMC2R::DO_NOTHING_
+    pub fn is_do_nothing(&self) -> bool {
+        *self == EMC2R::DO_NOTHING
     }
-    #[doc = "Checks if the value of the field is `CLEAR_THE_CORRESPOND`"]
+    #[doc = "Checks if the value of the field is `CLEAR`"]
     #[inline]
-    pub fn is_clear_the_correspond(&self) -> bool {
-        *self == EMC2R::CLEAR_THE_CORRESPOND
+    pub fn is_clear(&self) -> bool {
+        *self == EMC2R::CLEAR
     }
-    #[doc = "Checks if the value of the field is `SET_THE_CORRESPONDIN`"]
+    #[doc = "Checks if the value of the field is `SET`"]
     #[inline]
-    pub fn is_set_the_correspondin(&self) -> bool {
-        *self == EMC2R::SET_THE_CORRESPONDIN
+    pub fn is_set(&self) -> bool {
+        *self == EMC2R::SET
     }
-    #[doc = "Checks if the value of the field is `TOGGLE_THE_CORRESPON`"]
+    #[doc = "Checks if the value of the field is `TOGGLE`"]
     #[inline]
-    pub fn is_toggle_the_correspon(&self) -> bool {
-        *self == EMC2R::TOGGLE_THE_CORRESPON
+    pub fn is_toggle(&self) -> bool {
+        *self == EMC2R::TOGGLE
     }
 }
 #[doc = "Possible values of the field `EMC3`"]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum EMC3R {
     #[doc = "Do Nothing."]
-    DO_NOTHING_,
+    DO_NOTHING,
     #[doc = "Clear the corresponding External Match bit/output to 0 (CT32Bi_MAT3 pin is LOW if pinned out)."]
-    CLEAR_THE_CORRESPOND,
+    CLEAR,
     #[doc = "Set the corresponding External Match bit/output to 1 (CT32Bi_MAT3 pin is HIGH if pinned out)."]
-    SET_THE_CORRESPONDIN,
+    SET,
     #[doc = "Toggle the corresponding External Match bit/output."]
-    TOGGLE_THE_CORRESPON,
+    TOGGLE,
 }
 impl EMC3R {
     #[doc = r" Value of the field as raw bits"]
     #[inline]
     pub fn bits(&self) -> u8 {
         match *self {
-            EMC3R::DO_NOTHING_ => 0,
-            EMC3R::CLEAR_THE_CORRESPOND => 1,
-            EMC3R::SET_THE_CORRESPONDIN => 2,
-            EMC3R::TOGGLE_THE_CORRESPON => 3,
+            EMC3R::DO_NOTHING => 0,
+            EMC3R::CLEAR => 1,
+            EMC3R::SET => 2,
+            EMC3R::TOGGLE => 3,
         }
     }
     #[allow(missing_docs)]
@@ -322,32 +322,32 @@ impl EMC3R {
     #[inline]
     pub fn _from(value: u8) -> EMC3R {
         match value {
-            0 => EMC3R::DO_NOTHING_,
-            1 => EMC3R::CLEAR_THE_CORRESPOND,
-            2 => EMC3R::SET_THE_CORRESPONDIN,
-            3 => EMC3R::TOGGLE_THE_CORRESPON,
+            0 => EMC3R::DO_NOTHING,
+            1 => EMC3R::CLEAR,
+            2 => EMC3R::SET,
+            3 => EMC3R::TOGGLE,
             _ => unreachable!(),
         }
     }
-    #[doc = "Checks if the value of the field is `DO_NOTHING_`"]
+    #[doc = "Checks if the value of the field is `DO_NOTHING`"]
     #[inline]
-    pub fn is_do_nothing_(&self) -> bool {
-        *self == EMC3R::DO_NOTHING_
+    pub fn is_do_nothing(&self) -> bool {
+        *self == EMC3R::DO_NOTHING
     }
-    #[doc = "Checks if the value of the field is `CLEAR_THE_CORRESPOND`"]
+    #[doc = "Checks if the value of the field is `CLEAR`"]
     #[inline]
-    pub fn is_clear_the_correspond(&self) -> bool {
-        *self == EMC3R::CLEAR_THE_CORRESPOND
+    pub fn is_clear(&self) -> bool {
+        *self == EMC3R::CLEAR
     }
-    #[doc = "Checks if the value of the field is `SET_THE_CORRESPONDIN`"]
+    #[doc = "Checks if the value of the field is `SET`"]
     #[inline]
-    pub fn is_set_the_correspondin(&self) -> bool {
-        *self == EMC3R::SET_THE_CORRESPONDIN
+    pub fn is_set(&self) -> bool {
+        *self == EMC3R::SET
     }
-    #[doc = "Checks if the value of the field is `TOGGLE_THE_CORRESPON`"]
+    #[doc = "Checks if the value of the field is `TOGGLE`"]
     #[inline]
-    pub fn is_toggle_the_correspon(&self) -> bool {
-        *self == EMC3R::TOGGLE_THE_CORRESPON
+    pub fn is_toggle(&self) -> bool {
+        *self == EMC3R::TOGGLE
     }
 }
 #[doc = r" Proxy"]
@@ -445,13 +445,13 @@ impl<'a> _EM3W<'a> {
 #[doc = "Values that can be written to the field `EMC0`"]
 pub enum EMC0W {
     #[doc = "Do Nothing."]
-    DO_NOTHING_,
+    DO_NOTHING,
     #[doc = "Clear the corresponding External Match bit/output to 0 (CT32Bi_MAT0 pin is LOW if pinned out)."]
-    CLEAR_THE_CORRESPOND,
+    CLEAR,
     #[doc = "Set the corresponding External Match bit/output to 1 (CT32Bi_MAT0 pin is HIGH if pinned out)."]
-    SET_THE_CORRESPONDIN,
+    SET,
     #[doc = "Toggle the corresponding External Match bit/output."]
-    TOGGLE_THE_CORRESPON,
+    TOGGLE,
 }
 impl EMC0W {
     #[allow(missing_docs)]
@@ -459,10 +459,10 @@ impl EMC0W {
     #[inline]
     pub fn _bits(&self) -> u8 {
         match *self {
-            EMC0W::DO_NOTHING_ => 0,
-            EMC0W::CLEAR_THE_CORRESPOND => 1,
-            EMC0W::SET_THE_CORRESPONDIN => 2,
-            EMC0W::TOGGLE_THE_CORRESPON => 3,
+            EMC0W::DO_NOTHING => 0,
+            EMC0W::CLEAR => 1,
+            EMC0W::SET => 2,
+            EMC0W::TOGGLE => 3,
         }
     }
 }
@@ -480,23 +480,23 @@ impl<'a> _EMC0W<'a> {
     }
     #[doc = "Do Nothing."]
     #[inline]
-    pub fn do_nothing_(self) -> &'a mut W {
-        self.variant(EMC0W::DO_NOTHING_)
+    pub fn do_nothing(self) -> &'a mut W {
+        self.variant(EMC0W::DO_NOTHING)
     }
     #[doc = "Clear the corresponding External Match bit/output to 0 (CT32Bi_MAT0 pin is LOW if pinned out)."]
     #[inline]
-    pub fn clear_the_correspond(self) -> &'a mut W {
-        self.variant(EMC0W::CLEAR_THE_CORRESPOND)
+    pub fn clear(self) -> &'a mut W {
+        self.variant(EMC0W::CLEAR)
     }
     #[doc = "Set the corresponding External Match bit/output to 1 (CT32Bi_MAT0 pin is HIGH if pinned out)."]
     #[inline]
-    pub fn set_the_correspondin(self) -> &'a mut W {
-        self.variant(EMC0W::SET_THE_CORRESPONDIN)
+    pub fn set(self) -> &'a mut W {
+        self.variant(EMC0W::SET)
     }
     #[doc = "Toggle the corresponding External Match bit/output."]
     #[inline]
-    pub fn toggle_the_correspon(self) -> &'a mut W {
-        self.variant(EMC0W::TOGGLE_THE_CORRESPON)
+    pub fn toggle(self) -> &'a mut W {
+        self.variant(EMC0W::TOGGLE)
     }
     #[doc = r" Writes raw bits to the field"]
     #[inline]
@@ -511,13 +511,13 @@ impl<'a> _EMC0W<'a> {
 #[doc = "Values that can be written to the field `EMC1`"]
 pub enum EMC1W {
     #[doc = "Do Nothing."]
-    DO_NOTHING_,
+    DO_NOTHING,
     #[doc = "Clear the corresponding External Match bit/output to 0 (CT32Bi_MAT1 pin is LOW if pinned out)."]
-    CLEAR_THE_CORRESPOND,
+    CLEAR,
     #[doc = "Set the corresponding External Match bit/output to 1 (CT32Bi_MAT1 pin is HIGH if pinned out)."]
-    SET_THE_CORRESPONDIN,
+    SET,
     #[doc = "Toggle the corresponding External Match bit/output."]
-    TOGGLE_THE_CORRESPON,
+    TOGGLE,
 }
 impl EMC1W {
     #[allow(missing_docs)]
@@ -525,10 +525,10 @@ impl EMC1W {
     #[inline]
     pub fn _bits(&self) -> u8 {
         match *self {
-            EMC1W::DO_NOTHING_ => 0,
-            EMC1W::CLEAR_THE_CORRESPOND => 1,
-            EMC1W::SET_THE_CORRESPONDIN => 2,
-            EMC1W::TOGGLE_THE_CORRESPON => 3,
+            EMC1W::DO_NOTHING => 0,
+            EMC1W::CLEAR => 1,
+            EMC1W::SET => 2,
+            EMC1W::TOGGLE => 3,
         }
     }
 }
@@ -546,23 +546,23 @@ impl<'a> _EMC1W<'a> {
     }
     #[doc = "Do Nothing."]
     #[inline]
-    pub fn do_nothing_(self) -> &'a mut W {
-        self.variant(EMC1W::DO_NOTHING_)
+    pub fn do_nothing(self) -> &'a mut W {
+        self.variant(EMC1W::DO_NOTHING)
     }
     #[doc = "Clear the corresponding External Match bit/output to 0 (CT32Bi_MAT1 pin is LOW if pinned out)."]
     #[inline]
-    pub fn clear_the_correspond(self) -> &'a mut W {
-        self.variant(EMC1W::CLEAR_THE_CORRESPOND)
+    pub fn clear(self) -> &'a mut W {
+        self.variant(EMC1W::CLEAR)
     }
     #[doc = "Set the corresponding External Match bit/output to 1 (CT32Bi_MAT1 pin is HIGH if pinned out)."]
     #[inline]
-    pub fn set_the_correspondin(self) -> &'a mut W {
-        self.variant(EMC1W::SET_THE_CORRESPONDIN)
+    pub fn set(self) -> &'a mut W {
+        self.variant(EMC1W::SET)
     }
     #[doc = "Toggle the corresponding External Match bit/output."]
     #[inline]
-    pub fn toggle_the_correspon(self) -> &'a mut W {
-        self.variant(EMC1W::TOGGLE_THE_CORRESPON)
+    pub fn toggle(self) -> &'a mut W {
+        self.variant(EMC1W::TOGGLE)
     }
     #[doc = r" Writes raw bits to the field"]
     #[inline]
@@ -577,13 +577,13 @@ impl<'a> _EMC1W<'a> {
 #[doc = "Values that can be written to the field `EMC2`"]
 pub enum EMC2W {
     #[doc = "Do Nothing."]
-    DO_NOTHING_,
+    DO_NOTHING,
     #[doc = "Clear the corresponding External Match bit/output to 0 (CT32Bi_MAT2 pin is LOW if pinned out)."]
-    CLEAR_THE_CORRESPOND,
+    CLEAR,
     #[doc = "Set the corresponding External Match bit/output to 1 (CT32Bi_MAT2 pin is HIGH if pinned out)."]
-    SET_THE_CORRESPONDIN,
+    SET,
     #[doc = "Toggle the corresponding External Match bit/output."]
-    TOGGLE_THE_CORRESPON,
+    TOGGLE,
 }
 impl EMC2W {
     #[allow(missing_docs)]
@@ -591,10 +591,10 @@ impl EMC2W {
     #[inline]
     pub fn _bits(&self) -> u8 {
         match *self {
-            EMC2W::DO_NOTHING_ => 0,
-            EMC2W::CLEAR_THE_CORRESPOND => 1,
-            EMC2W::SET_THE_CORRESPONDIN => 2,
-            EMC2W::TOGGLE_THE_CORRESPON => 3,
+            EMC2W::DO_NOTHING => 0,
+            EMC2W::CLEAR => 1,
+            EMC2W::SET => 2,
+            EMC2W::TOGGLE => 3,
         }
     }
 }
@@ -612,23 +612,23 @@ impl<'a> _EMC2W<'a> {
     }
     #[doc = "Do Nothing."]
     #[inline]
-    pub fn do_nothing_(self) -> &'a mut W {
-        self.variant(EMC2W::DO_NOTHING_)
+    pub fn do_nothing(self) -> &'a mut W {
+        self.variant(EMC2W::DO_NOTHING)
     }
     #[doc = "Clear the corresponding External Match bit/output to 0 (CT32Bi_MAT2 pin is LOW if pinned out)."]
     #[inline]
-    pub fn clear_the_correspond(self) -> &'a mut W {
-        self.variant(EMC2W::CLEAR_THE_CORRESPOND)
+    pub fn clear(self) -> &'a mut W {
+        self.variant(EMC2W::CLEAR)
     }
     #[doc = "Set the corresponding External Match bit/output to 1 (CT32Bi_MAT2 pin is HIGH if pinned out)."]
     #[inline]
-    pub fn set_the_correspondin(self) -> &'a mut W {
-        self.variant(EMC2W::SET_THE_CORRESPONDIN)
+    pub fn set(self) -> &'a mut W {
+        self.variant(EMC2W::SET)
     }
     #[doc = "Toggle the corresponding External Match bit/output."]
     #[inline]
-    pub fn toggle_the_correspon(self) -> &'a mut W {
-        self.variant(EMC2W::TOGGLE_THE_CORRESPON)
+    pub fn toggle(self) -> &'a mut W {
+        self.variant(EMC2W::TOGGLE)
     }
     #[doc = r" Writes raw bits to the field"]
     #[inline]
@@ -643,13 +643,13 @@ impl<'a> _EMC2W<'a> {
 #[doc = "Values that can be written to the field `EMC3`"]
 pub enum EMC3W {
     #[doc = "Do Nothing."]
-    DO_NOTHING_,
+    DO_NOTHING,
     #[doc = "Clear the corresponding External Match bit/output to 0 (CT32Bi_MAT3 pin is LOW if pinned out)."]
-    CLEAR_THE_CORRESPOND,
+    CLEAR,
     #[doc = "Set the corresponding External Match bit/output to 1 (CT32Bi_MAT3 pin is HIGH if pinned out)."]
-    SET_THE_CORRESPONDIN,
+    SET,
     #[doc = "Toggle the corresponding External Match bit/output."]
-    TOGGLE_THE_CORRESPON,
+    TOGGLE,
 }
 impl EMC3W {
     #[allow(missing_docs)]
@@ -657,10 +657,10 @@ impl EMC3W {
     #[inline]
     pub fn _bits(&self) -> u8 {
         match *self {
-            EMC3W::DO_NOTHING_ => 0,
-            EMC3W::CLEAR_THE_CORRESPOND => 1,
-            EMC3W::SET_THE_CORRESPONDIN => 2,
-            EMC3W::TOGGLE_THE_CORRESPON => 3,
+            EMC3W::DO_NOTHING => 0,
+            EMC3W::CLEAR => 1,
+            EMC3W::SET => 2,
+            EMC3W::TOGGLE => 3,
         }
     }
 }
@@ -678,23 +678,23 @@ impl<'a> _EMC3W<'a> {
     }
     #[doc = "Do Nothing."]
     #[inline]
-    pub fn do_nothing_(self) -> &'a mut W {
-        self.variant(EMC3W::DO_NOTHING_)
+    pub fn do_nothing(self) -> &'a mut W {
+        self.variant(EMC3W::DO_NOTHING)
     }
     #[doc = "Clear the corresponding External Match bit/output to 0 (CT32Bi_MAT3 pin is LOW if pinned out)."]
     #[inline]
-    pub fn clear_the_correspond(self) -> &'a mut W {
-        self.variant(EMC3W::CLEAR_THE_CORRESPOND)
+    pub fn clear(self) -> &'a mut W {
+        self.variant(EMC3W::CLEAR)
     }
     #[doc = "Set the corresponding External Match bit/output to 1 (CT32Bi_MAT3 pin is HIGH if pinned out)."]
     #[inline]
-    pub fn set_the_correspondin(self) -> &'a mut W {
-        self.variant(EMC3W::SET_THE_CORRESPONDIN)
+    pub fn set(self) -> &'a mut W {
+        self.variant(EMC3W::SET)
     }
     #[doc = "Toggle the corresponding External Match bit/output."]
     #[inline]
-    pub fn toggle_the_correspon(self) -> &'a mut W {
-        self.variant(EMC3W::TOGGLE_THE_CORRESPON)
+    pub fn toggle(self) -> &'a mut W {
+        self.variant(EMC3W::TOGGLE)
     }
     #[doc = r" Writes raw bits to the field"]
     #[inline]

--- a/lpc11uxx/src/ct32b1/pwmc.rs
+++ b/lpc11uxx/src/ct32b1/pwmc.rs
@@ -46,9 +46,9 @@ impl super::PWMC {
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum PWMEN0R {
     #[doc = "CT32Bn_MAT0 is controlled by EM0."]
-    CT32BN_MAT0_IS_CONTR,
+    EM0,
     #[doc = "PWM mode is enabled for CT32Bn_MAT0."]
-    PWM_MODE_IS_ENABLED_,
+    ENABLED,
 }
 impl PWMEN0R {
     #[doc = r" Returns `true` if the bit is clear (0)"]
@@ -65,8 +65,8 @@ impl PWMEN0R {
     #[inline]
     pub fn bit(&self) -> bool {
         match *self {
-            PWMEN0R::CT32BN_MAT0_IS_CONTR => false,
-            PWMEN0R::PWM_MODE_IS_ENABLED_ => true,
+            PWMEN0R::EM0 => false,
+            PWMEN0R::ENABLED => true,
         }
     }
     #[allow(missing_docs)]
@@ -74,28 +74,28 @@ impl PWMEN0R {
     #[inline]
     pub fn _from(value: bool) -> PWMEN0R {
         match value {
-            false => PWMEN0R::CT32BN_MAT0_IS_CONTR,
-            true => PWMEN0R::PWM_MODE_IS_ENABLED_,
+            false => PWMEN0R::EM0,
+            true => PWMEN0R::ENABLED,
         }
     }
-    #[doc = "Checks if the value of the field is `CT32BN_MAT0_IS_CONTR`"]
+    #[doc = "Checks if the value of the field is `EM0`"]
     #[inline]
-    pub fn is_ct32bn_mat0_is_contr(&self) -> bool {
-        *self == PWMEN0R::CT32BN_MAT0_IS_CONTR
+    pub fn is_em0(&self) -> bool {
+        *self == PWMEN0R::EM0
     }
-    #[doc = "Checks if the value of the field is `PWM_MODE_IS_ENABLED_`"]
+    #[doc = "Checks if the value of the field is `ENABLED`"]
     #[inline]
-    pub fn is_pwm_mode_is_enabled_(&self) -> bool {
-        *self == PWMEN0R::PWM_MODE_IS_ENABLED_
+    pub fn is_enabled(&self) -> bool {
+        *self == PWMEN0R::ENABLED
     }
 }
 #[doc = "Possible values of the field `PWMEN1`"]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum PWMEN1R {
     #[doc = "CT32Bn_MAT01 is controlled by EM1."]
-    CT32BN_MAT01_IS_CONT,
+    EM1,
     #[doc = "PWM mode is enabled for CT32Bn_MAT1."]
-    PWM_MODE_IS_ENABLED_,
+    ENABLED,
 }
 impl PWMEN1R {
     #[doc = r" Returns `true` if the bit is clear (0)"]
@@ -112,8 +112,8 @@ impl PWMEN1R {
     #[inline]
     pub fn bit(&self) -> bool {
         match *self {
-            PWMEN1R::CT32BN_MAT01_IS_CONT => false,
-            PWMEN1R::PWM_MODE_IS_ENABLED_ => true,
+            PWMEN1R::EM1 => false,
+            PWMEN1R::ENABLED => true,
         }
     }
     #[allow(missing_docs)]
@@ -121,28 +121,28 @@ impl PWMEN1R {
     #[inline]
     pub fn _from(value: bool) -> PWMEN1R {
         match value {
-            false => PWMEN1R::CT32BN_MAT01_IS_CONT,
-            true => PWMEN1R::PWM_MODE_IS_ENABLED_,
+            false => PWMEN1R::EM1,
+            true => PWMEN1R::ENABLED,
         }
     }
-    #[doc = "Checks if the value of the field is `CT32BN_MAT01_IS_CONT`"]
+    #[doc = "Checks if the value of the field is `EM1`"]
     #[inline]
-    pub fn is_ct32bn_mat01_is_cont(&self) -> bool {
-        *self == PWMEN1R::CT32BN_MAT01_IS_CONT
+    pub fn is_em1(&self) -> bool {
+        *self == PWMEN1R::EM1
     }
-    #[doc = "Checks if the value of the field is `PWM_MODE_IS_ENABLED_`"]
+    #[doc = "Checks if the value of the field is `ENABLED`"]
     #[inline]
-    pub fn is_pwm_mode_is_enabled_(&self) -> bool {
-        *self == PWMEN1R::PWM_MODE_IS_ENABLED_
+    pub fn is_enabled(&self) -> bool {
+        *self == PWMEN1R::ENABLED
     }
 }
 #[doc = "Possible values of the field `PWMEN2`"]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum PWMEN2R {
     #[doc = "CT32Bn_MAT2 is controlled by EM2."]
-    CT32BN_MAT2_IS_CONTR,
+    EM2,
     #[doc = "PWM mode is enabled for CT32Bn_MAT2."]
-    PWM_MODE_IS_ENABLED_,
+    ENABLED,
 }
 impl PWMEN2R {
     #[doc = r" Returns `true` if the bit is clear (0)"]
@@ -159,8 +159,8 @@ impl PWMEN2R {
     #[inline]
     pub fn bit(&self) -> bool {
         match *self {
-            PWMEN2R::CT32BN_MAT2_IS_CONTR => false,
-            PWMEN2R::PWM_MODE_IS_ENABLED_ => true,
+            PWMEN2R::EM2 => false,
+            PWMEN2R::ENABLED => true,
         }
     }
     #[allow(missing_docs)]
@@ -168,28 +168,28 @@ impl PWMEN2R {
     #[inline]
     pub fn _from(value: bool) -> PWMEN2R {
         match value {
-            false => PWMEN2R::CT32BN_MAT2_IS_CONTR,
-            true => PWMEN2R::PWM_MODE_IS_ENABLED_,
+            false => PWMEN2R::EM2,
+            true => PWMEN2R::ENABLED,
         }
     }
-    #[doc = "Checks if the value of the field is `CT32BN_MAT2_IS_CONTR`"]
+    #[doc = "Checks if the value of the field is `EM2`"]
     #[inline]
-    pub fn is_ct32bn_mat2_is_contr(&self) -> bool {
-        *self == PWMEN2R::CT32BN_MAT2_IS_CONTR
+    pub fn is_em2(&self) -> bool {
+        *self == PWMEN2R::EM2
     }
-    #[doc = "Checks if the value of the field is `PWM_MODE_IS_ENABLED_`"]
+    #[doc = "Checks if the value of the field is `ENABLED`"]
     #[inline]
-    pub fn is_pwm_mode_is_enabled_(&self) -> bool {
-        *self == PWMEN2R::PWM_MODE_IS_ENABLED_
+    pub fn is_enabled(&self) -> bool {
+        *self == PWMEN2R::ENABLED
     }
 }
 #[doc = "Possible values of the field `PWMEN3`"]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum PWMEN3R {
     #[doc = "CT32Bn_MAT3 is controlled by EM3."]
-    CT32BN_MAT3_IS_CONTR,
+    EM3,
     #[doc = "PWM mode is enabled for CT132Bn_MAT3."]
-    PWM_MODE_IS_ENABLED_,
+    ENABLED,
 }
 impl PWMEN3R {
     #[doc = r" Returns `true` if the bit is clear (0)"]
@@ -206,8 +206,8 @@ impl PWMEN3R {
     #[inline]
     pub fn bit(&self) -> bool {
         match *self {
-            PWMEN3R::CT32BN_MAT3_IS_CONTR => false,
-            PWMEN3R::PWM_MODE_IS_ENABLED_ => true,
+            PWMEN3R::EM3 => false,
+            PWMEN3R::ENABLED => true,
         }
     }
     #[allow(missing_docs)]
@@ -215,27 +215,27 @@ impl PWMEN3R {
     #[inline]
     pub fn _from(value: bool) -> PWMEN3R {
         match value {
-            false => PWMEN3R::CT32BN_MAT3_IS_CONTR,
-            true => PWMEN3R::PWM_MODE_IS_ENABLED_,
+            false => PWMEN3R::EM3,
+            true => PWMEN3R::ENABLED,
         }
     }
-    #[doc = "Checks if the value of the field is `CT32BN_MAT3_IS_CONTR`"]
+    #[doc = "Checks if the value of the field is `EM3`"]
     #[inline]
-    pub fn is_ct32bn_mat3_is_contr(&self) -> bool {
-        *self == PWMEN3R::CT32BN_MAT3_IS_CONTR
+    pub fn is_em3(&self) -> bool {
+        *self == PWMEN3R::EM3
     }
-    #[doc = "Checks if the value of the field is `PWM_MODE_IS_ENABLED_`"]
+    #[doc = "Checks if the value of the field is `ENABLED`"]
     #[inline]
-    pub fn is_pwm_mode_is_enabled_(&self) -> bool {
-        *self == PWMEN3R::PWM_MODE_IS_ENABLED_
+    pub fn is_enabled(&self) -> bool {
+        *self == PWMEN3R::ENABLED
     }
 }
 #[doc = "Values that can be written to the field `PWMEN0`"]
 pub enum PWMEN0W {
     #[doc = "CT32Bn_MAT0 is controlled by EM0."]
-    CT32BN_MAT0_IS_CONTR,
+    EM0,
     #[doc = "PWM mode is enabled for CT32Bn_MAT0."]
-    PWM_MODE_IS_ENABLED_,
+    ENABLED,
 }
 impl PWMEN0W {
     #[allow(missing_docs)]
@@ -243,8 +243,8 @@ impl PWMEN0W {
     #[inline]
     pub fn _bits(&self) -> bool {
         match *self {
-            PWMEN0W::CT32BN_MAT0_IS_CONTR => false,
-            PWMEN0W::PWM_MODE_IS_ENABLED_ => true,
+            PWMEN0W::EM0 => false,
+            PWMEN0W::ENABLED => true,
         }
     }
 }
@@ -262,13 +262,13 @@ impl<'a> _PWMEN0W<'a> {
     }
     #[doc = "CT32Bn_MAT0 is controlled by EM0."]
     #[inline]
-    pub fn ct32bn_mat0_is_contr(self) -> &'a mut W {
-        self.variant(PWMEN0W::CT32BN_MAT0_IS_CONTR)
+    pub fn em0(self) -> &'a mut W {
+        self.variant(PWMEN0W::EM0)
     }
     #[doc = "PWM mode is enabled for CT32Bn_MAT0."]
     #[inline]
-    pub fn pwm_mode_is_enabled_(self) -> &'a mut W {
-        self.variant(PWMEN0W::PWM_MODE_IS_ENABLED_)
+    pub fn enabled(self) -> &'a mut W {
+        self.variant(PWMEN0W::ENABLED)
     }
     #[doc = r" Sets the field bit"]
     pub fn set_bit(self) -> &'a mut W {
@@ -291,9 +291,9 @@ impl<'a> _PWMEN0W<'a> {
 #[doc = "Values that can be written to the field `PWMEN1`"]
 pub enum PWMEN1W {
     #[doc = "CT32Bn_MAT01 is controlled by EM1."]
-    CT32BN_MAT01_IS_CONT,
+    EM1,
     #[doc = "PWM mode is enabled for CT32Bn_MAT1."]
-    PWM_MODE_IS_ENABLED_,
+    ENABLED,
 }
 impl PWMEN1W {
     #[allow(missing_docs)]
@@ -301,8 +301,8 @@ impl PWMEN1W {
     #[inline]
     pub fn _bits(&self) -> bool {
         match *self {
-            PWMEN1W::CT32BN_MAT01_IS_CONT => false,
-            PWMEN1W::PWM_MODE_IS_ENABLED_ => true,
+            PWMEN1W::EM1 => false,
+            PWMEN1W::ENABLED => true,
         }
     }
 }
@@ -320,13 +320,13 @@ impl<'a> _PWMEN1W<'a> {
     }
     #[doc = "CT32Bn_MAT01 is controlled by EM1."]
     #[inline]
-    pub fn ct32bn_mat01_is_cont(self) -> &'a mut W {
-        self.variant(PWMEN1W::CT32BN_MAT01_IS_CONT)
+    pub fn em1(self) -> &'a mut W {
+        self.variant(PWMEN1W::EM1)
     }
     #[doc = "PWM mode is enabled for CT32Bn_MAT1."]
     #[inline]
-    pub fn pwm_mode_is_enabled_(self) -> &'a mut W {
-        self.variant(PWMEN1W::PWM_MODE_IS_ENABLED_)
+    pub fn enabled(self) -> &'a mut W {
+        self.variant(PWMEN1W::ENABLED)
     }
     #[doc = r" Sets the field bit"]
     pub fn set_bit(self) -> &'a mut W {
@@ -349,9 +349,9 @@ impl<'a> _PWMEN1W<'a> {
 #[doc = "Values that can be written to the field `PWMEN2`"]
 pub enum PWMEN2W {
     #[doc = "CT32Bn_MAT2 is controlled by EM2."]
-    CT32BN_MAT2_IS_CONTR,
+    EM2,
     #[doc = "PWM mode is enabled for CT32Bn_MAT2."]
-    PWM_MODE_IS_ENABLED_,
+    ENABLED,
 }
 impl PWMEN2W {
     #[allow(missing_docs)]
@@ -359,8 +359,8 @@ impl PWMEN2W {
     #[inline]
     pub fn _bits(&self) -> bool {
         match *self {
-            PWMEN2W::CT32BN_MAT2_IS_CONTR => false,
-            PWMEN2W::PWM_MODE_IS_ENABLED_ => true,
+            PWMEN2W::EM2 => false,
+            PWMEN2W::ENABLED => true,
         }
     }
 }
@@ -378,13 +378,13 @@ impl<'a> _PWMEN2W<'a> {
     }
     #[doc = "CT32Bn_MAT2 is controlled by EM2."]
     #[inline]
-    pub fn ct32bn_mat2_is_contr(self) -> &'a mut W {
-        self.variant(PWMEN2W::CT32BN_MAT2_IS_CONTR)
+    pub fn em2(self) -> &'a mut W {
+        self.variant(PWMEN2W::EM2)
     }
     #[doc = "PWM mode is enabled for CT32Bn_MAT2."]
     #[inline]
-    pub fn pwm_mode_is_enabled_(self) -> &'a mut W {
-        self.variant(PWMEN2W::PWM_MODE_IS_ENABLED_)
+    pub fn enabled(self) -> &'a mut W {
+        self.variant(PWMEN2W::ENABLED)
     }
     #[doc = r" Sets the field bit"]
     pub fn set_bit(self) -> &'a mut W {
@@ -407,9 +407,9 @@ impl<'a> _PWMEN2W<'a> {
 #[doc = "Values that can be written to the field `PWMEN3`"]
 pub enum PWMEN3W {
     #[doc = "CT32Bn_MAT3 is controlled by EM3."]
-    CT32BN_MAT3_IS_CONTR,
+    EM3,
     #[doc = "PWM mode is enabled for CT132Bn_MAT3."]
-    PWM_MODE_IS_ENABLED_,
+    ENABLED,
 }
 impl PWMEN3W {
     #[allow(missing_docs)]
@@ -417,8 +417,8 @@ impl PWMEN3W {
     #[inline]
     pub fn _bits(&self) -> bool {
         match *self {
-            PWMEN3W::CT32BN_MAT3_IS_CONTR => false,
-            PWMEN3W::PWM_MODE_IS_ENABLED_ => true,
+            PWMEN3W::EM3 => false,
+            PWMEN3W::ENABLED => true,
         }
     }
 }
@@ -436,13 +436,13 @@ impl<'a> _PWMEN3W<'a> {
     }
     #[doc = "CT32Bn_MAT3 is controlled by EM3."]
     #[inline]
-    pub fn ct32bn_mat3_is_contr(self) -> &'a mut W {
-        self.variant(PWMEN3W::CT32BN_MAT3_IS_CONTR)
+    pub fn em3(self) -> &'a mut W {
+        self.variant(PWMEN3W::EM3)
     }
     #[doc = "PWM mode is enabled for CT132Bn_MAT3."]
     #[inline]
-    pub fn pwm_mode_is_enabled_(self) -> &'a mut W {
-        self.variant(PWMEN3W::PWM_MODE_IS_ENABLED_)
+    pub fn enabled(self) -> &'a mut W {
+        self.variant(PWMEN3W::ENABLED)
     }
     #[doc = r" Sets the field bit"]
     pub fn set_bit(self) -> &'a mut W {

--- a/lpc11uxx/src/ct32b1/tcr.rs
+++ b/lpc11uxx/src/ct32b1/tcr.rs
@@ -93,9 +93,9 @@ impl CENR {
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum CRSTR {
     #[doc = "Do nothing."]
-    DO_NOTHING_,
+    DO_NOTHING,
     #[doc = "The Timer Counter and the Prescale Counter are synchronously reset on the next positive edge of PCLK. The counters remain reset until TCR\\[1\\] is returned to zero."]
-    THE_TIMER_COUNTER_AN,
+    RESET,
 }
 impl CRSTR {
     #[doc = r" Returns `true` if the bit is clear (0)"]
@@ -112,8 +112,8 @@ impl CRSTR {
     #[inline]
     pub fn bit(&self) -> bool {
         match *self {
-            CRSTR::DO_NOTHING_ => false,
-            CRSTR::THE_TIMER_COUNTER_AN => true,
+            CRSTR::DO_NOTHING => false,
+            CRSTR::RESET => true,
         }
     }
     #[allow(missing_docs)]
@@ -121,19 +121,19 @@ impl CRSTR {
     #[inline]
     pub fn _from(value: bool) -> CRSTR {
         match value {
-            false => CRSTR::DO_NOTHING_,
-            true => CRSTR::THE_TIMER_COUNTER_AN,
+            false => CRSTR::DO_NOTHING,
+            true => CRSTR::RESET,
         }
     }
-    #[doc = "Checks if the value of the field is `DO_NOTHING_`"]
+    #[doc = "Checks if the value of the field is `DO_NOTHING`"]
     #[inline]
-    pub fn is_do_nothing_(&self) -> bool {
-        *self == CRSTR::DO_NOTHING_
+    pub fn is_do_nothing(&self) -> bool {
+        *self == CRSTR::DO_NOTHING
     }
-    #[doc = "Checks if the value of the field is `THE_TIMER_COUNTER_AN`"]
+    #[doc = "Checks if the value of the field is `RESET`"]
     #[inline]
-    pub fn is_the_timer_counter_an(&self) -> bool {
-        *self == CRSTR::THE_TIMER_COUNTER_AN
+    pub fn is_reset(&self) -> bool {
+        *self == CRSTR::RESET
     }
 }
 #[doc = "Values that can be written to the field `CEN`"]
@@ -197,9 +197,9 @@ impl<'a> _CENW<'a> {
 #[doc = "Values that can be written to the field `CRST`"]
 pub enum CRSTW {
     #[doc = "Do nothing."]
-    DO_NOTHING_,
+    DO_NOTHING,
     #[doc = "The Timer Counter and the Prescale Counter are synchronously reset on the next positive edge of PCLK. The counters remain reset until TCR\\[1\\] is returned to zero."]
-    THE_TIMER_COUNTER_AN,
+    RESET,
 }
 impl CRSTW {
     #[allow(missing_docs)]
@@ -207,8 +207,8 @@ impl CRSTW {
     #[inline]
     pub fn _bits(&self) -> bool {
         match *self {
-            CRSTW::DO_NOTHING_ => false,
-            CRSTW::THE_TIMER_COUNTER_AN => true,
+            CRSTW::DO_NOTHING => false,
+            CRSTW::RESET => true,
         }
     }
 }
@@ -226,13 +226,13 @@ impl<'a> _CRSTW<'a> {
     }
     #[doc = "Do nothing."]
     #[inline]
-    pub fn do_nothing_(self) -> &'a mut W {
-        self.variant(CRSTW::DO_NOTHING_)
+    pub fn do_nothing(self) -> &'a mut W {
+        self.variant(CRSTW::DO_NOTHING)
     }
     #[doc = "The Timer Counter and the Prescale Counter are synchronously reset on the next positive edge of PCLK. The counters remain reset until TCR\\[1\\] is returned to zero."]
     #[inline]
-    pub fn the_timer_counter_an(self) -> &'a mut W {
-        self.variant(CRSTW::THE_TIMER_COUNTER_AN)
+    pub fn reset(self) -> &'a mut W {
+        self.variant(CRSTW::RESET)
     }
     #[doc = r" Sets the field bit"]
     pub fn set_bit(self) -> &'a mut W {

--- a/lpc11uxx/src/gpio_group_int0/ctrl.rs
+++ b/lpc11uxx/src/gpio_group_int0/ctrl.rs
@@ -93,9 +93,9 @@ impl INTR {
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum COMBR {
     #[doc = "OR functionality: A grouped interrupt is generated when any one of the enabled inputs is active (based on its programmed polarity)."]
-    OR_FUNCTIONALITY_A_,
+    OR,
     #[doc = "AND functionality: An interrupt is generated when all enabled bits are active (based on their programmed polarity)."]
-    AND_FUNCTIONALITY_A,
+    AND,
 }
 impl COMBR {
     #[doc = r" Returns `true` if the bit is clear (0)"]
@@ -112,8 +112,8 @@ impl COMBR {
     #[inline]
     pub fn bit(&self) -> bool {
         match *self {
-            COMBR::OR_FUNCTIONALITY_A_ => false,
-            COMBR::AND_FUNCTIONALITY_A => true,
+            COMBR::OR => false,
+            COMBR::AND => true,
         }
     }
     #[allow(missing_docs)]
@@ -121,19 +121,19 @@ impl COMBR {
     #[inline]
     pub fn _from(value: bool) -> COMBR {
         match value {
-            false => COMBR::OR_FUNCTIONALITY_A_,
-            true => COMBR::AND_FUNCTIONALITY_A,
+            false => COMBR::OR,
+            true => COMBR::AND,
         }
     }
-    #[doc = "Checks if the value of the field is `OR_FUNCTIONALITY_A_`"]
+    #[doc = "Checks if the value of the field is `OR`"]
     #[inline]
-    pub fn is_or_functionality_a_(&self) -> bool {
-        *self == COMBR::OR_FUNCTIONALITY_A_
+    pub fn is_or(&self) -> bool {
+        *self == COMBR::OR
     }
-    #[doc = "Checks if the value of the field is `AND_FUNCTIONALITY_A`"]
+    #[doc = "Checks if the value of the field is `AND`"]
     #[inline]
-    pub fn is_and_functionality_a(&self) -> bool {
-        *self == COMBR::AND_FUNCTIONALITY_A
+    pub fn is_and(&self) -> bool {
+        *self == COMBR::AND
     }
 }
 #[doc = "Possible values of the field `TRIG`"]
@@ -244,9 +244,9 @@ impl<'a> _INTW<'a> {
 #[doc = "Values that can be written to the field `COMB`"]
 pub enum COMBW {
     #[doc = "OR functionality: A grouped interrupt is generated when any one of the enabled inputs is active (based on its programmed polarity)."]
-    OR_FUNCTIONALITY_A_,
+    OR,
     #[doc = "AND functionality: An interrupt is generated when all enabled bits are active (based on their programmed polarity)."]
-    AND_FUNCTIONALITY_A,
+    AND,
 }
 impl COMBW {
     #[allow(missing_docs)]
@@ -254,8 +254,8 @@ impl COMBW {
     #[inline]
     pub fn _bits(&self) -> bool {
         match *self {
-            COMBW::OR_FUNCTIONALITY_A_ => false,
-            COMBW::AND_FUNCTIONALITY_A => true,
+            COMBW::OR => false,
+            COMBW::AND => true,
         }
     }
 }
@@ -273,13 +273,13 @@ impl<'a> _COMBW<'a> {
     }
     #[doc = "OR functionality: A grouped interrupt is generated when any one of the enabled inputs is active (based on its programmed polarity)."]
     #[inline]
-    pub fn or_functionality_a_(self) -> &'a mut W {
-        self.variant(COMBW::OR_FUNCTIONALITY_A_)
+    pub fn or(self) -> &'a mut W {
+        self.variant(COMBW::OR)
     }
     #[doc = "AND functionality: An interrupt is generated when all enabled bits are active (based on their programmed polarity)."]
     #[inline]
-    pub fn and_functionality_a(self) -> &'a mut W {
-        self.variant(COMBW::AND_FUNCTIONALITY_A)
+    pub fn and(self) -> &'a mut W {
+        self.variant(COMBW::AND)
     }
     #[doc = r" Sets the field bit"]
     pub fn set_bit(self) -> &'a mut W {

--- a/lpc11uxx/src/i2c/mmctrl.rs
+++ b/lpc11uxx/src/i2c/mmctrl.rs
@@ -46,9 +46,9 @@ impl super::MMCTRL {
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum MM_ENAR {
     #[doc = "Monitor mode disabled."]
-    MONITOR_MODE_DISABLE,
+    DISABLED,
     #[doc = "The I2C module will enter monitor mode. In this mode the SDA output will be forced high. This will prevent the I2C module from outputting data of any kind (including ACK) onto the I 2C data bus. Depending on the state of the ENA_SCL bit, the output may be also forced high, preventing the module from having control over the I2C clock line."]
-    THE_I2C_MODULE_WILL_,
+    ENABLED,
 }
 impl MM_ENAR {
     #[doc = r" Returns `true` if the bit is clear (0)"]
@@ -65,8 +65,8 @@ impl MM_ENAR {
     #[inline]
     pub fn bit(&self) -> bool {
         match *self {
-            MM_ENAR::MONITOR_MODE_DISABLE => false,
-            MM_ENAR::THE_I2C_MODULE_WILL_ => true,
+            MM_ENAR::DISABLED => false,
+            MM_ENAR::ENABLED => true,
         }
     }
     #[allow(missing_docs)]
@@ -74,19 +74,19 @@ impl MM_ENAR {
     #[inline]
     pub fn _from(value: bool) -> MM_ENAR {
         match value {
-            false => MM_ENAR::MONITOR_MODE_DISABLE,
-            true => MM_ENAR::THE_I2C_MODULE_WILL_,
+            false => MM_ENAR::DISABLED,
+            true => MM_ENAR::ENABLED,
         }
     }
-    #[doc = "Checks if the value of the field is `MONITOR_MODE_DISABLE`"]
+    #[doc = "Checks if the value of the field is `DISABLED`"]
     #[inline]
-    pub fn is_monitor_mode_disable(&self) -> bool {
-        *self == MM_ENAR::MONITOR_MODE_DISABLE
+    pub fn is_disabled(&self) -> bool {
+        *self == MM_ENAR::DISABLED
     }
-    #[doc = "Checks if the value of the field is `THE_I2C_MODULE_WILL_`"]
+    #[doc = "Checks if the value of the field is `ENABLED`"]
     #[inline]
-    pub fn is_the_i2c_module_will_(&self) -> bool {
-        *self == MM_ENAR::THE_I2C_MODULE_WILL_
+    pub fn is_enabled(&self) -> bool {
+        *self == MM_ENAR::ENABLED
     }
 }
 #[doc = "Possible values of the field `ENA_SCL`"]
@@ -186,9 +186,9 @@ impl MATCH_ALLR {
 #[doc = "Values that can be written to the field `MM_ENA`"]
 pub enum MM_ENAW {
     #[doc = "Monitor mode disabled."]
-    MONITOR_MODE_DISABLE,
+    DISABLED,
     #[doc = "The I2C module will enter monitor mode. In this mode the SDA output will be forced high. This will prevent the I2C module from outputting data of any kind (including ACK) onto the I 2C data bus. Depending on the state of the ENA_SCL bit, the output may be also forced high, preventing the module from having control over the I2C clock line."]
-    THE_I2C_MODULE_WILL_,
+    ENABLED,
 }
 impl MM_ENAW {
     #[allow(missing_docs)]
@@ -196,8 +196,8 @@ impl MM_ENAW {
     #[inline]
     pub fn _bits(&self) -> bool {
         match *self {
-            MM_ENAW::MONITOR_MODE_DISABLE => false,
-            MM_ENAW::THE_I2C_MODULE_WILL_ => true,
+            MM_ENAW::DISABLED => false,
+            MM_ENAW::ENABLED => true,
         }
     }
 }
@@ -215,13 +215,13 @@ impl<'a> _MM_ENAW<'a> {
     }
     #[doc = "Monitor mode disabled."]
     #[inline]
-    pub fn monitor_mode_disable(self) -> &'a mut W {
-        self.variant(MM_ENAW::MONITOR_MODE_DISABLE)
+    pub fn disabled(self) -> &'a mut W {
+        self.variant(MM_ENAW::DISABLED)
     }
     #[doc = "The I2C module will enter monitor mode. In this mode the SDA output will be forced high. This will prevent the I2C module from outputting data of any kind (including ACK) onto the I 2C data bus. Depending on the state of the ENA_SCL bit, the output may be also forced high, preventing the module from having control over the I2C clock line."]
     #[inline]
-    pub fn the_i2c_module_will_(self) -> &'a mut W {
-        self.variant(MM_ENAW::THE_I2C_MODULE_WILL_)
+    pub fn enabled(self) -> &'a mut W {
+        self.variant(MM_ENAW::ENABLED)
     }
     #[doc = r" Sets the field bit"]
     pub fn set_bit(self) -> &'a mut W {

--- a/lpc11uxx/src/iocon/pio0_1.rs
+++ b/lpc11uxx/src/iocon/pio0_1.rs
@@ -46,13 +46,13 @@ impl super::PIO0_1 {
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum FUNCR {
     #[doc = "PIO0_1."]
-    PIO0_1_,
+    PIO0_1,
     #[doc = "CLKOUT."]
-    CLKOUT_,
+    CLKOUT,
     #[doc = "CT32B0_MAT2."]
-    CT32B0_MAT2_,
+    CT32B0_MAT2,
     #[doc = "USB_FTOGGLE."]
-    USB_FTOGGLE_,
+    USB_FTOGGLE,
     #[doc = r" Reserved"]
     _Reserved(u8),
 }
@@ -61,10 +61,10 @@ impl FUNCR {
     #[inline]
     pub fn bits(&self) -> u8 {
         match *self {
-            FUNCR::PIO0_1_ => 0,
-            FUNCR::CLKOUT_ => 1,
-            FUNCR::CT32B0_MAT2_ => 2,
-            FUNCR::USB_FTOGGLE_ => 3,
+            FUNCR::PIO0_1 => 0,
+            FUNCR::CLKOUT => 1,
+            FUNCR::CT32B0_MAT2 => 2,
+            FUNCR::USB_FTOGGLE => 3,
             FUNCR::_Reserved(bits) => bits,
         }
     }
@@ -73,55 +73,55 @@ impl FUNCR {
     #[inline]
     pub fn _from(value: u8) -> FUNCR {
         match value {
-            0 => FUNCR::PIO0_1_,
-            1 => FUNCR::CLKOUT_,
-            2 => FUNCR::CT32B0_MAT2_,
-            3 => FUNCR::USB_FTOGGLE_,
+            0 => FUNCR::PIO0_1,
+            1 => FUNCR::CLKOUT,
+            2 => FUNCR::CT32B0_MAT2,
+            3 => FUNCR::USB_FTOGGLE,
             i => FUNCR::_Reserved(i),
         }
     }
-    #[doc = "Checks if the value of the field is `PIO0_1_`"]
+    #[doc = "Checks if the value of the field is `PIO0_1`"]
     #[inline]
-    pub fn is_pio0_1_(&self) -> bool {
-        *self == FUNCR::PIO0_1_
+    pub fn is_pio0_1(&self) -> bool {
+        *self == FUNCR::PIO0_1
     }
-    #[doc = "Checks if the value of the field is `CLKOUT_`"]
+    #[doc = "Checks if the value of the field is `CLKOUT`"]
     #[inline]
-    pub fn is_clkout_(&self) -> bool {
-        *self == FUNCR::CLKOUT_
+    pub fn is_clkout(&self) -> bool {
+        *self == FUNCR::CLKOUT
     }
-    #[doc = "Checks if the value of the field is `CT32B0_MAT2_`"]
+    #[doc = "Checks if the value of the field is `CT32B0_MAT2`"]
     #[inline]
-    pub fn is_ct32b0_mat2_(&self) -> bool {
-        *self == FUNCR::CT32B0_MAT2_
+    pub fn is_ct32b0_mat2(&self) -> bool {
+        *self == FUNCR::CT32B0_MAT2
     }
-    #[doc = "Checks if the value of the field is `USB_FTOGGLE_`"]
+    #[doc = "Checks if the value of the field is `USB_FTOGGLE`"]
     #[inline]
-    pub fn is_usb_ftoggle_(&self) -> bool {
-        *self == FUNCR::USB_FTOGGLE_
+    pub fn is_usb_ftoggle(&self) -> bool {
+        *self == FUNCR::USB_FTOGGLE
     }
 }
 #[doc = "Possible values of the field `MODE`"]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum MODER {
     #[doc = "Inactive (no pull-down/pull-up resistor enabled)."]
-    INACTIVE_NO_PULL_DO,
+    INACTIVE,
     #[doc = "Pull-down resistor enabled."]
-    PULL_DOWN_RESISTOR_E,
+    PULL_DOWN,
     #[doc = "Pull-up resistor enabled."]
-    PULL_UP_RESISTOR_ENA,
+    PULL_UP,
     #[doc = "Repeater mode."]
-    REPEATER_MODE_,
+    REPEATER,
 }
 impl MODER {
     #[doc = r" Value of the field as raw bits"]
     #[inline]
     pub fn bits(&self) -> u8 {
         match *self {
-            MODER::INACTIVE_NO_PULL_DO => 0,
-            MODER::PULL_DOWN_RESISTOR_E => 1,
-            MODER::PULL_UP_RESISTOR_ENA => 2,
-            MODER::REPEATER_MODE_ => 3,
+            MODER::INACTIVE => 0,
+            MODER::PULL_DOWN => 1,
+            MODER::PULL_UP => 2,
+            MODER::REPEATER => 3,
         }
     }
     #[allow(missing_docs)]
@@ -129,41 +129,41 @@ impl MODER {
     #[inline]
     pub fn _from(value: u8) -> MODER {
         match value {
-            0 => MODER::INACTIVE_NO_PULL_DO,
-            1 => MODER::PULL_DOWN_RESISTOR_E,
-            2 => MODER::PULL_UP_RESISTOR_ENA,
-            3 => MODER::REPEATER_MODE_,
+            0 => MODER::INACTIVE,
+            1 => MODER::PULL_DOWN,
+            2 => MODER::PULL_UP,
+            3 => MODER::REPEATER,
             _ => unreachable!(),
         }
     }
-    #[doc = "Checks if the value of the field is `INACTIVE_NO_PULL_DO`"]
+    #[doc = "Checks if the value of the field is `INACTIVE`"]
     #[inline]
-    pub fn is_inactive_no_pull_do(&self) -> bool {
-        *self == MODER::INACTIVE_NO_PULL_DO
+    pub fn is_inactive(&self) -> bool {
+        *self == MODER::INACTIVE
     }
-    #[doc = "Checks if the value of the field is `PULL_DOWN_RESISTOR_E`"]
+    #[doc = "Checks if the value of the field is `PULL_DOWN`"]
     #[inline]
-    pub fn is_pull_down_resistor_e(&self) -> bool {
-        *self == MODER::PULL_DOWN_RESISTOR_E
+    pub fn is_pull_down(&self) -> bool {
+        *self == MODER::PULL_DOWN
     }
-    #[doc = "Checks if the value of the field is `PULL_UP_RESISTOR_ENA`"]
+    #[doc = "Checks if the value of the field is `PULL_UP`"]
     #[inline]
-    pub fn is_pull_up_resistor_ena(&self) -> bool {
-        *self == MODER::PULL_UP_RESISTOR_ENA
+    pub fn is_pull_up(&self) -> bool {
+        *self == MODER::PULL_UP
     }
-    #[doc = "Checks if the value of the field is `REPEATER_MODE_`"]
+    #[doc = "Checks if the value of the field is `REPEATER`"]
     #[inline]
-    pub fn is_repeater_mode_(&self) -> bool {
-        *self == MODER::REPEATER_MODE_
+    pub fn is_repeater(&self) -> bool {
+        *self == MODER::REPEATER
     }
 }
 #[doc = "Possible values of the field `HYS`"]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum HYSR {
     #[doc = "Disable."]
-    DISABLE_,
+    DISABLED,
     #[doc = "Enable."]
-    ENABLE_,
+    ENABLED,
 }
 impl HYSR {
     #[doc = r" Returns `true` if the bit is clear (0)"]
@@ -180,8 +180,8 @@ impl HYSR {
     #[inline]
     pub fn bit(&self) -> bool {
         match *self {
-            HYSR::DISABLE_ => false,
-            HYSR::ENABLE_ => true,
+            HYSR::DISABLED => false,
+            HYSR::ENABLED => true,
         }
     }
     #[allow(missing_docs)]
@@ -189,28 +189,28 @@ impl HYSR {
     #[inline]
     pub fn _from(value: bool) -> HYSR {
         match value {
-            false => HYSR::DISABLE_,
-            true => HYSR::ENABLE_,
+            false => HYSR::DISABLED,
+            true => HYSR::ENABLED,
         }
     }
-    #[doc = "Checks if the value of the field is `DISABLE_`"]
+    #[doc = "Checks if the value of the field is `DISABLED`"]
     #[inline]
-    pub fn is_disable_(&self) -> bool {
-        *self == HYSR::DISABLE_
+    pub fn is_disabled(&self) -> bool {
+        *self == HYSR::DISABLED
     }
-    #[doc = "Checks if the value of the field is `ENABLE_`"]
+    #[doc = "Checks if the value of the field is `ENABLED`"]
     #[inline]
-    pub fn is_enable_(&self) -> bool {
-        *self == HYSR::ENABLE_
+    pub fn is_enabled(&self) -> bool {
+        *self == HYSR::ENABLED
     }
 }
 #[doc = "Possible values of the field `INV`"]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum INVR {
     #[doc = "Input not inverted (HIGH on pin reads as 1, LOW on pin reads as 0)."]
-    INPUT_NOT_INVERTED_,
+    NOT_INVERTED,
     #[doc = "Input inverted (HIGH on pin reads as 0, LOW on pin reads as 1)."]
-    INPUT_INVERTED_HIGH,
+    INVERTED,
 }
 impl INVR {
     #[doc = r" Returns `true` if the bit is clear (0)"]
@@ -227,8 +227,8 @@ impl INVR {
     #[inline]
     pub fn bit(&self) -> bool {
         match *self {
-            INVR::INPUT_NOT_INVERTED_ => false,
-            INVR::INPUT_INVERTED_HIGH => true,
+            INVR::NOT_INVERTED => false,
+            INVR::INVERTED => true,
         }
     }
     #[allow(missing_docs)]
@@ -236,28 +236,28 @@ impl INVR {
     #[inline]
     pub fn _from(value: bool) -> INVR {
         match value {
-            false => INVR::INPUT_NOT_INVERTED_,
-            true => INVR::INPUT_INVERTED_HIGH,
+            false => INVR::NOT_INVERTED,
+            true => INVR::INVERTED,
         }
     }
-    #[doc = "Checks if the value of the field is `INPUT_NOT_INVERTED_`"]
+    #[doc = "Checks if the value of the field is `NOT_INVERTED`"]
     #[inline]
-    pub fn is_input_not_inverted_(&self) -> bool {
-        *self == INVR::INPUT_NOT_INVERTED_
+    pub fn is_not_inverted(&self) -> bool {
+        *self == INVR::NOT_INVERTED
     }
-    #[doc = "Checks if the value of the field is `INPUT_INVERTED_HIGH`"]
+    #[doc = "Checks if the value of the field is `INVERTED`"]
     #[inline]
-    pub fn is_input_inverted_high(&self) -> bool {
-        *self == INVR::INPUT_INVERTED_HIGH
+    pub fn is_inverted(&self) -> bool {
+        *self == INVR::INVERTED
     }
 }
 #[doc = "Possible values of the field `OD`"]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum ODR {
     #[doc = "Disable."]
-    DISABLE_,
+    DISABLED,
     #[doc = "Open-drain mode enabled.  This is not a true open-drain mode."]
-    OPEN_DRAIN_MODE_ENAB,
+    OPEN_DRAIN,
 }
 impl ODR {
     #[doc = r" Returns `true` if the bit is clear (0)"]
@@ -274,8 +274,8 @@ impl ODR {
     #[inline]
     pub fn bit(&self) -> bool {
         match *self {
-            ODR::DISABLE_ => false,
-            ODR::OPEN_DRAIN_MODE_ENAB => true,
+            ODR::DISABLED => false,
+            ODR::OPEN_DRAIN => true,
         }
     }
     #[allow(missing_docs)]
@@ -283,31 +283,31 @@ impl ODR {
     #[inline]
     pub fn _from(value: bool) -> ODR {
         match value {
-            false => ODR::DISABLE_,
-            true => ODR::OPEN_DRAIN_MODE_ENAB,
+            false => ODR::DISABLED,
+            true => ODR::OPEN_DRAIN,
         }
     }
-    #[doc = "Checks if the value of the field is `DISABLE_`"]
+    #[doc = "Checks if the value of the field is `DISABLED`"]
     #[inline]
-    pub fn is_disable_(&self) -> bool {
-        *self == ODR::DISABLE_
+    pub fn is_disabled(&self) -> bool {
+        *self == ODR::DISABLED
     }
-    #[doc = "Checks if the value of the field is `OPEN_DRAIN_MODE_ENAB`"]
+    #[doc = "Checks if the value of the field is `OPEN_DRAIN`"]
     #[inline]
-    pub fn is_open_drain_mode_enab(&self) -> bool {
-        *self == ODR::OPEN_DRAIN_MODE_ENAB
+    pub fn is_open_drain(&self) -> bool {
+        *self == ODR::OPEN_DRAIN
     }
 }
 #[doc = "Values that can be written to the field `FUNC`"]
 pub enum FUNCW {
     #[doc = "PIO0_1."]
-    PIO0_1_,
+    PIO0_1,
     #[doc = "CLKOUT."]
-    CLKOUT_,
+    CLKOUT,
     #[doc = "CT32B0_MAT2."]
-    CT32B0_MAT2_,
+    CT32B0_MAT2,
     #[doc = "USB_FTOGGLE."]
-    USB_FTOGGLE_,
+    USB_FTOGGLE,
 }
 impl FUNCW {
     #[allow(missing_docs)]
@@ -315,10 +315,10 @@ impl FUNCW {
     #[inline]
     pub fn _bits(&self) -> u8 {
         match *self {
-            FUNCW::PIO0_1_ => 0,
-            FUNCW::CLKOUT_ => 1,
-            FUNCW::CT32B0_MAT2_ => 2,
-            FUNCW::USB_FTOGGLE_ => 3,
+            FUNCW::PIO0_1 => 0,
+            FUNCW::CLKOUT => 1,
+            FUNCW::CT32B0_MAT2 => 2,
+            FUNCW::USB_FTOGGLE => 3,
         }
     }
 }
@@ -334,23 +334,23 @@ impl<'a> _FUNCW<'a> {
     }
     #[doc = "PIO0_1."]
     #[inline]
-    pub fn pio0_1_(self) -> &'a mut W {
-        self.variant(FUNCW::PIO0_1_)
+    pub fn pio0_1(self) -> &'a mut W {
+        self.variant(FUNCW::PIO0_1)
     }
     #[doc = "CLKOUT."]
     #[inline]
-    pub fn clkout_(self) -> &'a mut W {
-        self.variant(FUNCW::CLKOUT_)
+    pub fn clkout(self) -> &'a mut W {
+        self.variant(FUNCW::CLKOUT)
     }
     #[doc = "CT32B0_MAT2."]
     #[inline]
-    pub fn ct32b0_mat2_(self) -> &'a mut W {
-        self.variant(FUNCW::CT32B0_MAT2_)
+    pub fn ct32b0_mat2(self) -> &'a mut W {
+        self.variant(FUNCW::CT32B0_MAT2)
     }
     #[doc = "USB_FTOGGLE."]
     #[inline]
-    pub fn usb_ftoggle_(self) -> &'a mut W {
-        self.variant(FUNCW::USB_FTOGGLE_)
+    pub fn usb_ftoggle(self) -> &'a mut W {
+        self.variant(FUNCW::USB_FTOGGLE)
     }
     #[doc = r" Writes raw bits to the field"]
     #[inline]
@@ -365,13 +365,13 @@ impl<'a> _FUNCW<'a> {
 #[doc = "Values that can be written to the field `MODE`"]
 pub enum MODEW {
     #[doc = "Inactive (no pull-down/pull-up resistor enabled)."]
-    INACTIVE_NO_PULL_DO,
+    INACTIVE,
     #[doc = "Pull-down resistor enabled."]
-    PULL_DOWN_RESISTOR_E,
+    PULL_DOWN,
     #[doc = "Pull-up resistor enabled."]
-    PULL_UP_RESISTOR_ENA,
+    PULL_UP,
     #[doc = "Repeater mode."]
-    REPEATER_MODE_,
+    REPEATER,
 }
 impl MODEW {
     #[allow(missing_docs)]
@@ -379,10 +379,10 @@ impl MODEW {
     #[inline]
     pub fn _bits(&self) -> u8 {
         match *self {
-            MODEW::INACTIVE_NO_PULL_DO => 0,
-            MODEW::PULL_DOWN_RESISTOR_E => 1,
-            MODEW::PULL_UP_RESISTOR_ENA => 2,
-            MODEW::REPEATER_MODE_ => 3,
+            MODEW::INACTIVE => 0,
+            MODEW::PULL_DOWN => 1,
+            MODEW::PULL_UP => 2,
+            MODEW::REPEATER => 3,
         }
     }
 }
@@ -400,23 +400,23 @@ impl<'a> _MODEW<'a> {
     }
     #[doc = "Inactive (no pull-down/pull-up resistor enabled)."]
     #[inline]
-    pub fn inactive_no_pull_do(self) -> &'a mut W {
-        self.variant(MODEW::INACTIVE_NO_PULL_DO)
+    pub fn inactive(self) -> &'a mut W {
+        self.variant(MODEW::INACTIVE)
     }
     #[doc = "Pull-down resistor enabled."]
     #[inline]
-    pub fn pull_down_resistor_e(self) -> &'a mut W {
-        self.variant(MODEW::PULL_DOWN_RESISTOR_E)
+    pub fn pull_down(self) -> &'a mut W {
+        self.variant(MODEW::PULL_DOWN)
     }
     #[doc = "Pull-up resistor enabled."]
     #[inline]
-    pub fn pull_up_resistor_ena(self) -> &'a mut W {
-        self.variant(MODEW::PULL_UP_RESISTOR_ENA)
+    pub fn pull_up(self) -> &'a mut W {
+        self.variant(MODEW::PULL_UP)
     }
     #[doc = "Repeater mode."]
     #[inline]
-    pub fn repeater_mode_(self) -> &'a mut W {
-        self.variant(MODEW::REPEATER_MODE_)
+    pub fn repeater(self) -> &'a mut W {
+        self.variant(MODEW::REPEATER)
     }
     #[doc = r" Writes raw bits to the field"]
     #[inline]
@@ -431,9 +431,9 @@ impl<'a> _MODEW<'a> {
 #[doc = "Values that can be written to the field `HYS`"]
 pub enum HYSW {
     #[doc = "Disable."]
-    DISABLE_,
+    DISABLED,
     #[doc = "Enable."]
-    ENABLE_,
+    ENABLED,
 }
 impl HYSW {
     #[allow(missing_docs)]
@@ -441,8 +441,8 @@ impl HYSW {
     #[inline]
     pub fn _bits(&self) -> bool {
         match *self {
-            HYSW::DISABLE_ => false,
-            HYSW::ENABLE_ => true,
+            HYSW::DISABLED => false,
+            HYSW::ENABLED => true,
         }
     }
 }
@@ -460,13 +460,13 @@ impl<'a> _HYSW<'a> {
     }
     #[doc = "Disable."]
     #[inline]
-    pub fn disable_(self) -> &'a mut W {
-        self.variant(HYSW::DISABLE_)
+    pub fn disabled(self) -> &'a mut W {
+        self.variant(HYSW::DISABLED)
     }
     #[doc = "Enable."]
     #[inline]
-    pub fn enable_(self) -> &'a mut W {
-        self.variant(HYSW::ENABLE_)
+    pub fn enabled(self) -> &'a mut W {
+        self.variant(HYSW::ENABLED)
     }
     #[doc = r" Sets the field bit"]
     pub fn set_bit(self) -> &'a mut W {
@@ -489,9 +489,9 @@ impl<'a> _HYSW<'a> {
 #[doc = "Values that can be written to the field `INV`"]
 pub enum INVW {
     #[doc = "Input not inverted (HIGH on pin reads as 1, LOW on pin reads as 0)."]
-    INPUT_NOT_INVERTED_,
+    NOT_INVERTED,
     #[doc = "Input inverted (HIGH on pin reads as 0, LOW on pin reads as 1)."]
-    INPUT_INVERTED_HIGH,
+    INVERTED,
 }
 impl INVW {
     #[allow(missing_docs)]
@@ -499,8 +499,8 @@ impl INVW {
     #[inline]
     pub fn _bits(&self) -> bool {
         match *self {
-            INVW::INPUT_NOT_INVERTED_ => false,
-            INVW::INPUT_INVERTED_HIGH => true,
+            INVW::NOT_INVERTED => false,
+            INVW::INVERTED => true,
         }
     }
 }
@@ -518,13 +518,13 @@ impl<'a> _INVW<'a> {
     }
     #[doc = "Input not inverted (HIGH on pin reads as 1, LOW on pin reads as 0)."]
     #[inline]
-    pub fn input_not_inverted_(self) -> &'a mut W {
-        self.variant(INVW::INPUT_NOT_INVERTED_)
+    pub fn not_inverted(self) -> &'a mut W {
+        self.variant(INVW::NOT_INVERTED)
     }
     #[doc = "Input inverted (HIGH on pin reads as 0, LOW on pin reads as 1)."]
     #[inline]
-    pub fn input_inverted_high(self) -> &'a mut W {
-        self.variant(INVW::INPUT_INVERTED_HIGH)
+    pub fn inverted(self) -> &'a mut W {
+        self.variant(INVW::INVERTED)
     }
     #[doc = r" Sets the field bit"]
     pub fn set_bit(self) -> &'a mut W {
@@ -547,9 +547,9 @@ impl<'a> _INVW<'a> {
 #[doc = "Values that can be written to the field `OD`"]
 pub enum ODW {
     #[doc = "Disable."]
-    DISABLE_,
+    DISABLED,
     #[doc = "Open-drain mode enabled.  This is not a true open-drain mode."]
-    OPEN_DRAIN_MODE_ENAB,
+    OPEN_DRAIN,
 }
 impl ODW {
     #[allow(missing_docs)]
@@ -557,8 +557,8 @@ impl ODW {
     #[inline]
     pub fn _bits(&self) -> bool {
         match *self {
-            ODW::DISABLE_ => false,
-            ODW::OPEN_DRAIN_MODE_ENAB => true,
+            ODW::DISABLED => false,
+            ODW::OPEN_DRAIN => true,
         }
     }
 }
@@ -576,13 +576,13 @@ impl<'a> _ODW<'a> {
     }
     #[doc = "Disable."]
     #[inline]
-    pub fn disable_(self) -> &'a mut W {
-        self.variant(ODW::DISABLE_)
+    pub fn disabled(self) -> &'a mut W {
+        self.variant(ODW::DISABLED)
     }
     #[doc = "Open-drain mode enabled. This is not a true open-drain mode."]
     #[inline]
-    pub fn open_drain_mode_enab(self) -> &'a mut W {
-        self.variant(ODW::OPEN_DRAIN_MODE_ENAB)
+    pub fn open_drain(self) -> &'a mut W {
+        self.variant(ODW::OPEN_DRAIN)
     }
     #[doc = r" Sets the field bit"]
     pub fn set_bit(self) -> &'a mut W {

--- a/lpc11uxx/src/iocon/pio0_16.rs
+++ b/lpc11uxx/src/iocon/pio0_16.rs
@@ -46,11 +46,11 @@ impl super::PIO0_16 {
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum FUNCR {
     #[doc = "PIO0_16."]
-    PIO0_16_,
+    PIO0_16,
     #[doc = "AD5."]
-    AD5_,
+    AD5,
     #[doc = "CT32B1_MAT3."]
-    CT32B1_MAT3_,
+    CT32B1_MAT3,
     #[doc = r" Reserved"]
     _Reserved(u8),
 }
@@ -59,9 +59,9 @@ impl FUNCR {
     #[inline]
     pub fn bits(&self) -> u8 {
         match *self {
-            FUNCR::PIO0_16_ => 0,
-            FUNCR::AD5_ => 1,
-            FUNCR::CT32B1_MAT3_ => 2,
+            FUNCR::PIO0_16 => 0,
+            FUNCR::AD5 => 1,
+            FUNCR::CT32B1_MAT3 => 2,
             FUNCR::_Reserved(bits) => bits,
         }
     }
@@ -70,49 +70,49 @@ impl FUNCR {
     #[inline]
     pub fn _from(value: u8) -> FUNCR {
         match value {
-            0 => FUNCR::PIO0_16_,
-            1 => FUNCR::AD5_,
-            2 => FUNCR::CT32B1_MAT3_,
+            0 => FUNCR::PIO0_16,
+            1 => FUNCR::AD5,
+            2 => FUNCR::CT32B1_MAT3,
             i => FUNCR::_Reserved(i),
         }
     }
-    #[doc = "Checks if the value of the field is `PIO0_16_`"]
+    #[doc = "Checks if the value of the field is `PIO0_16`"]
     #[inline]
-    pub fn is_pio0_16_(&self) -> bool {
-        *self == FUNCR::PIO0_16_
+    pub fn is_pio0_16(&self) -> bool {
+        *self == FUNCR::PIO0_16
     }
-    #[doc = "Checks if the value of the field is `AD5_`"]
+    #[doc = "Checks if the value of the field is `AD5`"]
     #[inline]
-    pub fn is_ad5_(&self) -> bool {
-        *self == FUNCR::AD5_
+    pub fn is_ad5(&self) -> bool {
+        *self == FUNCR::AD5
     }
-    #[doc = "Checks if the value of the field is `CT32B1_MAT3_`"]
+    #[doc = "Checks if the value of the field is `CT32B1_MAT3`"]
     #[inline]
-    pub fn is_ct32b1_mat3_(&self) -> bool {
-        *self == FUNCR::CT32B1_MAT3_
+    pub fn is_ct32b1_mat3(&self) -> bool {
+        *self == FUNCR::CT32B1_MAT3
     }
 }
 #[doc = "Possible values of the field `MODE`"]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum MODER {
     #[doc = "Inactive (no pull-down/pull-up resistor enabled)."]
-    INACTIVE_NO_PULL_DO,
+    INACTIVE,
     #[doc = "Pull-down resistor enabled."]
-    PULL_DOWN_RESISTOR_E,
+    PULL_DOWN,
     #[doc = "Pull-up resistor enabled."]
-    PULL_UP_RESISTOR_ENA,
+    PULL_UP,
     #[doc = "Repeater mode."]
-    REPEATER_MODE_,
+    REPEATER,
 }
 impl MODER {
     #[doc = r" Value of the field as raw bits"]
     #[inline]
     pub fn bits(&self) -> u8 {
         match *self {
-            MODER::INACTIVE_NO_PULL_DO => 0,
-            MODER::PULL_DOWN_RESISTOR_E => 1,
-            MODER::PULL_UP_RESISTOR_ENA => 2,
-            MODER::REPEATER_MODE_ => 3,
+            MODER::INACTIVE => 0,
+            MODER::PULL_DOWN => 1,
+            MODER::PULL_UP => 2,
+            MODER::REPEATER => 3,
         }
     }
     #[allow(missing_docs)]
@@ -120,41 +120,41 @@ impl MODER {
     #[inline]
     pub fn _from(value: u8) -> MODER {
         match value {
-            0 => MODER::INACTIVE_NO_PULL_DO,
-            1 => MODER::PULL_DOWN_RESISTOR_E,
-            2 => MODER::PULL_UP_RESISTOR_ENA,
-            3 => MODER::REPEATER_MODE_,
+            0 => MODER::INACTIVE,
+            1 => MODER::PULL_DOWN,
+            2 => MODER::PULL_UP,
+            3 => MODER::REPEATER,
             _ => unreachable!(),
         }
     }
-    #[doc = "Checks if the value of the field is `INACTIVE_NO_PULL_DO`"]
+    #[doc = "Checks if the value of the field is `INACTIVE`"]
     #[inline]
-    pub fn is_inactive_no_pull_do(&self) -> bool {
-        *self == MODER::INACTIVE_NO_PULL_DO
+    pub fn is_inactive(&self) -> bool {
+        *self == MODER::INACTIVE
     }
-    #[doc = "Checks if the value of the field is `PULL_DOWN_RESISTOR_E`"]
+    #[doc = "Checks if the value of the field is `PULL_DOWN`"]
     #[inline]
-    pub fn is_pull_down_resistor_e(&self) -> bool {
-        *self == MODER::PULL_DOWN_RESISTOR_E
+    pub fn is_pull_down(&self) -> bool {
+        *self == MODER::PULL_DOWN
     }
-    #[doc = "Checks if the value of the field is `PULL_UP_RESISTOR_ENA`"]
+    #[doc = "Checks if the value of the field is `PULL_UP`"]
     #[inline]
-    pub fn is_pull_up_resistor_ena(&self) -> bool {
-        *self == MODER::PULL_UP_RESISTOR_ENA
+    pub fn is_pull_up(&self) -> bool {
+        *self == MODER::PULL_UP
     }
-    #[doc = "Checks if the value of the field is `REPEATER_MODE_`"]
+    #[doc = "Checks if the value of the field is `REPEATER`"]
     #[inline]
-    pub fn is_repeater_mode_(&self) -> bool {
-        *self == MODER::REPEATER_MODE_
+    pub fn is_repeater(&self) -> bool {
+        *self == MODER::REPEATER
     }
 }
 #[doc = "Possible values of the field `HYS`"]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum HYSR {
     #[doc = "Disable."]
-    DISABLE_,
+    DISABLED,
     #[doc = "Enable."]
-    ENABLE_,
+    ENABLED,
 }
 impl HYSR {
     #[doc = r" Returns `true` if the bit is clear (0)"]
@@ -171,8 +171,8 @@ impl HYSR {
     #[inline]
     pub fn bit(&self) -> bool {
         match *self {
-            HYSR::DISABLE_ => false,
-            HYSR::ENABLE_ => true,
+            HYSR::DISABLED => false,
+            HYSR::ENABLED => true,
         }
     }
     #[allow(missing_docs)]
@@ -180,28 +180,28 @@ impl HYSR {
     #[inline]
     pub fn _from(value: bool) -> HYSR {
         match value {
-            false => HYSR::DISABLE_,
-            true => HYSR::ENABLE_,
+            false => HYSR::DISABLED,
+            true => HYSR::ENABLED,
         }
     }
-    #[doc = "Checks if the value of the field is `DISABLE_`"]
+    #[doc = "Checks if the value of the field is `DISABLED`"]
     #[inline]
-    pub fn is_disable_(&self) -> bool {
-        *self == HYSR::DISABLE_
+    pub fn is_disabled(&self) -> bool {
+        *self == HYSR::DISABLED
     }
-    #[doc = "Checks if the value of the field is `ENABLE_`"]
+    #[doc = "Checks if the value of the field is `ENABLED`"]
     #[inline]
-    pub fn is_enable_(&self) -> bool {
-        *self == HYSR::ENABLE_
+    pub fn is_enabled(&self) -> bool {
+        *self == HYSR::ENABLED
     }
 }
 #[doc = "Possible values of the field `INV`"]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum INVR {
     #[doc = "Input not inverted (HIGH on pin reads as 1, LOW on pin reads as 0)."]
-    INPUT_NOT_INVERTED_,
+    NOT_INVERTED,
     #[doc = "Input inverted (HIGH on pin reads as 0, LOW on pin reads as 1)."]
-    INPUT_INVERTED_HIGH,
+    INVERTED,
 }
 impl INVR {
     #[doc = r" Returns `true` if the bit is clear (0)"]
@@ -218,8 +218,8 @@ impl INVR {
     #[inline]
     pub fn bit(&self) -> bool {
         match *self {
-            INVR::INPUT_NOT_INVERTED_ => false,
-            INVR::INPUT_INVERTED_HIGH => true,
+            INVR::NOT_INVERTED => false,
+            INVR::INVERTED => true,
         }
     }
     #[allow(missing_docs)]
@@ -227,28 +227,28 @@ impl INVR {
     #[inline]
     pub fn _from(value: bool) -> INVR {
         match value {
-            false => INVR::INPUT_NOT_INVERTED_,
-            true => INVR::INPUT_INVERTED_HIGH,
+            false => INVR::NOT_INVERTED,
+            true => INVR::INVERTED,
         }
     }
-    #[doc = "Checks if the value of the field is `INPUT_NOT_INVERTED_`"]
+    #[doc = "Checks if the value of the field is `NOT_INVERTED`"]
     #[inline]
-    pub fn is_input_not_inverted_(&self) -> bool {
-        *self == INVR::INPUT_NOT_INVERTED_
+    pub fn is_not_inverted(&self) -> bool {
+        *self == INVR::NOT_INVERTED
     }
-    #[doc = "Checks if the value of the field is `INPUT_INVERTED_HIGH`"]
+    #[doc = "Checks if the value of the field is `INVERTED`"]
     #[inline]
-    pub fn is_input_inverted_high(&self) -> bool {
-        *self == INVR::INPUT_INVERTED_HIGH
+    pub fn is_inverted(&self) -> bool {
+        *self == INVR::INVERTED
     }
 }
 #[doc = "Possible values of the field `ADMODE`"]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum ADMODER {
     #[doc = "Analog input mode."]
-    ANALOG_INPUT_MODE_,
+    ANALOG,
     #[doc = "Digital functional mode."]
-    DIGITAL_FUNCTIONAL_M,
+    DIGITAL,
 }
 impl ADMODER {
     #[doc = r" Returns `true` if the bit is clear (0)"]
@@ -265,8 +265,8 @@ impl ADMODER {
     #[inline]
     pub fn bit(&self) -> bool {
         match *self {
-            ADMODER::ANALOG_INPUT_MODE_ => false,
-            ADMODER::DIGITAL_FUNCTIONAL_M => true,
+            ADMODER::ANALOG => false,
+            ADMODER::DIGITAL => true,
         }
     }
     #[allow(missing_docs)]
@@ -274,28 +274,28 @@ impl ADMODER {
     #[inline]
     pub fn _from(value: bool) -> ADMODER {
         match value {
-            false => ADMODER::ANALOG_INPUT_MODE_,
-            true => ADMODER::DIGITAL_FUNCTIONAL_M,
+            false => ADMODER::ANALOG,
+            true => ADMODER::DIGITAL,
         }
     }
-    #[doc = "Checks if the value of the field is `ANALOG_INPUT_MODE_`"]
+    #[doc = "Checks if the value of the field is `ANALOG`"]
     #[inline]
-    pub fn is_analog_input_mode_(&self) -> bool {
-        *self == ADMODER::ANALOG_INPUT_MODE_
+    pub fn is_analog(&self) -> bool {
+        *self == ADMODER::ANALOG
     }
-    #[doc = "Checks if the value of the field is `DIGITAL_FUNCTIONAL_M`"]
+    #[doc = "Checks if the value of the field is `DIGITAL`"]
     #[inline]
-    pub fn is_digital_functional_m(&self) -> bool {
-        *self == ADMODER::DIGITAL_FUNCTIONAL_M
+    pub fn is_digital(&self) -> bool {
+        *self == ADMODER::DIGITAL
     }
 }
 #[doc = "Possible values of the field `FILTR`"]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum FILTRR {
     #[doc = "Filter enabled."]
-    FILTER_ENABLED_,
+    ENABLED,
     #[doc = "Filter disabled."]
-    FILTER_DISABLED_,
+    DISABLED,
 }
 impl FILTRR {
     #[doc = r" Returns `true` if the bit is clear (0)"]
@@ -312,8 +312,8 @@ impl FILTRR {
     #[inline]
     pub fn bit(&self) -> bool {
         match *self {
-            FILTRR::FILTER_ENABLED_ => false,
-            FILTRR::FILTER_DISABLED_ => true,
+            FILTRR::ENABLED => false,
+            FILTRR::DISABLED => true,
         }
     }
     #[allow(missing_docs)]
@@ -321,28 +321,28 @@ impl FILTRR {
     #[inline]
     pub fn _from(value: bool) -> FILTRR {
         match value {
-            false => FILTRR::FILTER_ENABLED_,
-            true => FILTRR::FILTER_DISABLED_,
+            false => FILTRR::ENABLED,
+            true => FILTRR::DISABLED,
         }
     }
-    #[doc = "Checks if the value of the field is `FILTER_ENABLED_`"]
+    #[doc = "Checks if the value of the field is `ENABLED`"]
     #[inline]
-    pub fn is_filter_enabled_(&self) -> bool {
-        *self == FILTRR::FILTER_ENABLED_
+    pub fn is_enabled(&self) -> bool {
+        *self == FILTRR::ENABLED
     }
-    #[doc = "Checks if the value of the field is `FILTER_DISABLED_`"]
+    #[doc = "Checks if the value of the field is `DISABLED`"]
     #[inline]
-    pub fn is_filter_disabled_(&self) -> bool {
-        *self == FILTRR::FILTER_DISABLED_
+    pub fn is_disabled(&self) -> bool {
+        *self == FILTRR::DISABLED
     }
 }
 #[doc = "Possible values of the field `OD`"]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum ODR {
     #[doc = "Disable."]
-    DISABLE_,
+    DISABLED,
     #[doc = "Open-drain mode enabled.  This is not a true open-drain mode."]
-    OPEN_DRAIN_MODE_ENAB,
+    OPEN_DRAIN,
 }
 impl ODR {
     #[doc = r" Returns `true` if the bit is clear (0)"]
@@ -359,8 +359,8 @@ impl ODR {
     #[inline]
     pub fn bit(&self) -> bool {
         match *self {
-            ODR::DISABLE_ => false,
-            ODR::OPEN_DRAIN_MODE_ENAB => true,
+            ODR::DISABLED => false,
+            ODR::OPEN_DRAIN => true,
         }
     }
     #[allow(missing_docs)]
@@ -368,29 +368,29 @@ impl ODR {
     #[inline]
     pub fn _from(value: bool) -> ODR {
         match value {
-            false => ODR::DISABLE_,
-            true => ODR::OPEN_DRAIN_MODE_ENAB,
+            false => ODR::DISABLED,
+            true => ODR::OPEN_DRAIN,
         }
     }
-    #[doc = "Checks if the value of the field is `DISABLE_`"]
+    #[doc = "Checks if the value of the field is `DISABLED`"]
     #[inline]
-    pub fn is_disable_(&self) -> bool {
-        *self == ODR::DISABLE_
+    pub fn is_disabled(&self) -> bool {
+        *self == ODR::DISABLED
     }
-    #[doc = "Checks if the value of the field is `OPEN_DRAIN_MODE_ENAB`"]
+    #[doc = "Checks if the value of the field is `OPEN_DRAIN`"]
     #[inline]
-    pub fn is_open_drain_mode_enab(&self) -> bool {
-        *self == ODR::OPEN_DRAIN_MODE_ENAB
+    pub fn is_open_drain(&self) -> bool {
+        *self == ODR::OPEN_DRAIN
     }
 }
 #[doc = "Values that can be written to the field `FUNC`"]
 pub enum FUNCW {
     #[doc = "PIO0_16."]
-    PIO0_16_,
+    PIO0_16,
     #[doc = "AD5."]
-    AD5_,
+    AD5,
     #[doc = "CT32B1_MAT3."]
-    CT32B1_MAT3_,
+    CT32B1_MAT3,
 }
 impl FUNCW {
     #[allow(missing_docs)]
@@ -398,9 +398,9 @@ impl FUNCW {
     #[inline]
     pub fn _bits(&self) -> u8 {
         match *self {
-            FUNCW::PIO0_16_ => 0,
-            FUNCW::AD5_ => 1,
-            FUNCW::CT32B1_MAT3_ => 2,
+            FUNCW::PIO0_16 => 0,
+            FUNCW::AD5 => 1,
+            FUNCW::CT32B1_MAT3 => 2,
         }
     }
 }
@@ -416,18 +416,18 @@ impl<'a> _FUNCW<'a> {
     }
     #[doc = "PIO0_16."]
     #[inline]
-    pub fn pio0_16_(self) -> &'a mut W {
-        self.variant(FUNCW::PIO0_16_)
+    pub fn pio0_16(self) -> &'a mut W {
+        self.variant(FUNCW::PIO0_16)
     }
     #[doc = "AD5."]
     #[inline]
-    pub fn ad5_(self) -> &'a mut W {
-        self.variant(FUNCW::AD5_)
+    pub fn ad5(self) -> &'a mut W {
+        self.variant(FUNCW::AD5)
     }
     #[doc = "CT32B1_MAT3."]
     #[inline]
-    pub fn ct32b1_mat3_(self) -> &'a mut W {
-        self.variant(FUNCW::CT32B1_MAT3_)
+    pub fn ct32b1_mat3(self) -> &'a mut W {
+        self.variant(FUNCW::CT32B1_MAT3)
     }
     #[doc = r" Writes raw bits to the field"]
     #[inline]
@@ -442,13 +442,13 @@ impl<'a> _FUNCW<'a> {
 #[doc = "Values that can be written to the field `MODE`"]
 pub enum MODEW {
     #[doc = "Inactive (no pull-down/pull-up resistor enabled)."]
-    INACTIVE_NO_PULL_DO,
+    INACTIVE,
     #[doc = "Pull-down resistor enabled."]
-    PULL_DOWN_RESISTOR_E,
+    PULL_DOWN,
     #[doc = "Pull-up resistor enabled."]
-    PULL_UP_RESISTOR_ENA,
+    PULL_UP,
     #[doc = "Repeater mode."]
-    REPEATER_MODE_,
+    REPEATER,
 }
 impl MODEW {
     #[allow(missing_docs)]
@@ -456,10 +456,10 @@ impl MODEW {
     #[inline]
     pub fn _bits(&self) -> u8 {
         match *self {
-            MODEW::INACTIVE_NO_PULL_DO => 0,
-            MODEW::PULL_DOWN_RESISTOR_E => 1,
-            MODEW::PULL_UP_RESISTOR_ENA => 2,
-            MODEW::REPEATER_MODE_ => 3,
+            MODEW::INACTIVE => 0,
+            MODEW::PULL_DOWN => 1,
+            MODEW::PULL_UP => 2,
+            MODEW::REPEATER => 3,
         }
     }
 }
@@ -477,23 +477,23 @@ impl<'a> _MODEW<'a> {
     }
     #[doc = "Inactive (no pull-down/pull-up resistor enabled)."]
     #[inline]
-    pub fn inactive_no_pull_do(self) -> &'a mut W {
-        self.variant(MODEW::INACTIVE_NO_PULL_DO)
+    pub fn inactive(self) -> &'a mut W {
+        self.variant(MODEW::INACTIVE)
     }
     #[doc = "Pull-down resistor enabled."]
     #[inline]
-    pub fn pull_down_resistor_e(self) -> &'a mut W {
-        self.variant(MODEW::PULL_DOWN_RESISTOR_E)
+    pub fn pull_down(self) -> &'a mut W {
+        self.variant(MODEW::PULL_DOWN)
     }
     #[doc = "Pull-up resistor enabled."]
     #[inline]
-    pub fn pull_up_resistor_ena(self) -> &'a mut W {
-        self.variant(MODEW::PULL_UP_RESISTOR_ENA)
+    pub fn pull_up(self) -> &'a mut W {
+        self.variant(MODEW::PULL_UP)
     }
     #[doc = "Repeater mode."]
     #[inline]
-    pub fn repeater_mode_(self) -> &'a mut W {
-        self.variant(MODEW::REPEATER_MODE_)
+    pub fn repeater(self) -> &'a mut W {
+        self.variant(MODEW::REPEATER)
     }
     #[doc = r" Writes raw bits to the field"]
     #[inline]
@@ -508,9 +508,9 @@ impl<'a> _MODEW<'a> {
 #[doc = "Values that can be written to the field `HYS`"]
 pub enum HYSW {
     #[doc = "Disable."]
-    DISABLE_,
+    DISABLED,
     #[doc = "Enable."]
-    ENABLE_,
+    ENABLED,
 }
 impl HYSW {
     #[allow(missing_docs)]
@@ -518,8 +518,8 @@ impl HYSW {
     #[inline]
     pub fn _bits(&self) -> bool {
         match *self {
-            HYSW::DISABLE_ => false,
-            HYSW::ENABLE_ => true,
+            HYSW::DISABLED => false,
+            HYSW::ENABLED => true,
         }
     }
 }
@@ -537,13 +537,13 @@ impl<'a> _HYSW<'a> {
     }
     #[doc = "Disable."]
     #[inline]
-    pub fn disable_(self) -> &'a mut W {
-        self.variant(HYSW::DISABLE_)
+    pub fn disabled(self) -> &'a mut W {
+        self.variant(HYSW::DISABLED)
     }
     #[doc = "Enable."]
     #[inline]
-    pub fn enable_(self) -> &'a mut W {
-        self.variant(HYSW::ENABLE_)
+    pub fn enabled(self) -> &'a mut W {
+        self.variant(HYSW::ENABLED)
     }
     #[doc = r" Sets the field bit"]
     pub fn set_bit(self) -> &'a mut W {
@@ -566,9 +566,9 @@ impl<'a> _HYSW<'a> {
 #[doc = "Values that can be written to the field `INV`"]
 pub enum INVW {
     #[doc = "Input not inverted (HIGH on pin reads as 1, LOW on pin reads as 0)."]
-    INPUT_NOT_INVERTED_,
+    NOT_INVERTED,
     #[doc = "Input inverted (HIGH on pin reads as 0, LOW on pin reads as 1)."]
-    INPUT_INVERTED_HIGH,
+    INVERTED,
 }
 impl INVW {
     #[allow(missing_docs)]
@@ -576,8 +576,8 @@ impl INVW {
     #[inline]
     pub fn _bits(&self) -> bool {
         match *self {
-            INVW::INPUT_NOT_INVERTED_ => false,
-            INVW::INPUT_INVERTED_HIGH => true,
+            INVW::NOT_INVERTED => false,
+            INVW::INVERTED => true,
         }
     }
 }
@@ -595,13 +595,13 @@ impl<'a> _INVW<'a> {
     }
     #[doc = "Input not inverted (HIGH on pin reads as 1, LOW on pin reads as 0)."]
     #[inline]
-    pub fn input_not_inverted_(self) -> &'a mut W {
-        self.variant(INVW::INPUT_NOT_INVERTED_)
+    pub fn not_inverted(self) -> &'a mut W {
+        self.variant(INVW::NOT_INVERTED)
     }
     #[doc = "Input inverted (HIGH on pin reads as 0, LOW on pin reads as 1)."]
     #[inline]
-    pub fn input_inverted_high(self) -> &'a mut W {
-        self.variant(INVW::INPUT_INVERTED_HIGH)
+    pub fn inverted(self) -> &'a mut W {
+        self.variant(INVW::INVERTED)
     }
     #[doc = r" Sets the field bit"]
     pub fn set_bit(self) -> &'a mut W {
@@ -624,9 +624,9 @@ impl<'a> _INVW<'a> {
 #[doc = "Values that can be written to the field `ADMODE`"]
 pub enum ADMODEW {
     #[doc = "Analog input mode."]
-    ANALOG_INPUT_MODE_,
+    ANALOG,
     #[doc = "Digital functional mode."]
-    DIGITAL_FUNCTIONAL_M,
+    DIGITAL,
 }
 impl ADMODEW {
     #[allow(missing_docs)]
@@ -634,8 +634,8 @@ impl ADMODEW {
     #[inline]
     pub fn _bits(&self) -> bool {
         match *self {
-            ADMODEW::ANALOG_INPUT_MODE_ => false,
-            ADMODEW::DIGITAL_FUNCTIONAL_M => true,
+            ADMODEW::ANALOG => false,
+            ADMODEW::DIGITAL => true,
         }
     }
 }
@@ -653,13 +653,13 @@ impl<'a> _ADMODEW<'a> {
     }
     #[doc = "Analog input mode."]
     #[inline]
-    pub fn analog_input_mode_(self) -> &'a mut W {
-        self.variant(ADMODEW::ANALOG_INPUT_MODE_)
+    pub fn analog(self) -> &'a mut W {
+        self.variant(ADMODEW::ANALOG)
     }
     #[doc = "Digital functional mode."]
     #[inline]
-    pub fn digital_functional_m(self) -> &'a mut W {
-        self.variant(ADMODEW::DIGITAL_FUNCTIONAL_M)
+    pub fn digital(self) -> &'a mut W {
+        self.variant(ADMODEW::DIGITAL)
     }
     #[doc = r" Sets the field bit"]
     pub fn set_bit(self) -> &'a mut W {
@@ -682,9 +682,9 @@ impl<'a> _ADMODEW<'a> {
 #[doc = "Values that can be written to the field `FILTR`"]
 pub enum FILTRW {
     #[doc = "Filter enabled."]
-    FILTER_ENABLED_,
+    ENABLED,
     #[doc = "Filter disabled."]
-    FILTER_DISABLED_,
+    DISABLED,
 }
 impl FILTRW {
     #[allow(missing_docs)]
@@ -692,8 +692,8 @@ impl FILTRW {
     #[inline]
     pub fn _bits(&self) -> bool {
         match *self {
-            FILTRW::FILTER_ENABLED_ => false,
-            FILTRW::FILTER_DISABLED_ => true,
+            FILTRW::ENABLED => false,
+            FILTRW::DISABLED => true,
         }
     }
 }
@@ -711,13 +711,13 @@ impl<'a> _FILTRW<'a> {
     }
     #[doc = "Filter enabled."]
     #[inline]
-    pub fn filter_enabled_(self) -> &'a mut W {
-        self.variant(FILTRW::FILTER_ENABLED_)
+    pub fn enabled(self) -> &'a mut W {
+        self.variant(FILTRW::ENABLED)
     }
     #[doc = "Filter disabled."]
     #[inline]
-    pub fn filter_disabled_(self) -> &'a mut W {
-        self.variant(FILTRW::FILTER_DISABLED_)
+    pub fn disabled(self) -> &'a mut W {
+        self.variant(FILTRW::DISABLED)
     }
     #[doc = r" Sets the field bit"]
     pub fn set_bit(self) -> &'a mut W {
@@ -740,9 +740,9 @@ impl<'a> _FILTRW<'a> {
 #[doc = "Values that can be written to the field `OD`"]
 pub enum ODW {
     #[doc = "Disable."]
-    DISABLE_,
+    DISABLED,
     #[doc = "Open-drain mode enabled.  This is not a true open-drain mode."]
-    OPEN_DRAIN_MODE_ENAB,
+    OPEN_DRAIN,
 }
 impl ODW {
     #[allow(missing_docs)]
@@ -750,8 +750,8 @@ impl ODW {
     #[inline]
     pub fn _bits(&self) -> bool {
         match *self {
-            ODW::DISABLE_ => false,
-            ODW::OPEN_DRAIN_MODE_ENAB => true,
+            ODW::DISABLED => false,
+            ODW::OPEN_DRAIN => true,
         }
     }
 }
@@ -769,13 +769,13 @@ impl<'a> _ODW<'a> {
     }
     #[doc = "Disable."]
     #[inline]
-    pub fn disable_(self) -> &'a mut W {
-        self.variant(ODW::DISABLE_)
+    pub fn disabled(self) -> &'a mut W {
+        self.variant(ODW::DISABLED)
     }
     #[doc = "Open-drain mode enabled. This is not a true open-drain mode."]
     #[inline]
-    pub fn open_drain_mode_enab(self) -> &'a mut W {
-        self.variant(ODW::OPEN_DRAIN_MODE_ENAB)
+    pub fn open_drain(self) -> &'a mut W {
+        self.variant(ODW::OPEN_DRAIN)
     }
     #[doc = r" Sets the field bit"]
     pub fn set_bit(self) -> &'a mut W {

--- a/lpc11uxx/src/iocon/pio0_17.rs
+++ b/lpc11uxx/src/iocon/pio0_17.rs
@@ -46,11 +46,11 @@ impl super::PIO0_17 {
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum FUNCR {
     #[doc = "PIO0_17."]
-    PIO0_17_,
+    PIO0_17,
     #[doc = "RTS."]
-    RTS_,
+    RTS,
     #[doc = "CT32B0_CAP0."]
-    CT32B0_CAP0_,
+    CT32B0_CAP0,
     #[doc = "SCLK (UART synchronous clock)."]
     SCLK_UART_SYNCHRONO,
     #[doc = r" Reserved"]
@@ -61,9 +61,9 @@ impl FUNCR {
     #[inline]
     pub fn bits(&self) -> u8 {
         match *self {
-            FUNCR::PIO0_17_ => 0,
-            FUNCR::RTS_ => 1,
-            FUNCR::CT32B0_CAP0_ => 2,
+            FUNCR::PIO0_17 => 0,
+            FUNCR::RTS => 1,
+            FUNCR::CT32B0_CAP0 => 2,
             FUNCR::SCLK_UART_SYNCHRONO => 3,
             FUNCR::_Reserved(bits) => bits,
         }
@@ -73,27 +73,27 @@ impl FUNCR {
     #[inline]
     pub fn _from(value: u8) -> FUNCR {
         match value {
-            0 => FUNCR::PIO0_17_,
-            1 => FUNCR::RTS_,
-            2 => FUNCR::CT32B0_CAP0_,
+            0 => FUNCR::PIO0_17,
+            1 => FUNCR::RTS,
+            2 => FUNCR::CT32B0_CAP0,
             3 => FUNCR::SCLK_UART_SYNCHRONO,
             i => FUNCR::_Reserved(i),
         }
     }
-    #[doc = "Checks if the value of the field is `PIO0_17_`"]
+    #[doc = "Checks if the value of the field is `PIO0_17`"]
     #[inline]
-    pub fn is_pio0_17_(&self) -> bool {
-        *self == FUNCR::PIO0_17_
+    pub fn is_pio0_17(&self) -> bool {
+        *self == FUNCR::PIO0_17
     }
-    #[doc = "Checks if the value of the field is `RTS_`"]
+    #[doc = "Checks if the value of the field is `RTS`"]
     #[inline]
-    pub fn is_rts_(&self) -> bool {
-        *self == FUNCR::RTS_
+    pub fn is_rts(&self) -> bool {
+        *self == FUNCR::RTS
     }
-    #[doc = "Checks if the value of the field is `CT32B0_CAP0_`"]
+    #[doc = "Checks if the value of the field is `CT32B0_CAP0`"]
     #[inline]
-    pub fn is_ct32b0_cap0_(&self) -> bool {
-        *self == FUNCR::CT32B0_CAP0_
+    pub fn is_ct32b0_cap0(&self) -> bool {
+        *self == FUNCR::CT32B0_CAP0
     }
     #[doc = "Checks if the value of the field is `SCLK_UART_SYNCHRONO`"]
     #[inline]
@@ -105,23 +105,23 @@ impl FUNCR {
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum MODER {
     #[doc = "Inactive (no pull-down/pull-up resistor enabled)."]
-    INACTIVE_NO_PULL_DO,
+    INACTIVE,
     #[doc = "Pull-down resistor enabled."]
-    PULL_DOWN_RESISTOR_E,
+    PULL_DOWN,
     #[doc = "Pull-up resistor enabled."]
-    PULL_UP_RESISTOR_ENA,
+    PULL_UP,
     #[doc = "Repeater mode."]
-    REPEATER_MODE_,
+    REPEATER,
 }
 impl MODER {
     #[doc = r" Value of the field as raw bits"]
     #[inline]
     pub fn bits(&self) -> u8 {
         match *self {
-            MODER::INACTIVE_NO_PULL_DO => 0,
-            MODER::PULL_DOWN_RESISTOR_E => 1,
-            MODER::PULL_UP_RESISTOR_ENA => 2,
-            MODER::REPEATER_MODE_ => 3,
+            MODER::INACTIVE => 0,
+            MODER::PULL_DOWN => 1,
+            MODER::PULL_UP => 2,
+            MODER::REPEATER => 3,
         }
     }
     #[allow(missing_docs)]
@@ -129,41 +129,41 @@ impl MODER {
     #[inline]
     pub fn _from(value: u8) -> MODER {
         match value {
-            0 => MODER::INACTIVE_NO_PULL_DO,
-            1 => MODER::PULL_DOWN_RESISTOR_E,
-            2 => MODER::PULL_UP_RESISTOR_ENA,
-            3 => MODER::REPEATER_MODE_,
+            0 => MODER::INACTIVE,
+            1 => MODER::PULL_DOWN,
+            2 => MODER::PULL_UP,
+            3 => MODER::REPEATER,
             _ => unreachable!(),
         }
     }
-    #[doc = "Checks if the value of the field is `INACTIVE_NO_PULL_DO`"]
+    #[doc = "Checks if the value of the field is `INACTIVE`"]
     #[inline]
-    pub fn is_inactive_no_pull_do(&self) -> bool {
-        *self == MODER::INACTIVE_NO_PULL_DO
+    pub fn is_inactive(&self) -> bool {
+        *self == MODER::INACTIVE
     }
-    #[doc = "Checks if the value of the field is `PULL_DOWN_RESISTOR_E`"]
+    #[doc = "Checks if the value of the field is `PULL_DOWN`"]
     #[inline]
-    pub fn is_pull_down_resistor_e(&self) -> bool {
-        *self == MODER::PULL_DOWN_RESISTOR_E
+    pub fn is_pull_down(&self) -> bool {
+        *self == MODER::PULL_DOWN
     }
-    #[doc = "Checks if the value of the field is `PULL_UP_RESISTOR_ENA`"]
+    #[doc = "Checks if the value of the field is `PULL_UP`"]
     #[inline]
-    pub fn is_pull_up_resistor_ena(&self) -> bool {
-        *self == MODER::PULL_UP_RESISTOR_ENA
+    pub fn is_pull_up(&self) -> bool {
+        *self == MODER::PULL_UP
     }
-    #[doc = "Checks if the value of the field is `REPEATER_MODE_`"]
+    #[doc = "Checks if the value of the field is `REPEATER`"]
     #[inline]
-    pub fn is_repeater_mode_(&self) -> bool {
-        *self == MODER::REPEATER_MODE_
+    pub fn is_repeater(&self) -> bool {
+        *self == MODER::REPEATER
     }
 }
 #[doc = "Possible values of the field `HYS`"]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum HYSR {
     #[doc = "Disable."]
-    DISABLE_,
+    DISABLED,
     #[doc = "Enable."]
-    ENABLE_,
+    ENABLED,
 }
 impl HYSR {
     #[doc = r" Returns `true` if the bit is clear (0)"]
@@ -180,8 +180,8 @@ impl HYSR {
     #[inline]
     pub fn bit(&self) -> bool {
         match *self {
-            HYSR::DISABLE_ => false,
-            HYSR::ENABLE_ => true,
+            HYSR::DISABLED => false,
+            HYSR::ENABLED => true,
         }
     }
     #[allow(missing_docs)]
@@ -189,28 +189,28 @@ impl HYSR {
     #[inline]
     pub fn _from(value: bool) -> HYSR {
         match value {
-            false => HYSR::DISABLE_,
-            true => HYSR::ENABLE_,
+            false => HYSR::DISABLED,
+            true => HYSR::ENABLED,
         }
     }
-    #[doc = "Checks if the value of the field is `DISABLE_`"]
+    #[doc = "Checks if the value of the field is `DISABLED`"]
     #[inline]
-    pub fn is_disable_(&self) -> bool {
-        *self == HYSR::DISABLE_
+    pub fn is_disabled(&self) -> bool {
+        *self == HYSR::DISABLED
     }
-    #[doc = "Checks if the value of the field is `ENABLE_`"]
+    #[doc = "Checks if the value of the field is `ENABLED`"]
     #[inline]
-    pub fn is_enable_(&self) -> bool {
-        *self == HYSR::ENABLE_
+    pub fn is_enabled(&self) -> bool {
+        *self == HYSR::ENABLED
     }
 }
 #[doc = "Possible values of the field `INV`"]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum INVR {
     #[doc = "Input not inverted (HIGH on pin reads as 1, LOW on pin reads as 0)."]
-    INPUT_NOT_INVERTED_,
+    NOT_INVERTED,
     #[doc = "Input inverted (HIGH on pin reads as 0, LOW on pin reads as 1)."]
-    INPUT_INVERTED_HIGH,
+    INVERTED,
 }
 impl INVR {
     #[doc = r" Returns `true` if the bit is clear (0)"]
@@ -227,8 +227,8 @@ impl INVR {
     #[inline]
     pub fn bit(&self) -> bool {
         match *self {
-            INVR::INPUT_NOT_INVERTED_ => false,
-            INVR::INPUT_INVERTED_HIGH => true,
+            INVR::NOT_INVERTED => false,
+            INVR::INVERTED => true,
         }
     }
     #[allow(missing_docs)]
@@ -236,28 +236,28 @@ impl INVR {
     #[inline]
     pub fn _from(value: bool) -> INVR {
         match value {
-            false => INVR::INPUT_NOT_INVERTED_,
-            true => INVR::INPUT_INVERTED_HIGH,
+            false => INVR::NOT_INVERTED,
+            true => INVR::INVERTED,
         }
     }
-    #[doc = "Checks if the value of the field is `INPUT_NOT_INVERTED_`"]
+    #[doc = "Checks if the value of the field is `NOT_INVERTED`"]
     #[inline]
-    pub fn is_input_not_inverted_(&self) -> bool {
-        *self == INVR::INPUT_NOT_INVERTED_
+    pub fn is_not_inverted(&self) -> bool {
+        *self == INVR::NOT_INVERTED
     }
-    #[doc = "Checks if the value of the field is `INPUT_INVERTED_HIGH`"]
+    #[doc = "Checks if the value of the field is `INVERTED`"]
     #[inline]
-    pub fn is_input_inverted_high(&self) -> bool {
-        *self == INVR::INPUT_INVERTED_HIGH
+    pub fn is_inverted(&self) -> bool {
+        *self == INVR::INVERTED
     }
 }
 #[doc = "Possible values of the field `OD`"]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum ODR {
     #[doc = "Disable."]
-    DISABLE_,
+    DISABLED,
     #[doc = "Open-drain mode enabled.  This is not a true open-drain mode."]
-    OPEN_DRAIN_MODE_ENAB,
+    OPEN_DRAIN,
 }
 impl ODR {
     #[doc = r" Returns `true` if the bit is clear (0)"]
@@ -274,8 +274,8 @@ impl ODR {
     #[inline]
     pub fn bit(&self) -> bool {
         match *self {
-            ODR::DISABLE_ => false,
-            ODR::OPEN_DRAIN_MODE_ENAB => true,
+            ODR::DISABLED => false,
+            ODR::OPEN_DRAIN => true,
         }
     }
     #[allow(missing_docs)]
@@ -283,29 +283,29 @@ impl ODR {
     #[inline]
     pub fn _from(value: bool) -> ODR {
         match value {
-            false => ODR::DISABLE_,
-            true => ODR::OPEN_DRAIN_MODE_ENAB,
+            false => ODR::DISABLED,
+            true => ODR::OPEN_DRAIN,
         }
     }
-    #[doc = "Checks if the value of the field is `DISABLE_`"]
+    #[doc = "Checks if the value of the field is `DISABLED`"]
     #[inline]
-    pub fn is_disable_(&self) -> bool {
-        *self == ODR::DISABLE_
+    pub fn is_disabled(&self) -> bool {
+        *self == ODR::DISABLED
     }
-    #[doc = "Checks if the value of the field is `OPEN_DRAIN_MODE_ENAB`"]
+    #[doc = "Checks if the value of the field is `OPEN_DRAIN`"]
     #[inline]
-    pub fn is_open_drain_mode_enab(&self) -> bool {
-        *self == ODR::OPEN_DRAIN_MODE_ENAB
+    pub fn is_open_drain(&self) -> bool {
+        *self == ODR::OPEN_DRAIN
     }
 }
 #[doc = "Values that can be written to the field `FUNC`"]
 pub enum FUNCW {
     #[doc = "PIO0_17."]
-    PIO0_17_,
+    PIO0_17,
     #[doc = "RTS."]
-    RTS_,
+    RTS,
     #[doc = "CT32B0_CAP0."]
-    CT32B0_CAP0_,
+    CT32B0_CAP0,
     #[doc = "SCLK (UART synchronous clock)."]
     SCLK_UART_SYNCHRONO,
 }
@@ -315,9 +315,9 @@ impl FUNCW {
     #[inline]
     pub fn _bits(&self) -> u8 {
         match *self {
-            FUNCW::PIO0_17_ => 0,
-            FUNCW::RTS_ => 1,
-            FUNCW::CT32B0_CAP0_ => 2,
+            FUNCW::PIO0_17 => 0,
+            FUNCW::RTS => 1,
+            FUNCW::CT32B0_CAP0 => 2,
             FUNCW::SCLK_UART_SYNCHRONO => 3,
         }
     }
@@ -334,18 +334,18 @@ impl<'a> _FUNCW<'a> {
     }
     #[doc = "PIO0_17."]
     #[inline]
-    pub fn pio0_17_(self) -> &'a mut W {
-        self.variant(FUNCW::PIO0_17_)
+    pub fn pio0_17(self) -> &'a mut W {
+        self.variant(FUNCW::PIO0_17)
     }
     #[doc = "RTS."]
     #[inline]
-    pub fn rts_(self) -> &'a mut W {
-        self.variant(FUNCW::RTS_)
+    pub fn rts(self) -> &'a mut W {
+        self.variant(FUNCW::RTS)
     }
     #[doc = "CT32B0_CAP0."]
     #[inline]
-    pub fn ct32b0_cap0_(self) -> &'a mut W {
-        self.variant(FUNCW::CT32B0_CAP0_)
+    pub fn ct32b0_cap0(self) -> &'a mut W {
+        self.variant(FUNCW::CT32B0_CAP0)
     }
     #[doc = "SCLK (UART synchronous clock)."]
     #[inline]
@@ -365,13 +365,13 @@ impl<'a> _FUNCW<'a> {
 #[doc = "Values that can be written to the field `MODE`"]
 pub enum MODEW {
     #[doc = "Inactive (no pull-down/pull-up resistor enabled)."]
-    INACTIVE_NO_PULL_DO,
+    INACTIVE,
     #[doc = "Pull-down resistor enabled."]
-    PULL_DOWN_RESISTOR_E,
+    PULL_DOWN,
     #[doc = "Pull-up resistor enabled."]
-    PULL_UP_RESISTOR_ENA,
+    PULL_UP,
     #[doc = "Repeater mode."]
-    REPEATER_MODE_,
+    REPEATER,
 }
 impl MODEW {
     #[allow(missing_docs)]
@@ -379,10 +379,10 @@ impl MODEW {
     #[inline]
     pub fn _bits(&self) -> u8 {
         match *self {
-            MODEW::INACTIVE_NO_PULL_DO => 0,
-            MODEW::PULL_DOWN_RESISTOR_E => 1,
-            MODEW::PULL_UP_RESISTOR_ENA => 2,
-            MODEW::REPEATER_MODE_ => 3,
+            MODEW::INACTIVE => 0,
+            MODEW::PULL_DOWN => 1,
+            MODEW::PULL_UP => 2,
+            MODEW::REPEATER => 3,
         }
     }
 }
@@ -400,23 +400,23 @@ impl<'a> _MODEW<'a> {
     }
     #[doc = "Inactive (no pull-down/pull-up resistor enabled)."]
     #[inline]
-    pub fn inactive_no_pull_do(self) -> &'a mut W {
-        self.variant(MODEW::INACTIVE_NO_PULL_DO)
+    pub fn inactive(self) -> &'a mut W {
+        self.variant(MODEW::INACTIVE)
     }
     #[doc = "Pull-down resistor enabled."]
     #[inline]
-    pub fn pull_down_resistor_e(self) -> &'a mut W {
-        self.variant(MODEW::PULL_DOWN_RESISTOR_E)
+    pub fn pull_down(self) -> &'a mut W {
+        self.variant(MODEW::PULL_DOWN)
     }
     #[doc = "Pull-up resistor enabled."]
     #[inline]
-    pub fn pull_up_resistor_ena(self) -> &'a mut W {
-        self.variant(MODEW::PULL_UP_RESISTOR_ENA)
+    pub fn pull_up(self) -> &'a mut W {
+        self.variant(MODEW::PULL_UP)
     }
     #[doc = "Repeater mode."]
     #[inline]
-    pub fn repeater_mode_(self) -> &'a mut W {
-        self.variant(MODEW::REPEATER_MODE_)
+    pub fn repeater(self) -> &'a mut W {
+        self.variant(MODEW::REPEATER)
     }
     #[doc = r" Writes raw bits to the field"]
     #[inline]
@@ -431,9 +431,9 @@ impl<'a> _MODEW<'a> {
 #[doc = "Values that can be written to the field `HYS`"]
 pub enum HYSW {
     #[doc = "Disable."]
-    DISABLE_,
+    DISABLED,
     #[doc = "Enable."]
-    ENABLE_,
+    ENABLED,
 }
 impl HYSW {
     #[allow(missing_docs)]
@@ -441,8 +441,8 @@ impl HYSW {
     #[inline]
     pub fn _bits(&self) -> bool {
         match *self {
-            HYSW::DISABLE_ => false,
-            HYSW::ENABLE_ => true,
+            HYSW::DISABLED => false,
+            HYSW::ENABLED => true,
         }
     }
 }
@@ -460,13 +460,13 @@ impl<'a> _HYSW<'a> {
     }
     #[doc = "Disable."]
     #[inline]
-    pub fn disable_(self) -> &'a mut W {
-        self.variant(HYSW::DISABLE_)
+    pub fn disabled(self) -> &'a mut W {
+        self.variant(HYSW::DISABLED)
     }
     #[doc = "Enable."]
     #[inline]
-    pub fn enable_(self) -> &'a mut W {
-        self.variant(HYSW::ENABLE_)
+    pub fn enabled(self) -> &'a mut W {
+        self.variant(HYSW::ENABLED)
     }
     #[doc = r" Sets the field bit"]
     pub fn set_bit(self) -> &'a mut W {
@@ -489,9 +489,9 @@ impl<'a> _HYSW<'a> {
 #[doc = "Values that can be written to the field `INV`"]
 pub enum INVW {
     #[doc = "Input not inverted (HIGH on pin reads as 1, LOW on pin reads as 0)."]
-    INPUT_NOT_INVERTED_,
+    NOT_INVERTED,
     #[doc = "Input inverted (HIGH on pin reads as 0, LOW on pin reads as 1)."]
-    INPUT_INVERTED_HIGH,
+    INVERTED,
 }
 impl INVW {
     #[allow(missing_docs)]
@@ -499,8 +499,8 @@ impl INVW {
     #[inline]
     pub fn _bits(&self) -> bool {
         match *self {
-            INVW::INPUT_NOT_INVERTED_ => false,
-            INVW::INPUT_INVERTED_HIGH => true,
+            INVW::NOT_INVERTED => false,
+            INVW::INVERTED => true,
         }
     }
 }
@@ -518,13 +518,13 @@ impl<'a> _INVW<'a> {
     }
     #[doc = "Input not inverted (HIGH on pin reads as 1, LOW on pin reads as 0)."]
     #[inline]
-    pub fn input_not_inverted_(self) -> &'a mut W {
-        self.variant(INVW::INPUT_NOT_INVERTED_)
+    pub fn not_inverted(self) -> &'a mut W {
+        self.variant(INVW::NOT_INVERTED)
     }
     #[doc = "Input inverted (HIGH on pin reads as 0, LOW on pin reads as 1)."]
     #[inline]
-    pub fn input_inverted_high(self) -> &'a mut W {
-        self.variant(INVW::INPUT_INVERTED_HIGH)
+    pub fn inverted(self) -> &'a mut W {
+        self.variant(INVW::INVERTED)
     }
     #[doc = r" Sets the field bit"]
     pub fn set_bit(self) -> &'a mut W {
@@ -547,9 +547,9 @@ impl<'a> _INVW<'a> {
 #[doc = "Values that can be written to the field `OD`"]
 pub enum ODW {
     #[doc = "Disable."]
-    DISABLE_,
+    DISABLED,
     #[doc = "Open-drain mode enabled.  This is not a true open-drain mode."]
-    OPEN_DRAIN_MODE_ENAB,
+    OPEN_DRAIN,
 }
 impl ODW {
     #[allow(missing_docs)]
@@ -557,8 +557,8 @@ impl ODW {
     #[inline]
     pub fn _bits(&self) -> bool {
         match *self {
-            ODW::DISABLE_ => false,
-            ODW::OPEN_DRAIN_MODE_ENAB => true,
+            ODW::DISABLED => false,
+            ODW::OPEN_DRAIN => true,
         }
     }
 }
@@ -576,13 +576,13 @@ impl<'a> _ODW<'a> {
     }
     #[doc = "Disable."]
     #[inline]
-    pub fn disable_(self) -> &'a mut W {
-        self.variant(ODW::DISABLE_)
+    pub fn disabled(self) -> &'a mut W {
+        self.variant(ODW::DISABLED)
     }
     #[doc = "Open-drain mode enabled. This is not a true open-drain mode."]
     #[inline]
-    pub fn open_drain_mode_enab(self) -> &'a mut W {
-        self.variant(ODW::OPEN_DRAIN_MODE_ENAB)
+    pub fn open_drain(self) -> &'a mut W {
+        self.variant(ODW::OPEN_DRAIN)
     }
     #[doc = r" Sets the field bit"]
     pub fn set_bit(self) -> &'a mut W {

--- a/lpc11uxx/src/iocon/pio0_18.rs
+++ b/lpc11uxx/src/iocon/pio0_18.rs
@@ -46,11 +46,11 @@ impl super::PIO0_18 {
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum FUNCR {
     #[doc = "PIO0_18."]
-    PIO0_18_,
+    PIO0_18,
     #[doc = "RXD."]
-    RXD_,
+    RXD,
     #[doc = "CT32B0_MAT0."]
-    CT32B0_MAT0_,
+    CT32B0_MAT0,
     #[doc = r" Reserved"]
     _Reserved(u8),
 }
@@ -59,9 +59,9 @@ impl FUNCR {
     #[inline]
     pub fn bits(&self) -> u8 {
         match *self {
-            FUNCR::PIO0_18_ => 0,
-            FUNCR::RXD_ => 1,
-            FUNCR::CT32B0_MAT0_ => 2,
+            FUNCR::PIO0_18 => 0,
+            FUNCR::RXD => 1,
+            FUNCR::CT32B0_MAT0 => 2,
             FUNCR::_Reserved(bits) => bits,
         }
     }
@@ -70,49 +70,49 @@ impl FUNCR {
     #[inline]
     pub fn _from(value: u8) -> FUNCR {
         match value {
-            0 => FUNCR::PIO0_18_,
-            1 => FUNCR::RXD_,
-            2 => FUNCR::CT32B0_MAT0_,
+            0 => FUNCR::PIO0_18,
+            1 => FUNCR::RXD,
+            2 => FUNCR::CT32B0_MAT0,
             i => FUNCR::_Reserved(i),
         }
     }
-    #[doc = "Checks if the value of the field is `PIO0_18_`"]
+    #[doc = "Checks if the value of the field is `PIO0_18`"]
     #[inline]
-    pub fn is_pio0_18_(&self) -> bool {
-        *self == FUNCR::PIO0_18_
+    pub fn is_pio0_18(&self) -> bool {
+        *self == FUNCR::PIO0_18
     }
-    #[doc = "Checks if the value of the field is `RXD_`"]
+    #[doc = "Checks if the value of the field is `RXD`"]
     #[inline]
-    pub fn is_rxd_(&self) -> bool {
-        *self == FUNCR::RXD_
+    pub fn is_rxd(&self) -> bool {
+        *self == FUNCR::RXD
     }
-    #[doc = "Checks if the value of the field is `CT32B0_MAT0_`"]
+    #[doc = "Checks if the value of the field is `CT32B0_MAT0`"]
     #[inline]
-    pub fn is_ct32b0_mat0_(&self) -> bool {
-        *self == FUNCR::CT32B0_MAT0_
+    pub fn is_ct32b0_mat0(&self) -> bool {
+        *self == FUNCR::CT32B0_MAT0
     }
 }
 #[doc = "Possible values of the field `MODE`"]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum MODER {
     #[doc = "Inactive (no pull-down/pull-up resistor enabled)."]
-    INACTIVE_NO_PULL_DO,
+    INACTIVE,
     #[doc = "Pull-down resistor enabled."]
-    PULL_DOWN_RESISTOR_E,
+    PULL_DOWN,
     #[doc = "Pull-up resistor enabled."]
-    PULL_UP_RESISTOR_ENA,
+    PULL_UP,
     #[doc = "Repeater mode."]
-    REPEATER_MODE_,
+    REPEATER,
 }
 impl MODER {
     #[doc = r" Value of the field as raw bits"]
     #[inline]
     pub fn bits(&self) -> u8 {
         match *self {
-            MODER::INACTIVE_NO_PULL_DO => 0,
-            MODER::PULL_DOWN_RESISTOR_E => 1,
-            MODER::PULL_UP_RESISTOR_ENA => 2,
-            MODER::REPEATER_MODE_ => 3,
+            MODER::INACTIVE => 0,
+            MODER::PULL_DOWN => 1,
+            MODER::PULL_UP => 2,
+            MODER::REPEATER => 3,
         }
     }
     #[allow(missing_docs)]
@@ -120,41 +120,41 @@ impl MODER {
     #[inline]
     pub fn _from(value: u8) -> MODER {
         match value {
-            0 => MODER::INACTIVE_NO_PULL_DO,
-            1 => MODER::PULL_DOWN_RESISTOR_E,
-            2 => MODER::PULL_UP_RESISTOR_ENA,
-            3 => MODER::REPEATER_MODE_,
+            0 => MODER::INACTIVE,
+            1 => MODER::PULL_DOWN,
+            2 => MODER::PULL_UP,
+            3 => MODER::REPEATER,
             _ => unreachable!(),
         }
     }
-    #[doc = "Checks if the value of the field is `INACTIVE_NO_PULL_DO`"]
+    #[doc = "Checks if the value of the field is `INACTIVE`"]
     #[inline]
-    pub fn is_inactive_no_pull_do(&self) -> bool {
-        *self == MODER::INACTIVE_NO_PULL_DO
+    pub fn is_inactive(&self) -> bool {
+        *self == MODER::INACTIVE
     }
-    #[doc = "Checks if the value of the field is `PULL_DOWN_RESISTOR_E`"]
+    #[doc = "Checks if the value of the field is `PULL_DOWN`"]
     #[inline]
-    pub fn is_pull_down_resistor_e(&self) -> bool {
-        *self == MODER::PULL_DOWN_RESISTOR_E
+    pub fn is_pull_down(&self) -> bool {
+        *self == MODER::PULL_DOWN
     }
-    #[doc = "Checks if the value of the field is `PULL_UP_RESISTOR_ENA`"]
+    #[doc = "Checks if the value of the field is `PULL_UP`"]
     #[inline]
-    pub fn is_pull_up_resistor_ena(&self) -> bool {
-        *self == MODER::PULL_UP_RESISTOR_ENA
+    pub fn is_pull_up(&self) -> bool {
+        *self == MODER::PULL_UP
     }
-    #[doc = "Checks if the value of the field is `REPEATER_MODE_`"]
+    #[doc = "Checks if the value of the field is `REPEATER`"]
     #[inline]
-    pub fn is_repeater_mode_(&self) -> bool {
-        *self == MODER::REPEATER_MODE_
+    pub fn is_repeater(&self) -> bool {
+        *self == MODER::REPEATER
     }
 }
 #[doc = "Possible values of the field `HYS`"]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum HYSR {
     #[doc = "Disable."]
-    DISABLE_,
+    DISABLED,
     #[doc = "Enable."]
-    ENABLE_,
+    ENABLED,
 }
 impl HYSR {
     #[doc = r" Returns `true` if the bit is clear (0)"]
@@ -171,8 +171,8 @@ impl HYSR {
     #[inline]
     pub fn bit(&self) -> bool {
         match *self {
-            HYSR::DISABLE_ => false,
-            HYSR::ENABLE_ => true,
+            HYSR::DISABLED => false,
+            HYSR::ENABLED => true,
         }
     }
     #[allow(missing_docs)]
@@ -180,28 +180,28 @@ impl HYSR {
     #[inline]
     pub fn _from(value: bool) -> HYSR {
         match value {
-            false => HYSR::DISABLE_,
-            true => HYSR::ENABLE_,
+            false => HYSR::DISABLED,
+            true => HYSR::ENABLED,
         }
     }
-    #[doc = "Checks if the value of the field is `DISABLE_`"]
+    #[doc = "Checks if the value of the field is `DISABLED`"]
     #[inline]
-    pub fn is_disable_(&self) -> bool {
-        *self == HYSR::DISABLE_
+    pub fn is_disabled(&self) -> bool {
+        *self == HYSR::DISABLED
     }
-    #[doc = "Checks if the value of the field is `ENABLE_`"]
+    #[doc = "Checks if the value of the field is `ENABLED`"]
     #[inline]
-    pub fn is_enable_(&self) -> bool {
-        *self == HYSR::ENABLE_
+    pub fn is_enabled(&self) -> bool {
+        *self == HYSR::ENABLED
     }
 }
 #[doc = "Possible values of the field `INV`"]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum INVR {
     #[doc = "Input not inverted (HIGH on pin reads as 1, LOW on pin reads as 0)."]
-    INPUT_NOT_INVERTED_,
+    NOT_INVERTED,
     #[doc = "Input inverted (HIGH on pin reads as 0, LOW on pin reads as 1)."]
-    INPUT_INVERTED_HIGH,
+    INVERTED,
 }
 impl INVR {
     #[doc = r" Returns `true` if the bit is clear (0)"]
@@ -218,8 +218,8 @@ impl INVR {
     #[inline]
     pub fn bit(&self) -> bool {
         match *self {
-            INVR::INPUT_NOT_INVERTED_ => false,
-            INVR::INPUT_INVERTED_HIGH => true,
+            INVR::NOT_INVERTED => false,
+            INVR::INVERTED => true,
         }
     }
     #[allow(missing_docs)]
@@ -227,28 +227,28 @@ impl INVR {
     #[inline]
     pub fn _from(value: bool) -> INVR {
         match value {
-            false => INVR::INPUT_NOT_INVERTED_,
-            true => INVR::INPUT_INVERTED_HIGH,
+            false => INVR::NOT_INVERTED,
+            true => INVR::INVERTED,
         }
     }
-    #[doc = "Checks if the value of the field is `INPUT_NOT_INVERTED_`"]
+    #[doc = "Checks if the value of the field is `NOT_INVERTED`"]
     #[inline]
-    pub fn is_input_not_inverted_(&self) -> bool {
-        *self == INVR::INPUT_NOT_INVERTED_
+    pub fn is_not_inverted(&self) -> bool {
+        *self == INVR::NOT_INVERTED
     }
-    #[doc = "Checks if the value of the field is `INPUT_INVERTED_HIGH`"]
+    #[doc = "Checks if the value of the field is `INVERTED`"]
     #[inline]
-    pub fn is_input_inverted_high(&self) -> bool {
-        *self == INVR::INPUT_INVERTED_HIGH
+    pub fn is_inverted(&self) -> bool {
+        *self == INVR::INVERTED
     }
 }
 #[doc = "Possible values of the field `OD`"]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum ODR {
     #[doc = "Disable."]
-    DISABLE_,
+    DISABLED,
     #[doc = "Open-drain mode enabled.  This is not a true open-drain mode."]
-    OPEN_DRAIN_MODE_ENAB,
+    OPEN_DRAIN,
 }
 impl ODR {
     #[doc = r" Returns `true` if the bit is clear (0)"]
@@ -265,8 +265,8 @@ impl ODR {
     #[inline]
     pub fn bit(&self) -> bool {
         match *self {
-            ODR::DISABLE_ => false,
-            ODR::OPEN_DRAIN_MODE_ENAB => true,
+            ODR::DISABLED => false,
+            ODR::OPEN_DRAIN => true,
         }
     }
     #[allow(missing_docs)]
@@ -274,29 +274,29 @@ impl ODR {
     #[inline]
     pub fn _from(value: bool) -> ODR {
         match value {
-            false => ODR::DISABLE_,
-            true => ODR::OPEN_DRAIN_MODE_ENAB,
+            false => ODR::DISABLED,
+            true => ODR::OPEN_DRAIN,
         }
     }
-    #[doc = "Checks if the value of the field is `DISABLE_`"]
+    #[doc = "Checks if the value of the field is `DISABLED`"]
     #[inline]
-    pub fn is_disable_(&self) -> bool {
-        *self == ODR::DISABLE_
+    pub fn is_disabled(&self) -> bool {
+        *self == ODR::DISABLED
     }
-    #[doc = "Checks if the value of the field is `OPEN_DRAIN_MODE_ENAB`"]
+    #[doc = "Checks if the value of the field is `OPEN_DRAIN`"]
     #[inline]
-    pub fn is_open_drain_mode_enab(&self) -> bool {
-        *self == ODR::OPEN_DRAIN_MODE_ENAB
+    pub fn is_open_drain(&self) -> bool {
+        *self == ODR::OPEN_DRAIN
     }
 }
 #[doc = "Values that can be written to the field `FUNC`"]
 pub enum FUNCW {
     #[doc = "PIO0_18."]
-    PIO0_18_,
+    PIO0_18,
     #[doc = "RXD."]
-    RXD_,
+    RXD,
     #[doc = "CT32B0_MAT0."]
-    CT32B0_MAT0_,
+    CT32B0_MAT0,
 }
 impl FUNCW {
     #[allow(missing_docs)]
@@ -304,9 +304,9 @@ impl FUNCW {
     #[inline]
     pub fn _bits(&self) -> u8 {
         match *self {
-            FUNCW::PIO0_18_ => 0,
-            FUNCW::RXD_ => 1,
-            FUNCW::CT32B0_MAT0_ => 2,
+            FUNCW::PIO0_18 => 0,
+            FUNCW::RXD => 1,
+            FUNCW::CT32B0_MAT0 => 2,
         }
     }
 }
@@ -322,18 +322,18 @@ impl<'a> _FUNCW<'a> {
     }
     #[doc = "PIO0_18."]
     #[inline]
-    pub fn pio0_18_(self) -> &'a mut W {
-        self.variant(FUNCW::PIO0_18_)
+    pub fn pio0_18(self) -> &'a mut W {
+        self.variant(FUNCW::PIO0_18)
     }
     #[doc = "RXD."]
     #[inline]
-    pub fn rxd_(self) -> &'a mut W {
-        self.variant(FUNCW::RXD_)
+    pub fn rxd(self) -> &'a mut W {
+        self.variant(FUNCW::RXD)
     }
     #[doc = "CT32B0_MAT0."]
     #[inline]
-    pub fn ct32b0_mat0_(self) -> &'a mut W {
-        self.variant(FUNCW::CT32B0_MAT0_)
+    pub fn ct32b0_mat0(self) -> &'a mut W {
+        self.variant(FUNCW::CT32B0_MAT0)
     }
     #[doc = r" Writes raw bits to the field"]
     #[inline]
@@ -348,13 +348,13 @@ impl<'a> _FUNCW<'a> {
 #[doc = "Values that can be written to the field `MODE`"]
 pub enum MODEW {
     #[doc = "Inactive (no pull-down/pull-up resistor enabled)."]
-    INACTIVE_NO_PULL_DO,
+    INACTIVE,
     #[doc = "Pull-down resistor enabled."]
-    PULL_DOWN_RESISTOR_E,
+    PULL_DOWN,
     #[doc = "Pull-up resistor enabled."]
-    PULL_UP_RESISTOR_ENA,
+    PULL_UP,
     #[doc = "Repeater mode."]
-    REPEATER_MODE_,
+    REPEATER,
 }
 impl MODEW {
     #[allow(missing_docs)]
@@ -362,10 +362,10 @@ impl MODEW {
     #[inline]
     pub fn _bits(&self) -> u8 {
         match *self {
-            MODEW::INACTIVE_NO_PULL_DO => 0,
-            MODEW::PULL_DOWN_RESISTOR_E => 1,
-            MODEW::PULL_UP_RESISTOR_ENA => 2,
-            MODEW::REPEATER_MODE_ => 3,
+            MODEW::INACTIVE => 0,
+            MODEW::PULL_DOWN => 1,
+            MODEW::PULL_UP => 2,
+            MODEW::REPEATER => 3,
         }
     }
 }
@@ -383,23 +383,23 @@ impl<'a> _MODEW<'a> {
     }
     #[doc = "Inactive (no pull-down/pull-up resistor enabled)."]
     #[inline]
-    pub fn inactive_no_pull_do(self) -> &'a mut W {
-        self.variant(MODEW::INACTIVE_NO_PULL_DO)
+    pub fn inactive(self) -> &'a mut W {
+        self.variant(MODEW::INACTIVE)
     }
     #[doc = "Pull-down resistor enabled."]
     #[inline]
-    pub fn pull_down_resistor_e(self) -> &'a mut W {
-        self.variant(MODEW::PULL_DOWN_RESISTOR_E)
+    pub fn pull_down(self) -> &'a mut W {
+        self.variant(MODEW::PULL_DOWN)
     }
     #[doc = "Pull-up resistor enabled."]
     #[inline]
-    pub fn pull_up_resistor_ena(self) -> &'a mut W {
-        self.variant(MODEW::PULL_UP_RESISTOR_ENA)
+    pub fn pull_up(self) -> &'a mut W {
+        self.variant(MODEW::PULL_UP)
     }
     #[doc = "Repeater mode."]
     #[inline]
-    pub fn repeater_mode_(self) -> &'a mut W {
-        self.variant(MODEW::REPEATER_MODE_)
+    pub fn repeater(self) -> &'a mut W {
+        self.variant(MODEW::REPEATER)
     }
     #[doc = r" Writes raw bits to the field"]
     #[inline]
@@ -414,9 +414,9 @@ impl<'a> _MODEW<'a> {
 #[doc = "Values that can be written to the field `HYS`"]
 pub enum HYSW {
     #[doc = "Disable."]
-    DISABLE_,
+    DISABLED,
     #[doc = "Enable."]
-    ENABLE_,
+    ENABLED,
 }
 impl HYSW {
     #[allow(missing_docs)]
@@ -424,8 +424,8 @@ impl HYSW {
     #[inline]
     pub fn _bits(&self) -> bool {
         match *self {
-            HYSW::DISABLE_ => false,
-            HYSW::ENABLE_ => true,
+            HYSW::DISABLED => false,
+            HYSW::ENABLED => true,
         }
     }
 }
@@ -443,13 +443,13 @@ impl<'a> _HYSW<'a> {
     }
     #[doc = "Disable."]
     #[inline]
-    pub fn disable_(self) -> &'a mut W {
-        self.variant(HYSW::DISABLE_)
+    pub fn disabled(self) -> &'a mut W {
+        self.variant(HYSW::DISABLED)
     }
     #[doc = "Enable."]
     #[inline]
-    pub fn enable_(self) -> &'a mut W {
-        self.variant(HYSW::ENABLE_)
+    pub fn enabled(self) -> &'a mut W {
+        self.variant(HYSW::ENABLED)
     }
     #[doc = r" Sets the field bit"]
     pub fn set_bit(self) -> &'a mut W {
@@ -472,9 +472,9 @@ impl<'a> _HYSW<'a> {
 #[doc = "Values that can be written to the field `INV`"]
 pub enum INVW {
     #[doc = "Input not inverted (HIGH on pin reads as 1, LOW on pin reads as 0)."]
-    INPUT_NOT_INVERTED_,
+    NOT_INVERTED,
     #[doc = "Input inverted (HIGH on pin reads as 0, LOW on pin reads as 1)."]
-    INPUT_INVERTED_HIGH,
+    INVERTED,
 }
 impl INVW {
     #[allow(missing_docs)]
@@ -482,8 +482,8 @@ impl INVW {
     #[inline]
     pub fn _bits(&self) -> bool {
         match *self {
-            INVW::INPUT_NOT_INVERTED_ => false,
-            INVW::INPUT_INVERTED_HIGH => true,
+            INVW::NOT_INVERTED => false,
+            INVW::INVERTED => true,
         }
     }
 }
@@ -501,13 +501,13 @@ impl<'a> _INVW<'a> {
     }
     #[doc = "Input not inverted (HIGH on pin reads as 1, LOW on pin reads as 0)."]
     #[inline]
-    pub fn input_not_inverted_(self) -> &'a mut W {
-        self.variant(INVW::INPUT_NOT_INVERTED_)
+    pub fn not_inverted(self) -> &'a mut W {
+        self.variant(INVW::NOT_INVERTED)
     }
     #[doc = "Input inverted (HIGH on pin reads as 0, LOW on pin reads as 1)."]
     #[inline]
-    pub fn input_inverted_high(self) -> &'a mut W {
-        self.variant(INVW::INPUT_INVERTED_HIGH)
+    pub fn inverted(self) -> &'a mut W {
+        self.variant(INVW::INVERTED)
     }
     #[doc = r" Sets the field bit"]
     pub fn set_bit(self) -> &'a mut W {
@@ -530,9 +530,9 @@ impl<'a> _INVW<'a> {
 #[doc = "Values that can be written to the field `OD`"]
 pub enum ODW {
     #[doc = "Disable."]
-    DISABLE_,
+    DISABLED,
     #[doc = "Open-drain mode enabled.  This is not a true open-drain mode."]
-    OPEN_DRAIN_MODE_ENAB,
+    OPEN_DRAIN,
 }
 impl ODW {
     #[allow(missing_docs)]
@@ -540,8 +540,8 @@ impl ODW {
     #[inline]
     pub fn _bits(&self) -> bool {
         match *self {
-            ODW::DISABLE_ => false,
-            ODW::OPEN_DRAIN_MODE_ENAB => true,
+            ODW::DISABLED => false,
+            ODW::OPEN_DRAIN => true,
         }
     }
 }
@@ -559,13 +559,13 @@ impl<'a> _ODW<'a> {
     }
     #[doc = "Disable."]
     #[inline]
-    pub fn disable_(self) -> &'a mut W {
-        self.variant(ODW::DISABLE_)
+    pub fn disabled(self) -> &'a mut W {
+        self.variant(ODW::DISABLED)
     }
     #[doc = "Open-drain mode enabled. This is not a true open-drain mode."]
     #[inline]
-    pub fn open_drain_mode_enab(self) -> &'a mut W {
-        self.variant(ODW::OPEN_DRAIN_MODE_ENAB)
+    pub fn open_drain(self) -> &'a mut W {
+        self.variant(ODW::OPEN_DRAIN)
     }
     #[doc = r" Sets the field bit"]
     pub fn set_bit(self) -> &'a mut W {

--- a/lpc11uxx/src/iocon/pio0_19.rs
+++ b/lpc11uxx/src/iocon/pio0_19.rs
@@ -46,11 +46,11 @@ impl super::PIO0_19 {
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum FUNCR {
     #[doc = "PIO0_19."]
-    PIO0_19_,
+    PIO0_19,
     #[doc = "TXD."]
-    TXD_,
+    TXD,
     #[doc = "CT32B0_MAT1."]
-    CT32B0_MAT1_,
+    CT32B0_MAT1,
     #[doc = r" Reserved"]
     _Reserved(u8),
 }
@@ -59,9 +59,9 @@ impl FUNCR {
     #[inline]
     pub fn bits(&self) -> u8 {
         match *self {
-            FUNCR::PIO0_19_ => 0,
-            FUNCR::TXD_ => 1,
-            FUNCR::CT32B0_MAT1_ => 2,
+            FUNCR::PIO0_19 => 0,
+            FUNCR::TXD => 1,
+            FUNCR::CT32B0_MAT1 => 2,
             FUNCR::_Reserved(bits) => bits,
         }
     }
@@ -70,49 +70,49 @@ impl FUNCR {
     #[inline]
     pub fn _from(value: u8) -> FUNCR {
         match value {
-            0 => FUNCR::PIO0_19_,
-            1 => FUNCR::TXD_,
-            2 => FUNCR::CT32B0_MAT1_,
+            0 => FUNCR::PIO0_19,
+            1 => FUNCR::TXD,
+            2 => FUNCR::CT32B0_MAT1,
             i => FUNCR::_Reserved(i),
         }
     }
-    #[doc = "Checks if the value of the field is `PIO0_19_`"]
+    #[doc = "Checks if the value of the field is `PIO0_19`"]
     #[inline]
-    pub fn is_pio0_19_(&self) -> bool {
-        *self == FUNCR::PIO0_19_
+    pub fn is_pio0_19(&self) -> bool {
+        *self == FUNCR::PIO0_19
     }
-    #[doc = "Checks if the value of the field is `TXD_`"]
+    #[doc = "Checks if the value of the field is `TXD`"]
     #[inline]
-    pub fn is_txd_(&self) -> bool {
-        *self == FUNCR::TXD_
+    pub fn is_txd(&self) -> bool {
+        *self == FUNCR::TXD
     }
-    #[doc = "Checks if the value of the field is `CT32B0_MAT1_`"]
+    #[doc = "Checks if the value of the field is `CT32B0_MAT1`"]
     #[inline]
-    pub fn is_ct32b0_mat1_(&self) -> bool {
-        *self == FUNCR::CT32B0_MAT1_
+    pub fn is_ct32b0_mat1(&self) -> bool {
+        *self == FUNCR::CT32B0_MAT1
     }
 }
 #[doc = "Possible values of the field `MODE`"]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum MODER {
     #[doc = "Inactive (no pull-down/pull-up resistor enabled)."]
-    INACTIVE_NO_PULL_DO,
+    INACTIVE,
     #[doc = "Pull-down resistor enabled."]
-    PULL_DOWN_RESISTOR_E,
+    PULL_DOWN,
     #[doc = "Pull-up resistor enabled."]
-    PULL_UP_RESISTOR_ENA,
+    PULL_UP,
     #[doc = "Repeater mode."]
-    REPEATER_MODE_,
+    REPEATER,
 }
 impl MODER {
     #[doc = r" Value of the field as raw bits"]
     #[inline]
     pub fn bits(&self) -> u8 {
         match *self {
-            MODER::INACTIVE_NO_PULL_DO => 0,
-            MODER::PULL_DOWN_RESISTOR_E => 1,
-            MODER::PULL_UP_RESISTOR_ENA => 2,
-            MODER::REPEATER_MODE_ => 3,
+            MODER::INACTIVE => 0,
+            MODER::PULL_DOWN => 1,
+            MODER::PULL_UP => 2,
+            MODER::REPEATER => 3,
         }
     }
     #[allow(missing_docs)]
@@ -120,41 +120,41 @@ impl MODER {
     #[inline]
     pub fn _from(value: u8) -> MODER {
         match value {
-            0 => MODER::INACTIVE_NO_PULL_DO,
-            1 => MODER::PULL_DOWN_RESISTOR_E,
-            2 => MODER::PULL_UP_RESISTOR_ENA,
-            3 => MODER::REPEATER_MODE_,
+            0 => MODER::INACTIVE,
+            1 => MODER::PULL_DOWN,
+            2 => MODER::PULL_UP,
+            3 => MODER::REPEATER,
             _ => unreachable!(),
         }
     }
-    #[doc = "Checks if the value of the field is `INACTIVE_NO_PULL_DO`"]
+    #[doc = "Checks if the value of the field is `INACTIVE`"]
     #[inline]
-    pub fn is_inactive_no_pull_do(&self) -> bool {
-        *self == MODER::INACTIVE_NO_PULL_DO
+    pub fn is_inactive(&self) -> bool {
+        *self == MODER::INACTIVE
     }
-    #[doc = "Checks if the value of the field is `PULL_DOWN_RESISTOR_E`"]
+    #[doc = "Checks if the value of the field is `PULL_DOWN`"]
     #[inline]
-    pub fn is_pull_down_resistor_e(&self) -> bool {
-        *self == MODER::PULL_DOWN_RESISTOR_E
+    pub fn is_pull_down(&self) -> bool {
+        *self == MODER::PULL_DOWN
     }
-    #[doc = "Checks if the value of the field is `PULL_UP_RESISTOR_ENA`"]
+    #[doc = "Checks if the value of the field is `PULL_UP`"]
     #[inline]
-    pub fn is_pull_up_resistor_ena(&self) -> bool {
-        *self == MODER::PULL_UP_RESISTOR_ENA
+    pub fn is_pull_up(&self) -> bool {
+        *self == MODER::PULL_UP
     }
-    #[doc = "Checks if the value of the field is `REPEATER_MODE_`"]
+    #[doc = "Checks if the value of the field is `REPEATER`"]
     #[inline]
-    pub fn is_repeater_mode_(&self) -> bool {
-        *self == MODER::REPEATER_MODE_
+    pub fn is_repeater(&self) -> bool {
+        *self == MODER::REPEATER
     }
 }
 #[doc = "Possible values of the field `HYS`"]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum HYSR {
     #[doc = "Disable."]
-    DISABLE_,
+    DISABLED,
     #[doc = "Enable."]
-    ENABLE_,
+    ENABLED,
 }
 impl HYSR {
     #[doc = r" Returns `true` if the bit is clear (0)"]
@@ -171,8 +171,8 @@ impl HYSR {
     #[inline]
     pub fn bit(&self) -> bool {
         match *self {
-            HYSR::DISABLE_ => false,
-            HYSR::ENABLE_ => true,
+            HYSR::DISABLED => false,
+            HYSR::ENABLED => true,
         }
     }
     #[allow(missing_docs)]
@@ -180,28 +180,28 @@ impl HYSR {
     #[inline]
     pub fn _from(value: bool) -> HYSR {
         match value {
-            false => HYSR::DISABLE_,
-            true => HYSR::ENABLE_,
+            false => HYSR::DISABLED,
+            true => HYSR::ENABLED,
         }
     }
-    #[doc = "Checks if the value of the field is `DISABLE_`"]
+    #[doc = "Checks if the value of the field is `DISABLED`"]
     #[inline]
-    pub fn is_disable_(&self) -> bool {
-        *self == HYSR::DISABLE_
+    pub fn is_disabled(&self) -> bool {
+        *self == HYSR::DISABLED
     }
-    #[doc = "Checks if the value of the field is `ENABLE_`"]
+    #[doc = "Checks if the value of the field is `ENABLED`"]
     #[inline]
-    pub fn is_enable_(&self) -> bool {
-        *self == HYSR::ENABLE_
+    pub fn is_enabled(&self) -> bool {
+        *self == HYSR::ENABLED
     }
 }
 #[doc = "Possible values of the field `INV`"]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum INVR {
     #[doc = "Input not inverted (HIGH on pin reads as 1, LOW on pin reads as 0)."]
-    INPUT_NOT_INVERTED_,
+    NOT_INVERTED,
     #[doc = "Input inverted (HIGH on pin reads as 0, LOW on pin reads as 1)."]
-    INPUT_INVERTED_HIGH,
+    INVERTED,
 }
 impl INVR {
     #[doc = r" Returns `true` if the bit is clear (0)"]
@@ -218,8 +218,8 @@ impl INVR {
     #[inline]
     pub fn bit(&self) -> bool {
         match *self {
-            INVR::INPUT_NOT_INVERTED_ => false,
-            INVR::INPUT_INVERTED_HIGH => true,
+            INVR::NOT_INVERTED => false,
+            INVR::INVERTED => true,
         }
     }
     #[allow(missing_docs)]
@@ -227,28 +227,28 @@ impl INVR {
     #[inline]
     pub fn _from(value: bool) -> INVR {
         match value {
-            false => INVR::INPUT_NOT_INVERTED_,
-            true => INVR::INPUT_INVERTED_HIGH,
+            false => INVR::NOT_INVERTED,
+            true => INVR::INVERTED,
         }
     }
-    #[doc = "Checks if the value of the field is `INPUT_NOT_INVERTED_`"]
+    #[doc = "Checks if the value of the field is `NOT_INVERTED`"]
     #[inline]
-    pub fn is_input_not_inverted_(&self) -> bool {
-        *self == INVR::INPUT_NOT_INVERTED_
+    pub fn is_not_inverted(&self) -> bool {
+        *self == INVR::NOT_INVERTED
     }
-    #[doc = "Checks if the value of the field is `INPUT_INVERTED_HIGH`"]
+    #[doc = "Checks if the value of the field is `INVERTED`"]
     #[inline]
-    pub fn is_input_inverted_high(&self) -> bool {
-        *self == INVR::INPUT_INVERTED_HIGH
+    pub fn is_inverted(&self) -> bool {
+        *self == INVR::INVERTED
     }
 }
 #[doc = "Possible values of the field `OD`"]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum ODR {
     #[doc = "Disable."]
-    DISABLE_,
+    DISABLED,
     #[doc = "Open-drain mode enabled.  This is not a true open-drain mode."]
-    OPEN_DRAIN_MODE_ENAB,
+    OPEN_DRAIN,
 }
 impl ODR {
     #[doc = r" Returns `true` if the bit is clear (0)"]
@@ -265,8 +265,8 @@ impl ODR {
     #[inline]
     pub fn bit(&self) -> bool {
         match *self {
-            ODR::DISABLE_ => false,
-            ODR::OPEN_DRAIN_MODE_ENAB => true,
+            ODR::DISABLED => false,
+            ODR::OPEN_DRAIN => true,
         }
     }
     #[allow(missing_docs)]
@@ -274,29 +274,29 @@ impl ODR {
     #[inline]
     pub fn _from(value: bool) -> ODR {
         match value {
-            false => ODR::DISABLE_,
-            true => ODR::OPEN_DRAIN_MODE_ENAB,
+            false => ODR::DISABLED,
+            true => ODR::OPEN_DRAIN,
         }
     }
-    #[doc = "Checks if the value of the field is `DISABLE_`"]
+    #[doc = "Checks if the value of the field is `DISABLED`"]
     #[inline]
-    pub fn is_disable_(&self) -> bool {
-        *self == ODR::DISABLE_
+    pub fn is_disabled(&self) -> bool {
+        *self == ODR::DISABLED
     }
-    #[doc = "Checks if the value of the field is `OPEN_DRAIN_MODE_ENAB`"]
+    #[doc = "Checks if the value of the field is `OPEN_DRAIN`"]
     #[inline]
-    pub fn is_open_drain_mode_enab(&self) -> bool {
-        *self == ODR::OPEN_DRAIN_MODE_ENAB
+    pub fn is_open_drain(&self) -> bool {
+        *self == ODR::OPEN_DRAIN
     }
 }
 #[doc = "Values that can be written to the field `FUNC`"]
 pub enum FUNCW {
     #[doc = "PIO0_19."]
-    PIO0_19_,
+    PIO0_19,
     #[doc = "TXD."]
-    TXD_,
+    TXD,
     #[doc = "CT32B0_MAT1."]
-    CT32B0_MAT1_,
+    CT32B0_MAT1,
 }
 impl FUNCW {
     #[allow(missing_docs)]
@@ -304,9 +304,9 @@ impl FUNCW {
     #[inline]
     pub fn _bits(&self) -> u8 {
         match *self {
-            FUNCW::PIO0_19_ => 0,
-            FUNCW::TXD_ => 1,
-            FUNCW::CT32B0_MAT1_ => 2,
+            FUNCW::PIO0_19 => 0,
+            FUNCW::TXD => 1,
+            FUNCW::CT32B0_MAT1 => 2,
         }
     }
 }
@@ -322,18 +322,18 @@ impl<'a> _FUNCW<'a> {
     }
     #[doc = "PIO0_19."]
     #[inline]
-    pub fn pio0_19_(self) -> &'a mut W {
-        self.variant(FUNCW::PIO0_19_)
+    pub fn pio0_19(self) -> &'a mut W {
+        self.variant(FUNCW::PIO0_19)
     }
     #[doc = "TXD."]
     #[inline]
-    pub fn txd_(self) -> &'a mut W {
-        self.variant(FUNCW::TXD_)
+    pub fn txd(self) -> &'a mut W {
+        self.variant(FUNCW::TXD)
     }
     #[doc = "CT32B0_MAT1."]
     #[inline]
-    pub fn ct32b0_mat1_(self) -> &'a mut W {
-        self.variant(FUNCW::CT32B0_MAT1_)
+    pub fn ct32b0_mat1(self) -> &'a mut W {
+        self.variant(FUNCW::CT32B0_MAT1)
     }
     #[doc = r" Writes raw bits to the field"]
     #[inline]
@@ -348,13 +348,13 @@ impl<'a> _FUNCW<'a> {
 #[doc = "Values that can be written to the field `MODE`"]
 pub enum MODEW {
     #[doc = "Inactive (no pull-down/pull-up resistor enabled)."]
-    INACTIVE_NO_PULL_DO,
+    INACTIVE,
     #[doc = "Pull-down resistor enabled."]
-    PULL_DOWN_RESISTOR_E,
+    PULL_DOWN,
     #[doc = "Pull-up resistor enabled."]
-    PULL_UP_RESISTOR_ENA,
+    PULL_UP,
     #[doc = "Repeater mode."]
-    REPEATER_MODE_,
+    REPEATER,
 }
 impl MODEW {
     #[allow(missing_docs)]
@@ -362,10 +362,10 @@ impl MODEW {
     #[inline]
     pub fn _bits(&self) -> u8 {
         match *self {
-            MODEW::INACTIVE_NO_PULL_DO => 0,
-            MODEW::PULL_DOWN_RESISTOR_E => 1,
-            MODEW::PULL_UP_RESISTOR_ENA => 2,
-            MODEW::REPEATER_MODE_ => 3,
+            MODEW::INACTIVE => 0,
+            MODEW::PULL_DOWN => 1,
+            MODEW::PULL_UP => 2,
+            MODEW::REPEATER => 3,
         }
     }
 }
@@ -383,23 +383,23 @@ impl<'a> _MODEW<'a> {
     }
     #[doc = "Inactive (no pull-down/pull-up resistor enabled)."]
     #[inline]
-    pub fn inactive_no_pull_do(self) -> &'a mut W {
-        self.variant(MODEW::INACTIVE_NO_PULL_DO)
+    pub fn inactive(self) -> &'a mut W {
+        self.variant(MODEW::INACTIVE)
     }
     #[doc = "Pull-down resistor enabled."]
     #[inline]
-    pub fn pull_down_resistor_e(self) -> &'a mut W {
-        self.variant(MODEW::PULL_DOWN_RESISTOR_E)
+    pub fn pull_down(self) -> &'a mut W {
+        self.variant(MODEW::PULL_DOWN)
     }
     #[doc = "Pull-up resistor enabled."]
     #[inline]
-    pub fn pull_up_resistor_ena(self) -> &'a mut W {
-        self.variant(MODEW::PULL_UP_RESISTOR_ENA)
+    pub fn pull_up(self) -> &'a mut W {
+        self.variant(MODEW::PULL_UP)
     }
     #[doc = "Repeater mode."]
     #[inline]
-    pub fn repeater_mode_(self) -> &'a mut W {
-        self.variant(MODEW::REPEATER_MODE_)
+    pub fn repeater(self) -> &'a mut W {
+        self.variant(MODEW::REPEATER)
     }
     #[doc = r" Writes raw bits to the field"]
     #[inline]
@@ -414,9 +414,9 @@ impl<'a> _MODEW<'a> {
 #[doc = "Values that can be written to the field `HYS`"]
 pub enum HYSW {
     #[doc = "Disable."]
-    DISABLE_,
+    DISABLED,
     #[doc = "Enable."]
-    ENABLE_,
+    ENABLED,
 }
 impl HYSW {
     #[allow(missing_docs)]
@@ -424,8 +424,8 @@ impl HYSW {
     #[inline]
     pub fn _bits(&self) -> bool {
         match *self {
-            HYSW::DISABLE_ => false,
-            HYSW::ENABLE_ => true,
+            HYSW::DISABLED => false,
+            HYSW::ENABLED => true,
         }
     }
 }
@@ -443,13 +443,13 @@ impl<'a> _HYSW<'a> {
     }
     #[doc = "Disable."]
     #[inline]
-    pub fn disable_(self) -> &'a mut W {
-        self.variant(HYSW::DISABLE_)
+    pub fn disabled(self) -> &'a mut W {
+        self.variant(HYSW::DISABLED)
     }
     #[doc = "Enable."]
     #[inline]
-    pub fn enable_(self) -> &'a mut W {
-        self.variant(HYSW::ENABLE_)
+    pub fn enabled(self) -> &'a mut W {
+        self.variant(HYSW::ENABLED)
     }
     #[doc = r" Sets the field bit"]
     pub fn set_bit(self) -> &'a mut W {
@@ -472,9 +472,9 @@ impl<'a> _HYSW<'a> {
 #[doc = "Values that can be written to the field `INV`"]
 pub enum INVW {
     #[doc = "Input not inverted (HIGH on pin reads as 1, LOW on pin reads as 0)."]
-    INPUT_NOT_INVERTED_,
+    NOT_INVERTED,
     #[doc = "Input inverted (HIGH on pin reads as 0, LOW on pin reads as 1)."]
-    INPUT_INVERTED_HIGH,
+    INVERTED,
 }
 impl INVW {
     #[allow(missing_docs)]
@@ -482,8 +482,8 @@ impl INVW {
     #[inline]
     pub fn _bits(&self) -> bool {
         match *self {
-            INVW::INPUT_NOT_INVERTED_ => false,
-            INVW::INPUT_INVERTED_HIGH => true,
+            INVW::NOT_INVERTED => false,
+            INVW::INVERTED => true,
         }
     }
 }
@@ -501,13 +501,13 @@ impl<'a> _INVW<'a> {
     }
     #[doc = "Input not inverted (HIGH on pin reads as 1, LOW on pin reads as 0)."]
     #[inline]
-    pub fn input_not_inverted_(self) -> &'a mut W {
-        self.variant(INVW::INPUT_NOT_INVERTED_)
+    pub fn not_inverted(self) -> &'a mut W {
+        self.variant(INVW::NOT_INVERTED)
     }
     #[doc = "Input inverted (HIGH on pin reads as 0, LOW on pin reads as 1)."]
     #[inline]
-    pub fn input_inverted_high(self) -> &'a mut W {
-        self.variant(INVW::INPUT_INVERTED_HIGH)
+    pub fn inverted(self) -> &'a mut W {
+        self.variant(INVW::INVERTED)
     }
     #[doc = r" Sets the field bit"]
     pub fn set_bit(self) -> &'a mut W {
@@ -530,9 +530,9 @@ impl<'a> _INVW<'a> {
 #[doc = "Values that can be written to the field `OD`"]
 pub enum ODW {
     #[doc = "Disable."]
-    DISABLE_,
+    DISABLED,
     #[doc = "Open-drain mode enabled.  This is not a true open-drain mode."]
-    OPEN_DRAIN_MODE_ENAB,
+    OPEN_DRAIN,
 }
 impl ODW {
     #[allow(missing_docs)]
@@ -540,8 +540,8 @@ impl ODW {
     #[inline]
     pub fn _bits(&self) -> bool {
         match *self {
-            ODW::DISABLE_ => false,
-            ODW::OPEN_DRAIN_MODE_ENAB => true,
+            ODW::DISABLED => false,
+            ODW::OPEN_DRAIN => true,
         }
     }
 }
@@ -559,13 +559,13 @@ impl<'a> _ODW<'a> {
     }
     #[doc = "Disable."]
     #[inline]
-    pub fn disable_(self) -> &'a mut W {
-        self.variant(ODW::DISABLE_)
+    pub fn disabled(self) -> &'a mut W {
+        self.variant(ODW::DISABLED)
     }
     #[doc = "Open-drain mode enabled. This is not a true open-drain mode."]
     #[inline]
-    pub fn open_drain_mode_enab(self) -> &'a mut W {
-        self.variant(ODW::OPEN_DRAIN_MODE_ENAB)
+    pub fn open_drain(self) -> &'a mut W {
+        self.variant(ODW::OPEN_DRAIN)
     }
     #[doc = r" Sets the field bit"]
     pub fn set_bit(self) -> &'a mut W {

--- a/lpc11uxx/src/iocon/pio0_2.rs
+++ b/lpc11uxx/src/iocon/pio0_2.rs
@@ -46,11 +46,11 @@ impl super::PIO0_2 {
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum FUNCR {
     #[doc = "PIO0_2."]
-    PIO0_2_,
+    PIO0_2,
     #[doc = "SSEL0."]
-    SSEL0_,
+    SSEL0,
     #[doc = "CT16B0_CAP0."]
-    CT16B0_CAP0_,
+    CT16B0_CAP0,
     #[doc = r" Reserved"]
     _Reserved(u8),
 }
@@ -59,9 +59,9 @@ impl FUNCR {
     #[inline]
     pub fn bits(&self) -> u8 {
         match *self {
-            FUNCR::PIO0_2_ => 0,
-            FUNCR::SSEL0_ => 1,
-            FUNCR::CT16B0_CAP0_ => 2,
+            FUNCR::PIO0_2 => 0,
+            FUNCR::SSEL0 => 1,
+            FUNCR::CT16B0_CAP0 => 2,
             FUNCR::_Reserved(bits) => bits,
         }
     }
@@ -70,49 +70,49 @@ impl FUNCR {
     #[inline]
     pub fn _from(value: u8) -> FUNCR {
         match value {
-            0 => FUNCR::PIO0_2_,
-            1 => FUNCR::SSEL0_,
-            2 => FUNCR::CT16B0_CAP0_,
+            0 => FUNCR::PIO0_2,
+            1 => FUNCR::SSEL0,
+            2 => FUNCR::CT16B0_CAP0,
             i => FUNCR::_Reserved(i),
         }
     }
-    #[doc = "Checks if the value of the field is `PIO0_2_`"]
+    #[doc = "Checks if the value of the field is `PIO0_2`"]
     #[inline]
-    pub fn is_pio0_2_(&self) -> bool {
-        *self == FUNCR::PIO0_2_
+    pub fn is_pio0_2(&self) -> bool {
+        *self == FUNCR::PIO0_2
     }
-    #[doc = "Checks if the value of the field is `SSEL0_`"]
+    #[doc = "Checks if the value of the field is `SSEL0`"]
     #[inline]
-    pub fn is_ssel0_(&self) -> bool {
-        *self == FUNCR::SSEL0_
+    pub fn is_ssel0(&self) -> bool {
+        *self == FUNCR::SSEL0
     }
-    #[doc = "Checks if the value of the field is `CT16B0_CAP0_`"]
+    #[doc = "Checks if the value of the field is `CT16B0_CAP0`"]
     #[inline]
-    pub fn is_ct16b0_cap0_(&self) -> bool {
-        *self == FUNCR::CT16B0_CAP0_
+    pub fn is_ct16b0_cap0(&self) -> bool {
+        *self == FUNCR::CT16B0_CAP0
     }
 }
 #[doc = "Possible values of the field `MODE`"]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum MODER {
     #[doc = "Inactive (no pull-down/pull-up resistor enabled)."]
-    INACTIVE_NO_PULL_DO,
+    INACTIVE,
     #[doc = "Pull-down resistor enabled."]
-    PULL_DOWN_RESISTOR_E,
+    PULL_DOWN,
     #[doc = "Pull-up resistor enabled."]
-    PULL_UP_RESISTOR_ENA,
+    PULL_UP,
     #[doc = "Repeater mode."]
-    REPEATER_MODE_,
+    REPEATER,
 }
 impl MODER {
     #[doc = r" Value of the field as raw bits"]
     #[inline]
     pub fn bits(&self) -> u8 {
         match *self {
-            MODER::INACTIVE_NO_PULL_DO => 0,
-            MODER::PULL_DOWN_RESISTOR_E => 1,
-            MODER::PULL_UP_RESISTOR_ENA => 2,
-            MODER::REPEATER_MODE_ => 3,
+            MODER::INACTIVE => 0,
+            MODER::PULL_DOWN => 1,
+            MODER::PULL_UP => 2,
+            MODER::REPEATER => 3,
         }
     }
     #[allow(missing_docs)]
@@ -120,41 +120,41 @@ impl MODER {
     #[inline]
     pub fn _from(value: u8) -> MODER {
         match value {
-            0 => MODER::INACTIVE_NO_PULL_DO,
-            1 => MODER::PULL_DOWN_RESISTOR_E,
-            2 => MODER::PULL_UP_RESISTOR_ENA,
-            3 => MODER::REPEATER_MODE_,
+            0 => MODER::INACTIVE,
+            1 => MODER::PULL_DOWN,
+            2 => MODER::PULL_UP,
+            3 => MODER::REPEATER,
             _ => unreachable!(),
         }
     }
-    #[doc = "Checks if the value of the field is `INACTIVE_NO_PULL_DO`"]
+    #[doc = "Checks if the value of the field is `INACTIVE`"]
     #[inline]
-    pub fn is_inactive_no_pull_do(&self) -> bool {
-        *self == MODER::INACTIVE_NO_PULL_DO
+    pub fn is_inactive(&self) -> bool {
+        *self == MODER::INACTIVE
     }
-    #[doc = "Checks if the value of the field is `PULL_DOWN_RESISTOR_E`"]
+    #[doc = "Checks if the value of the field is `PULL_DOWN`"]
     #[inline]
-    pub fn is_pull_down_resistor_e(&self) -> bool {
-        *self == MODER::PULL_DOWN_RESISTOR_E
+    pub fn is_pull_down(&self) -> bool {
+        *self == MODER::PULL_DOWN
     }
-    #[doc = "Checks if the value of the field is `PULL_UP_RESISTOR_ENA`"]
+    #[doc = "Checks if the value of the field is `PULL_UP`"]
     #[inline]
-    pub fn is_pull_up_resistor_ena(&self) -> bool {
-        *self == MODER::PULL_UP_RESISTOR_ENA
+    pub fn is_pull_up(&self) -> bool {
+        *self == MODER::PULL_UP
     }
-    #[doc = "Checks if the value of the field is `REPEATER_MODE_`"]
+    #[doc = "Checks if the value of the field is `REPEATER`"]
     #[inline]
-    pub fn is_repeater_mode_(&self) -> bool {
-        *self == MODER::REPEATER_MODE_
+    pub fn is_repeater(&self) -> bool {
+        *self == MODER::REPEATER
     }
 }
 #[doc = "Possible values of the field `HYS`"]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum HYSR {
     #[doc = "Disable."]
-    DISABLE_,
+    DISABLED,
     #[doc = "Enable."]
-    ENABLE_,
+    ENABLED,
 }
 impl HYSR {
     #[doc = r" Returns `true` if the bit is clear (0)"]
@@ -171,8 +171,8 @@ impl HYSR {
     #[inline]
     pub fn bit(&self) -> bool {
         match *self {
-            HYSR::DISABLE_ => false,
-            HYSR::ENABLE_ => true,
+            HYSR::DISABLED => false,
+            HYSR::ENABLED => true,
         }
     }
     #[allow(missing_docs)]
@@ -180,28 +180,28 @@ impl HYSR {
     #[inline]
     pub fn _from(value: bool) -> HYSR {
         match value {
-            false => HYSR::DISABLE_,
-            true => HYSR::ENABLE_,
+            false => HYSR::DISABLED,
+            true => HYSR::ENABLED,
         }
     }
-    #[doc = "Checks if the value of the field is `DISABLE_`"]
+    #[doc = "Checks if the value of the field is `DISABLED`"]
     #[inline]
-    pub fn is_disable_(&self) -> bool {
-        *self == HYSR::DISABLE_
+    pub fn is_disabled(&self) -> bool {
+        *self == HYSR::DISABLED
     }
-    #[doc = "Checks if the value of the field is `ENABLE_`"]
+    #[doc = "Checks if the value of the field is `ENABLED`"]
     #[inline]
-    pub fn is_enable_(&self) -> bool {
-        *self == HYSR::ENABLE_
+    pub fn is_enabled(&self) -> bool {
+        *self == HYSR::ENABLED
     }
 }
 #[doc = "Possible values of the field `INV`"]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum INVR {
     #[doc = "Input not inverted (HIGH on pin reads as 1, LOW on pin reads as 0)."]
-    INPUT_NOT_INVERTED_,
+    NOT_INVERTED,
     #[doc = "Input inverted (HIGH on pin reads as 0, LOW on pin reads as 1)."]
-    INPUT_INVERTED_HIGH,
+    INVERTED,
 }
 impl INVR {
     #[doc = r" Returns `true` if the bit is clear (0)"]
@@ -218,8 +218,8 @@ impl INVR {
     #[inline]
     pub fn bit(&self) -> bool {
         match *self {
-            INVR::INPUT_NOT_INVERTED_ => false,
-            INVR::INPUT_INVERTED_HIGH => true,
+            INVR::NOT_INVERTED => false,
+            INVR::INVERTED => true,
         }
     }
     #[allow(missing_docs)]
@@ -227,28 +227,28 @@ impl INVR {
     #[inline]
     pub fn _from(value: bool) -> INVR {
         match value {
-            false => INVR::INPUT_NOT_INVERTED_,
-            true => INVR::INPUT_INVERTED_HIGH,
+            false => INVR::NOT_INVERTED,
+            true => INVR::INVERTED,
         }
     }
-    #[doc = "Checks if the value of the field is `INPUT_NOT_INVERTED_`"]
+    #[doc = "Checks if the value of the field is `NOT_INVERTED`"]
     #[inline]
-    pub fn is_input_not_inverted_(&self) -> bool {
-        *self == INVR::INPUT_NOT_INVERTED_
+    pub fn is_not_inverted(&self) -> bool {
+        *self == INVR::NOT_INVERTED
     }
-    #[doc = "Checks if the value of the field is `INPUT_INVERTED_HIGH`"]
+    #[doc = "Checks if the value of the field is `INVERTED`"]
     #[inline]
-    pub fn is_input_inverted_high(&self) -> bool {
-        *self == INVR::INPUT_INVERTED_HIGH
+    pub fn is_inverted(&self) -> bool {
+        *self == INVR::INVERTED
     }
 }
 #[doc = "Possible values of the field `OD`"]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum ODR {
     #[doc = "Disable."]
-    DISABLE_,
+    DISABLED,
     #[doc = "Open-drain mode enabled.  This is not a true open-drain mode."]
-    OPEN_DRAIN_MODE_ENAB,
+    OPEN_DRAIN,
 }
 impl ODR {
     #[doc = r" Returns `true` if the bit is clear (0)"]
@@ -265,8 +265,8 @@ impl ODR {
     #[inline]
     pub fn bit(&self) -> bool {
         match *self {
-            ODR::DISABLE_ => false,
-            ODR::OPEN_DRAIN_MODE_ENAB => true,
+            ODR::DISABLED => false,
+            ODR::OPEN_DRAIN => true,
         }
     }
     #[allow(missing_docs)]
@@ -274,29 +274,29 @@ impl ODR {
     #[inline]
     pub fn _from(value: bool) -> ODR {
         match value {
-            false => ODR::DISABLE_,
-            true => ODR::OPEN_DRAIN_MODE_ENAB,
+            false => ODR::DISABLED,
+            true => ODR::OPEN_DRAIN,
         }
     }
-    #[doc = "Checks if the value of the field is `DISABLE_`"]
+    #[doc = "Checks if the value of the field is `DISABLED`"]
     #[inline]
-    pub fn is_disable_(&self) -> bool {
-        *self == ODR::DISABLE_
+    pub fn is_disabled(&self) -> bool {
+        *self == ODR::DISABLED
     }
-    #[doc = "Checks if the value of the field is `OPEN_DRAIN_MODE_ENAB`"]
+    #[doc = "Checks if the value of the field is `OPEN_DRAIN`"]
     #[inline]
-    pub fn is_open_drain_mode_enab(&self) -> bool {
-        *self == ODR::OPEN_DRAIN_MODE_ENAB
+    pub fn is_open_drain(&self) -> bool {
+        *self == ODR::OPEN_DRAIN
     }
 }
 #[doc = "Values that can be written to the field `FUNC`"]
 pub enum FUNCW {
     #[doc = "PIO0_2."]
-    PIO0_2_,
+    PIO0_2,
     #[doc = "SSEL0."]
-    SSEL0_,
+    SSEL0,
     #[doc = "CT16B0_CAP0."]
-    CT16B0_CAP0_,
+    CT16B0_CAP0,
 }
 impl FUNCW {
     #[allow(missing_docs)]
@@ -304,9 +304,9 @@ impl FUNCW {
     #[inline]
     pub fn _bits(&self) -> u8 {
         match *self {
-            FUNCW::PIO0_2_ => 0,
-            FUNCW::SSEL0_ => 1,
-            FUNCW::CT16B0_CAP0_ => 2,
+            FUNCW::PIO0_2 => 0,
+            FUNCW::SSEL0 => 1,
+            FUNCW::CT16B0_CAP0 => 2,
         }
     }
 }
@@ -322,18 +322,18 @@ impl<'a> _FUNCW<'a> {
     }
     #[doc = "PIO0_2."]
     #[inline]
-    pub fn pio0_2_(self) -> &'a mut W {
-        self.variant(FUNCW::PIO0_2_)
+    pub fn pio0_2(self) -> &'a mut W {
+        self.variant(FUNCW::PIO0_2)
     }
     #[doc = "SSEL0."]
     #[inline]
-    pub fn ssel0_(self) -> &'a mut W {
-        self.variant(FUNCW::SSEL0_)
+    pub fn ssel0(self) -> &'a mut W {
+        self.variant(FUNCW::SSEL0)
     }
     #[doc = "CT16B0_CAP0."]
     #[inline]
-    pub fn ct16b0_cap0_(self) -> &'a mut W {
-        self.variant(FUNCW::CT16B0_CAP0_)
+    pub fn ct16b0_cap0(self) -> &'a mut W {
+        self.variant(FUNCW::CT16B0_CAP0)
     }
     #[doc = r" Writes raw bits to the field"]
     #[inline]
@@ -348,13 +348,13 @@ impl<'a> _FUNCW<'a> {
 #[doc = "Values that can be written to the field `MODE`"]
 pub enum MODEW {
     #[doc = "Inactive (no pull-down/pull-up resistor enabled)."]
-    INACTIVE_NO_PULL_DO,
+    INACTIVE,
     #[doc = "Pull-down resistor enabled."]
-    PULL_DOWN_RESISTOR_E,
+    PULL_DOWN,
     #[doc = "Pull-up resistor enabled."]
-    PULL_UP_RESISTOR_ENA,
+    PULL_UP,
     #[doc = "Repeater mode."]
-    REPEATER_MODE_,
+    REPEATER,
 }
 impl MODEW {
     #[allow(missing_docs)]
@@ -362,10 +362,10 @@ impl MODEW {
     #[inline]
     pub fn _bits(&self) -> u8 {
         match *self {
-            MODEW::INACTIVE_NO_PULL_DO => 0,
-            MODEW::PULL_DOWN_RESISTOR_E => 1,
-            MODEW::PULL_UP_RESISTOR_ENA => 2,
-            MODEW::REPEATER_MODE_ => 3,
+            MODEW::INACTIVE => 0,
+            MODEW::PULL_DOWN => 1,
+            MODEW::PULL_UP => 2,
+            MODEW::REPEATER => 3,
         }
     }
 }
@@ -383,23 +383,23 @@ impl<'a> _MODEW<'a> {
     }
     #[doc = "Inactive (no pull-down/pull-up resistor enabled)."]
     #[inline]
-    pub fn inactive_no_pull_do(self) -> &'a mut W {
-        self.variant(MODEW::INACTIVE_NO_PULL_DO)
+    pub fn inactive(self) -> &'a mut W {
+        self.variant(MODEW::INACTIVE)
     }
     #[doc = "Pull-down resistor enabled."]
     #[inline]
-    pub fn pull_down_resistor_e(self) -> &'a mut W {
-        self.variant(MODEW::PULL_DOWN_RESISTOR_E)
+    pub fn pull_down(self) -> &'a mut W {
+        self.variant(MODEW::PULL_DOWN)
     }
     #[doc = "Pull-up resistor enabled."]
     #[inline]
-    pub fn pull_up_resistor_ena(self) -> &'a mut W {
-        self.variant(MODEW::PULL_UP_RESISTOR_ENA)
+    pub fn pull_up(self) -> &'a mut W {
+        self.variant(MODEW::PULL_UP)
     }
     #[doc = "Repeater mode."]
     #[inline]
-    pub fn repeater_mode_(self) -> &'a mut W {
-        self.variant(MODEW::REPEATER_MODE_)
+    pub fn repeater(self) -> &'a mut W {
+        self.variant(MODEW::REPEATER)
     }
     #[doc = r" Writes raw bits to the field"]
     #[inline]
@@ -414,9 +414,9 @@ impl<'a> _MODEW<'a> {
 #[doc = "Values that can be written to the field `HYS`"]
 pub enum HYSW {
     #[doc = "Disable."]
-    DISABLE_,
+    DISABLED,
     #[doc = "Enable."]
-    ENABLE_,
+    ENABLED,
 }
 impl HYSW {
     #[allow(missing_docs)]
@@ -424,8 +424,8 @@ impl HYSW {
     #[inline]
     pub fn _bits(&self) -> bool {
         match *self {
-            HYSW::DISABLE_ => false,
-            HYSW::ENABLE_ => true,
+            HYSW::DISABLED => false,
+            HYSW::ENABLED => true,
         }
     }
 }
@@ -443,13 +443,13 @@ impl<'a> _HYSW<'a> {
     }
     #[doc = "Disable."]
     #[inline]
-    pub fn disable_(self) -> &'a mut W {
-        self.variant(HYSW::DISABLE_)
+    pub fn disabled(self) -> &'a mut W {
+        self.variant(HYSW::DISABLED)
     }
     #[doc = "Enable."]
     #[inline]
-    pub fn enable_(self) -> &'a mut W {
-        self.variant(HYSW::ENABLE_)
+    pub fn enabled(self) -> &'a mut W {
+        self.variant(HYSW::ENABLED)
     }
     #[doc = r" Sets the field bit"]
     pub fn set_bit(self) -> &'a mut W {
@@ -472,9 +472,9 @@ impl<'a> _HYSW<'a> {
 #[doc = "Values that can be written to the field `INV`"]
 pub enum INVW {
     #[doc = "Input not inverted (HIGH on pin reads as 1, LOW on pin reads as 0)."]
-    INPUT_NOT_INVERTED_,
+    NOT_INVERTED,
     #[doc = "Input inverted (HIGH on pin reads as 0, LOW on pin reads as 1)."]
-    INPUT_INVERTED_HIGH,
+    INVERTED,
 }
 impl INVW {
     #[allow(missing_docs)]
@@ -482,8 +482,8 @@ impl INVW {
     #[inline]
     pub fn _bits(&self) -> bool {
         match *self {
-            INVW::INPUT_NOT_INVERTED_ => false,
-            INVW::INPUT_INVERTED_HIGH => true,
+            INVW::NOT_INVERTED => false,
+            INVW::INVERTED => true,
         }
     }
 }
@@ -501,13 +501,13 @@ impl<'a> _INVW<'a> {
     }
     #[doc = "Input not inverted (HIGH on pin reads as 1, LOW on pin reads as 0)."]
     #[inline]
-    pub fn input_not_inverted_(self) -> &'a mut W {
-        self.variant(INVW::INPUT_NOT_INVERTED_)
+    pub fn not_inverted(self) -> &'a mut W {
+        self.variant(INVW::NOT_INVERTED)
     }
     #[doc = "Input inverted (HIGH on pin reads as 0, LOW on pin reads as 1)."]
     #[inline]
-    pub fn input_inverted_high(self) -> &'a mut W {
-        self.variant(INVW::INPUT_INVERTED_HIGH)
+    pub fn inverted(self) -> &'a mut W {
+        self.variant(INVW::INVERTED)
     }
     #[doc = r" Sets the field bit"]
     pub fn set_bit(self) -> &'a mut W {
@@ -530,9 +530,9 @@ impl<'a> _INVW<'a> {
 #[doc = "Values that can be written to the field `OD`"]
 pub enum ODW {
     #[doc = "Disable."]
-    DISABLE_,
+    DISABLED,
     #[doc = "Open-drain mode enabled.  This is not a true open-drain mode."]
-    OPEN_DRAIN_MODE_ENAB,
+    OPEN_DRAIN,
 }
 impl ODW {
     #[allow(missing_docs)]
@@ -540,8 +540,8 @@ impl ODW {
     #[inline]
     pub fn _bits(&self) -> bool {
         match *self {
-            ODW::DISABLE_ => false,
-            ODW::OPEN_DRAIN_MODE_ENAB => true,
+            ODW::DISABLED => false,
+            ODW::OPEN_DRAIN => true,
         }
     }
 }
@@ -559,13 +559,13 @@ impl<'a> _ODW<'a> {
     }
     #[doc = "Disable."]
     #[inline]
-    pub fn disable_(self) -> &'a mut W {
-        self.variant(ODW::DISABLE_)
+    pub fn disabled(self) -> &'a mut W {
+        self.variant(ODW::DISABLED)
     }
     #[doc = "Open-drain mode enabled. This is not a true open-drain mode."]
     #[inline]
-    pub fn open_drain_mode_enab(self) -> &'a mut W {
-        self.variant(ODW::OPEN_DRAIN_MODE_ENAB)
+    pub fn open_drain(self) -> &'a mut W {
+        self.variant(ODW::OPEN_DRAIN)
     }
     #[doc = r" Sets the field bit"]
     pub fn set_bit(self) -> &'a mut W {

--- a/lpc11uxx/src/iocon/pio0_20.rs
+++ b/lpc11uxx/src/iocon/pio0_20.rs
@@ -46,9 +46,9 @@ impl super::PIO0_20 {
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum FUNCR {
     #[doc = "PIO0_20."]
-    PIO0_20_,
+    PIO0_20,
     #[doc = "CT16B1_CAP0."]
-    CT16B1_CAP0_,
+    CT16B1_CAP0,
     #[doc = r" Reserved"]
     _Reserved(u8),
 }
@@ -57,8 +57,8 @@ impl FUNCR {
     #[inline]
     pub fn bits(&self) -> u8 {
         match *self {
-            FUNCR::PIO0_20_ => 0,
-            FUNCR::CT16B1_CAP0_ => 1,
+            FUNCR::PIO0_20 => 0,
+            FUNCR::CT16B1_CAP0 => 1,
             FUNCR::_Reserved(bits) => bits,
         }
     }
@@ -67,43 +67,43 @@ impl FUNCR {
     #[inline]
     pub fn _from(value: u8) -> FUNCR {
         match value {
-            0 => FUNCR::PIO0_20_,
-            1 => FUNCR::CT16B1_CAP0_,
+            0 => FUNCR::PIO0_20,
+            1 => FUNCR::CT16B1_CAP0,
             i => FUNCR::_Reserved(i),
         }
     }
-    #[doc = "Checks if the value of the field is `PIO0_20_`"]
+    #[doc = "Checks if the value of the field is `PIO0_20`"]
     #[inline]
-    pub fn is_pio0_20_(&self) -> bool {
-        *self == FUNCR::PIO0_20_
+    pub fn is_pio0_20(&self) -> bool {
+        *self == FUNCR::PIO0_20
     }
-    #[doc = "Checks if the value of the field is `CT16B1_CAP0_`"]
+    #[doc = "Checks if the value of the field is `CT16B1_CAP0`"]
     #[inline]
-    pub fn is_ct16b1_cap0_(&self) -> bool {
-        *self == FUNCR::CT16B1_CAP0_
+    pub fn is_ct16b1_cap0(&self) -> bool {
+        *self == FUNCR::CT16B1_CAP0
     }
 }
 #[doc = "Possible values of the field `MODE`"]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum MODER {
     #[doc = "Inactive (no pull-down/pull-up resistor enabled)."]
-    INACTIVE_NO_PULL_DO,
+    INACTIVE,
     #[doc = "Pull-down resistor enabled."]
-    PULL_DOWN_RESISTOR_E,
+    PULL_DOWN,
     #[doc = "Pull-up resistor enabled."]
-    PULL_UP_RESISTOR_ENA,
+    PULL_UP,
     #[doc = "Repeater mode."]
-    REPEATER_MODE_,
+    REPEATER,
 }
 impl MODER {
     #[doc = r" Value of the field as raw bits"]
     #[inline]
     pub fn bits(&self) -> u8 {
         match *self {
-            MODER::INACTIVE_NO_PULL_DO => 0,
-            MODER::PULL_DOWN_RESISTOR_E => 1,
-            MODER::PULL_UP_RESISTOR_ENA => 2,
-            MODER::REPEATER_MODE_ => 3,
+            MODER::INACTIVE => 0,
+            MODER::PULL_DOWN => 1,
+            MODER::PULL_UP => 2,
+            MODER::REPEATER => 3,
         }
     }
     #[allow(missing_docs)]
@@ -111,41 +111,41 @@ impl MODER {
     #[inline]
     pub fn _from(value: u8) -> MODER {
         match value {
-            0 => MODER::INACTIVE_NO_PULL_DO,
-            1 => MODER::PULL_DOWN_RESISTOR_E,
-            2 => MODER::PULL_UP_RESISTOR_ENA,
-            3 => MODER::REPEATER_MODE_,
+            0 => MODER::INACTIVE,
+            1 => MODER::PULL_DOWN,
+            2 => MODER::PULL_UP,
+            3 => MODER::REPEATER,
             _ => unreachable!(),
         }
     }
-    #[doc = "Checks if the value of the field is `INACTIVE_NO_PULL_DO`"]
+    #[doc = "Checks if the value of the field is `INACTIVE`"]
     #[inline]
-    pub fn is_inactive_no_pull_do(&self) -> bool {
-        *self == MODER::INACTIVE_NO_PULL_DO
+    pub fn is_inactive(&self) -> bool {
+        *self == MODER::INACTIVE
     }
-    #[doc = "Checks if the value of the field is `PULL_DOWN_RESISTOR_E`"]
+    #[doc = "Checks if the value of the field is `PULL_DOWN`"]
     #[inline]
-    pub fn is_pull_down_resistor_e(&self) -> bool {
-        *self == MODER::PULL_DOWN_RESISTOR_E
+    pub fn is_pull_down(&self) -> bool {
+        *self == MODER::PULL_DOWN
     }
-    #[doc = "Checks if the value of the field is `PULL_UP_RESISTOR_ENA`"]
+    #[doc = "Checks if the value of the field is `PULL_UP`"]
     #[inline]
-    pub fn is_pull_up_resistor_ena(&self) -> bool {
-        *self == MODER::PULL_UP_RESISTOR_ENA
+    pub fn is_pull_up(&self) -> bool {
+        *self == MODER::PULL_UP
     }
-    #[doc = "Checks if the value of the field is `REPEATER_MODE_`"]
+    #[doc = "Checks if the value of the field is `REPEATER`"]
     #[inline]
-    pub fn is_repeater_mode_(&self) -> bool {
-        *self == MODER::REPEATER_MODE_
+    pub fn is_repeater(&self) -> bool {
+        *self == MODER::REPEATER
     }
 }
 #[doc = "Possible values of the field `HYS`"]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum HYSR {
     #[doc = "Disable."]
-    DISABLE_,
+    DISABLED,
     #[doc = "Enable."]
-    ENABLE_,
+    ENABLED,
 }
 impl HYSR {
     #[doc = r" Returns `true` if the bit is clear (0)"]
@@ -162,8 +162,8 @@ impl HYSR {
     #[inline]
     pub fn bit(&self) -> bool {
         match *self {
-            HYSR::DISABLE_ => false,
-            HYSR::ENABLE_ => true,
+            HYSR::DISABLED => false,
+            HYSR::ENABLED => true,
         }
     }
     #[allow(missing_docs)]
@@ -171,28 +171,28 @@ impl HYSR {
     #[inline]
     pub fn _from(value: bool) -> HYSR {
         match value {
-            false => HYSR::DISABLE_,
-            true => HYSR::ENABLE_,
+            false => HYSR::DISABLED,
+            true => HYSR::ENABLED,
         }
     }
-    #[doc = "Checks if the value of the field is `DISABLE_`"]
+    #[doc = "Checks if the value of the field is `DISABLED`"]
     #[inline]
-    pub fn is_disable_(&self) -> bool {
-        *self == HYSR::DISABLE_
+    pub fn is_disabled(&self) -> bool {
+        *self == HYSR::DISABLED
     }
-    #[doc = "Checks if the value of the field is `ENABLE_`"]
+    #[doc = "Checks if the value of the field is `ENABLED`"]
     #[inline]
-    pub fn is_enable_(&self) -> bool {
-        *self == HYSR::ENABLE_
+    pub fn is_enabled(&self) -> bool {
+        *self == HYSR::ENABLED
     }
 }
 #[doc = "Possible values of the field `INV`"]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum INVR {
     #[doc = "Input not inverted (HIGH on pin reads as 1, LOW on pin reads as 0)."]
-    INPUT_NOT_INVERTED_,
+    NOT_INVERTED,
     #[doc = "Input inverted (HIGH on pin reads as 0, LOW on pin reads as 1)."]
-    INPUT_INVERTED_HIGH,
+    INVERTED,
 }
 impl INVR {
     #[doc = r" Returns `true` if the bit is clear (0)"]
@@ -209,8 +209,8 @@ impl INVR {
     #[inline]
     pub fn bit(&self) -> bool {
         match *self {
-            INVR::INPUT_NOT_INVERTED_ => false,
-            INVR::INPUT_INVERTED_HIGH => true,
+            INVR::NOT_INVERTED => false,
+            INVR::INVERTED => true,
         }
     }
     #[allow(missing_docs)]
@@ -218,28 +218,28 @@ impl INVR {
     #[inline]
     pub fn _from(value: bool) -> INVR {
         match value {
-            false => INVR::INPUT_NOT_INVERTED_,
-            true => INVR::INPUT_INVERTED_HIGH,
+            false => INVR::NOT_INVERTED,
+            true => INVR::INVERTED,
         }
     }
-    #[doc = "Checks if the value of the field is `INPUT_NOT_INVERTED_`"]
+    #[doc = "Checks if the value of the field is `NOT_INVERTED`"]
     #[inline]
-    pub fn is_input_not_inverted_(&self) -> bool {
-        *self == INVR::INPUT_NOT_INVERTED_
+    pub fn is_not_inverted(&self) -> bool {
+        *self == INVR::NOT_INVERTED
     }
-    #[doc = "Checks if the value of the field is `INPUT_INVERTED_HIGH`"]
+    #[doc = "Checks if the value of the field is `INVERTED`"]
     #[inline]
-    pub fn is_input_inverted_high(&self) -> bool {
-        *self == INVR::INPUT_INVERTED_HIGH
+    pub fn is_inverted(&self) -> bool {
+        *self == INVR::INVERTED
     }
 }
 #[doc = "Possible values of the field `OD`"]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum ODR {
     #[doc = "Disable."]
-    DISABLE_,
+    DISABLED,
     #[doc = "Open-drain mode enabled.  This is not a true open-drain mode."]
-    OPEN_DRAIN_MODE_ENAB,
+    OPEN_DRAIN,
 }
 impl ODR {
     #[doc = r" Returns `true` if the bit is clear (0)"]
@@ -256,8 +256,8 @@ impl ODR {
     #[inline]
     pub fn bit(&self) -> bool {
         match *self {
-            ODR::DISABLE_ => false,
-            ODR::OPEN_DRAIN_MODE_ENAB => true,
+            ODR::DISABLED => false,
+            ODR::OPEN_DRAIN => true,
         }
     }
     #[allow(missing_docs)]
@@ -265,27 +265,27 @@ impl ODR {
     #[inline]
     pub fn _from(value: bool) -> ODR {
         match value {
-            false => ODR::DISABLE_,
-            true => ODR::OPEN_DRAIN_MODE_ENAB,
+            false => ODR::DISABLED,
+            true => ODR::OPEN_DRAIN,
         }
     }
-    #[doc = "Checks if the value of the field is `DISABLE_`"]
+    #[doc = "Checks if the value of the field is `DISABLED`"]
     #[inline]
-    pub fn is_disable_(&self) -> bool {
-        *self == ODR::DISABLE_
+    pub fn is_disabled(&self) -> bool {
+        *self == ODR::DISABLED
     }
-    #[doc = "Checks if the value of the field is `OPEN_DRAIN_MODE_ENAB`"]
+    #[doc = "Checks if the value of the field is `OPEN_DRAIN`"]
     #[inline]
-    pub fn is_open_drain_mode_enab(&self) -> bool {
-        *self == ODR::OPEN_DRAIN_MODE_ENAB
+    pub fn is_open_drain(&self) -> bool {
+        *self == ODR::OPEN_DRAIN
     }
 }
 #[doc = "Values that can be written to the field `FUNC`"]
 pub enum FUNCW {
     #[doc = "PIO0_20."]
-    PIO0_20_,
+    PIO0_20,
     #[doc = "CT16B1_CAP0."]
-    CT16B1_CAP0_,
+    CT16B1_CAP0,
 }
 impl FUNCW {
     #[allow(missing_docs)]
@@ -293,8 +293,8 @@ impl FUNCW {
     #[inline]
     pub fn _bits(&self) -> u8 {
         match *self {
-            FUNCW::PIO0_20_ => 0,
-            FUNCW::CT16B1_CAP0_ => 1,
+            FUNCW::PIO0_20 => 0,
+            FUNCW::CT16B1_CAP0 => 1,
         }
     }
 }
@@ -310,13 +310,13 @@ impl<'a> _FUNCW<'a> {
     }
     #[doc = "PIO0_20."]
     #[inline]
-    pub fn pio0_20_(self) -> &'a mut W {
-        self.variant(FUNCW::PIO0_20_)
+    pub fn pio0_20(self) -> &'a mut W {
+        self.variant(FUNCW::PIO0_20)
     }
     #[doc = "CT16B1_CAP0."]
     #[inline]
-    pub fn ct16b1_cap0_(self) -> &'a mut W {
-        self.variant(FUNCW::CT16B1_CAP0_)
+    pub fn ct16b1_cap0(self) -> &'a mut W {
+        self.variant(FUNCW::CT16B1_CAP0)
     }
     #[doc = r" Writes raw bits to the field"]
     #[inline]
@@ -331,13 +331,13 @@ impl<'a> _FUNCW<'a> {
 #[doc = "Values that can be written to the field `MODE`"]
 pub enum MODEW {
     #[doc = "Inactive (no pull-down/pull-up resistor enabled)."]
-    INACTIVE_NO_PULL_DO,
+    INACTIVE,
     #[doc = "Pull-down resistor enabled."]
-    PULL_DOWN_RESISTOR_E,
+    PULL_DOWN,
     #[doc = "Pull-up resistor enabled."]
-    PULL_UP_RESISTOR_ENA,
+    PULL_UP,
     #[doc = "Repeater mode."]
-    REPEATER_MODE_,
+    REPEATER,
 }
 impl MODEW {
     #[allow(missing_docs)]
@@ -345,10 +345,10 @@ impl MODEW {
     #[inline]
     pub fn _bits(&self) -> u8 {
         match *self {
-            MODEW::INACTIVE_NO_PULL_DO => 0,
-            MODEW::PULL_DOWN_RESISTOR_E => 1,
-            MODEW::PULL_UP_RESISTOR_ENA => 2,
-            MODEW::REPEATER_MODE_ => 3,
+            MODEW::INACTIVE => 0,
+            MODEW::PULL_DOWN => 1,
+            MODEW::PULL_UP => 2,
+            MODEW::REPEATER => 3,
         }
     }
 }
@@ -366,23 +366,23 @@ impl<'a> _MODEW<'a> {
     }
     #[doc = "Inactive (no pull-down/pull-up resistor enabled)."]
     #[inline]
-    pub fn inactive_no_pull_do(self) -> &'a mut W {
-        self.variant(MODEW::INACTIVE_NO_PULL_DO)
+    pub fn inactive(self) -> &'a mut W {
+        self.variant(MODEW::INACTIVE)
     }
     #[doc = "Pull-down resistor enabled."]
     #[inline]
-    pub fn pull_down_resistor_e(self) -> &'a mut W {
-        self.variant(MODEW::PULL_DOWN_RESISTOR_E)
+    pub fn pull_down(self) -> &'a mut W {
+        self.variant(MODEW::PULL_DOWN)
     }
     #[doc = "Pull-up resistor enabled."]
     #[inline]
-    pub fn pull_up_resistor_ena(self) -> &'a mut W {
-        self.variant(MODEW::PULL_UP_RESISTOR_ENA)
+    pub fn pull_up(self) -> &'a mut W {
+        self.variant(MODEW::PULL_UP)
     }
     #[doc = "Repeater mode."]
     #[inline]
-    pub fn repeater_mode_(self) -> &'a mut W {
-        self.variant(MODEW::REPEATER_MODE_)
+    pub fn repeater(self) -> &'a mut W {
+        self.variant(MODEW::REPEATER)
     }
     #[doc = r" Writes raw bits to the field"]
     #[inline]
@@ -397,9 +397,9 @@ impl<'a> _MODEW<'a> {
 #[doc = "Values that can be written to the field `HYS`"]
 pub enum HYSW {
     #[doc = "Disable."]
-    DISABLE_,
+    DISABLED,
     #[doc = "Enable."]
-    ENABLE_,
+    ENABLED,
 }
 impl HYSW {
     #[allow(missing_docs)]
@@ -407,8 +407,8 @@ impl HYSW {
     #[inline]
     pub fn _bits(&self) -> bool {
         match *self {
-            HYSW::DISABLE_ => false,
-            HYSW::ENABLE_ => true,
+            HYSW::DISABLED => false,
+            HYSW::ENABLED => true,
         }
     }
 }
@@ -426,13 +426,13 @@ impl<'a> _HYSW<'a> {
     }
     #[doc = "Disable."]
     #[inline]
-    pub fn disable_(self) -> &'a mut W {
-        self.variant(HYSW::DISABLE_)
+    pub fn disabled(self) -> &'a mut W {
+        self.variant(HYSW::DISABLED)
     }
     #[doc = "Enable."]
     #[inline]
-    pub fn enable_(self) -> &'a mut W {
-        self.variant(HYSW::ENABLE_)
+    pub fn enabled(self) -> &'a mut W {
+        self.variant(HYSW::ENABLED)
     }
     #[doc = r" Sets the field bit"]
     pub fn set_bit(self) -> &'a mut W {
@@ -455,9 +455,9 @@ impl<'a> _HYSW<'a> {
 #[doc = "Values that can be written to the field `INV`"]
 pub enum INVW {
     #[doc = "Input not inverted (HIGH on pin reads as 1, LOW on pin reads as 0)."]
-    INPUT_NOT_INVERTED_,
+    NOT_INVERTED,
     #[doc = "Input inverted (HIGH on pin reads as 0, LOW on pin reads as 1)."]
-    INPUT_INVERTED_HIGH,
+    INVERTED,
 }
 impl INVW {
     #[allow(missing_docs)]
@@ -465,8 +465,8 @@ impl INVW {
     #[inline]
     pub fn _bits(&self) -> bool {
         match *self {
-            INVW::INPUT_NOT_INVERTED_ => false,
-            INVW::INPUT_INVERTED_HIGH => true,
+            INVW::NOT_INVERTED => false,
+            INVW::INVERTED => true,
         }
     }
 }
@@ -484,13 +484,13 @@ impl<'a> _INVW<'a> {
     }
     #[doc = "Input not inverted (HIGH on pin reads as 1, LOW on pin reads as 0)."]
     #[inline]
-    pub fn input_not_inverted_(self) -> &'a mut W {
-        self.variant(INVW::INPUT_NOT_INVERTED_)
+    pub fn not_inverted(self) -> &'a mut W {
+        self.variant(INVW::NOT_INVERTED)
     }
     #[doc = "Input inverted (HIGH on pin reads as 0, LOW on pin reads as 1)."]
     #[inline]
-    pub fn input_inverted_high(self) -> &'a mut W {
-        self.variant(INVW::INPUT_INVERTED_HIGH)
+    pub fn inverted(self) -> &'a mut W {
+        self.variant(INVW::INVERTED)
     }
     #[doc = r" Sets the field bit"]
     pub fn set_bit(self) -> &'a mut W {
@@ -513,9 +513,9 @@ impl<'a> _INVW<'a> {
 #[doc = "Values that can be written to the field `OD`"]
 pub enum ODW {
     #[doc = "Disable."]
-    DISABLE_,
+    DISABLED,
     #[doc = "Open-drain mode enabled.  This is not a true open-drain mode."]
-    OPEN_DRAIN_MODE_ENAB,
+    OPEN_DRAIN,
 }
 impl ODW {
     #[allow(missing_docs)]
@@ -523,8 +523,8 @@ impl ODW {
     #[inline]
     pub fn _bits(&self) -> bool {
         match *self {
-            ODW::DISABLE_ => false,
-            ODW::OPEN_DRAIN_MODE_ENAB => true,
+            ODW::DISABLED => false,
+            ODW::OPEN_DRAIN => true,
         }
     }
 }
@@ -542,13 +542,13 @@ impl<'a> _ODW<'a> {
     }
     #[doc = "Disable."]
     #[inline]
-    pub fn disable_(self) -> &'a mut W {
-        self.variant(ODW::DISABLE_)
+    pub fn disabled(self) -> &'a mut W {
+        self.variant(ODW::DISABLED)
     }
     #[doc = "Open-drain mode enabled. This is not a true open-drain mode."]
     #[inline]
-    pub fn open_drain_mode_enab(self) -> &'a mut W {
-        self.variant(ODW::OPEN_DRAIN_MODE_ENAB)
+    pub fn open_drain(self) -> &'a mut W {
+        self.variant(ODW::OPEN_DRAIN)
     }
     #[doc = r" Sets the field bit"]
     pub fn set_bit(self) -> &'a mut W {

--- a/lpc11uxx/src/iocon/pio0_21.rs
+++ b/lpc11uxx/src/iocon/pio0_21.rs
@@ -46,11 +46,11 @@ impl super::PIO0_21 {
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum FUNCR {
     #[doc = "PIO0_21."]
-    PIO0_21_,
+    PIO0_21,
     #[doc = "CT16B1_MAT0."]
-    CT16B1_MAT0_,
+    CT16B1_MAT0,
     #[doc = "MOSI1."]
-    MOSI1_,
+    MOSI1,
     #[doc = r" Reserved"]
     _Reserved(u8),
 }
@@ -59,9 +59,9 @@ impl FUNCR {
     #[inline]
     pub fn bits(&self) -> u8 {
         match *self {
-            FUNCR::PIO0_21_ => 0,
-            FUNCR::CT16B1_MAT0_ => 1,
-            FUNCR::MOSI1_ => 2,
+            FUNCR::PIO0_21 => 0,
+            FUNCR::CT16B1_MAT0 => 1,
+            FUNCR::MOSI1 => 2,
             FUNCR::_Reserved(bits) => bits,
         }
     }
@@ -70,49 +70,49 @@ impl FUNCR {
     #[inline]
     pub fn _from(value: u8) -> FUNCR {
         match value {
-            0 => FUNCR::PIO0_21_,
-            1 => FUNCR::CT16B1_MAT0_,
-            2 => FUNCR::MOSI1_,
+            0 => FUNCR::PIO0_21,
+            1 => FUNCR::CT16B1_MAT0,
+            2 => FUNCR::MOSI1,
             i => FUNCR::_Reserved(i),
         }
     }
-    #[doc = "Checks if the value of the field is `PIO0_21_`"]
+    #[doc = "Checks if the value of the field is `PIO0_21`"]
     #[inline]
-    pub fn is_pio0_21_(&self) -> bool {
-        *self == FUNCR::PIO0_21_
+    pub fn is_pio0_21(&self) -> bool {
+        *self == FUNCR::PIO0_21
     }
-    #[doc = "Checks if the value of the field is `CT16B1_MAT0_`"]
+    #[doc = "Checks if the value of the field is `CT16B1_MAT0`"]
     #[inline]
-    pub fn is_ct16b1_mat0_(&self) -> bool {
-        *self == FUNCR::CT16B1_MAT0_
+    pub fn is_ct16b1_mat0(&self) -> bool {
+        *self == FUNCR::CT16B1_MAT0
     }
-    #[doc = "Checks if the value of the field is `MOSI1_`"]
+    #[doc = "Checks if the value of the field is `MOSI1`"]
     #[inline]
-    pub fn is_mosi1_(&self) -> bool {
-        *self == FUNCR::MOSI1_
+    pub fn is_mosi1(&self) -> bool {
+        *self == FUNCR::MOSI1
     }
 }
 #[doc = "Possible values of the field `MODE`"]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum MODER {
     #[doc = "Inactive (no pull-down/pull-up resistor enabled)."]
-    INACTIVE_NO_PULL_DO,
+    INACTIVE,
     #[doc = "Pull-down resistor enabled."]
-    PULL_DOWN_RESISTOR_E,
+    PULL_DOWN,
     #[doc = "Pull-up resistor enabled."]
-    PULL_UP_RESISTOR_ENA,
+    PULL_UP,
     #[doc = "Repeater mode."]
-    REPEATER_MODE_,
+    REPEATER,
 }
 impl MODER {
     #[doc = r" Value of the field as raw bits"]
     #[inline]
     pub fn bits(&self) -> u8 {
         match *self {
-            MODER::INACTIVE_NO_PULL_DO => 0,
-            MODER::PULL_DOWN_RESISTOR_E => 1,
-            MODER::PULL_UP_RESISTOR_ENA => 2,
-            MODER::REPEATER_MODE_ => 3,
+            MODER::INACTIVE => 0,
+            MODER::PULL_DOWN => 1,
+            MODER::PULL_UP => 2,
+            MODER::REPEATER => 3,
         }
     }
     #[allow(missing_docs)]
@@ -120,41 +120,41 @@ impl MODER {
     #[inline]
     pub fn _from(value: u8) -> MODER {
         match value {
-            0 => MODER::INACTIVE_NO_PULL_DO,
-            1 => MODER::PULL_DOWN_RESISTOR_E,
-            2 => MODER::PULL_UP_RESISTOR_ENA,
-            3 => MODER::REPEATER_MODE_,
+            0 => MODER::INACTIVE,
+            1 => MODER::PULL_DOWN,
+            2 => MODER::PULL_UP,
+            3 => MODER::REPEATER,
             _ => unreachable!(),
         }
     }
-    #[doc = "Checks if the value of the field is `INACTIVE_NO_PULL_DO`"]
+    #[doc = "Checks if the value of the field is `INACTIVE`"]
     #[inline]
-    pub fn is_inactive_no_pull_do(&self) -> bool {
-        *self == MODER::INACTIVE_NO_PULL_DO
+    pub fn is_inactive(&self) -> bool {
+        *self == MODER::INACTIVE
     }
-    #[doc = "Checks if the value of the field is `PULL_DOWN_RESISTOR_E`"]
+    #[doc = "Checks if the value of the field is `PULL_DOWN`"]
     #[inline]
-    pub fn is_pull_down_resistor_e(&self) -> bool {
-        *self == MODER::PULL_DOWN_RESISTOR_E
+    pub fn is_pull_down(&self) -> bool {
+        *self == MODER::PULL_DOWN
     }
-    #[doc = "Checks if the value of the field is `PULL_UP_RESISTOR_ENA`"]
+    #[doc = "Checks if the value of the field is `PULL_UP`"]
     #[inline]
-    pub fn is_pull_up_resistor_ena(&self) -> bool {
-        *self == MODER::PULL_UP_RESISTOR_ENA
+    pub fn is_pull_up(&self) -> bool {
+        *self == MODER::PULL_UP
     }
-    #[doc = "Checks if the value of the field is `REPEATER_MODE_`"]
+    #[doc = "Checks if the value of the field is `REPEATER`"]
     #[inline]
-    pub fn is_repeater_mode_(&self) -> bool {
-        *self == MODER::REPEATER_MODE_
+    pub fn is_repeater(&self) -> bool {
+        *self == MODER::REPEATER
     }
 }
 #[doc = "Possible values of the field `HYS`"]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum HYSR {
     #[doc = "Disable."]
-    DISABLE_,
+    DISABLED,
     #[doc = "Enable."]
-    ENABLE_,
+    ENABLED,
 }
 impl HYSR {
     #[doc = r" Returns `true` if the bit is clear (0)"]
@@ -171,8 +171,8 @@ impl HYSR {
     #[inline]
     pub fn bit(&self) -> bool {
         match *self {
-            HYSR::DISABLE_ => false,
-            HYSR::ENABLE_ => true,
+            HYSR::DISABLED => false,
+            HYSR::ENABLED => true,
         }
     }
     #[allow(missing_docs)]
@@ -180,28 +180,28 @@ impl HYSR {
     #[inline]
     pub fn _from(value: bool) -> HYSR {
         match value {
-            false => HYSR::DISABLE_,
-            true => HYSR::ENABLE_,
+            false => HYSR::DISABLED,
+            true => HYSR::ENABLED,
         }
     }
-    #[doc = "Checks if the value of the field is `DISABLE_`"]
+    #[doc = "Checks if the value of the field is `DISABLED`"]
     #[inline]
-    pub fn is_disable_(&self) -> bool {
-        *self == HYSR::DISABLE_
+    pub fn is_disabled(&self) -> bool {
+        *self == HYSR::DISABLED
     }
-    #[doc = "Checks if the value of the field is `ENABLE_`"]
+    #[doc = "Checks if the value of the field is `ENABLED`"]
     #[inline]
-    pub fn is_enable_(&self) -> bool {
-        *self == HYSR::ENABLE_
+    pub fn is_enabled(&self) -> bool {
+        *self == HYSR::ENABLED
     }
 }
 #[doc = "Possible values of the field `INV`"]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum INVR {
     #[doc = "Input not inverted (HIGH on pin reads as 1, LOW on pin reads as 0)."]
-    INPUT_NOT_INVERTED_,
+    NOT_INVERTED,
     #[doc = "Input inverted (HIGH on pin reads as 0, LOW on pin reads as 1)."]
-    INPUT_INVERTED_HIGH,
+    INVERTED,
 }
 impl INVR {
     #[doc = r" Returns `true` if the bit is clear (0)"]
@@ -218,8 +218,8 @@ impl INVR {
     #[inline]
     pub fn bit(&self) -> bool {
         match *self {
-            INVR::INPUT_NOT_INVERTED_ => false,
-            INVR::INPUT_INVERTED_HIGH => true,
+            INVR::NOT_INVERTED => false,
+            INVR::INVERTED => true,
         }
     }
     #[allow(missing_docs)]
@@ -227,28 +227,28 @@ impl INVR {
     #[inline]
     pub fn _from(value: bool) -> INVR {
         match value {
-            false => INVR::INPUT_NOT_INVERTED_,
-            true => INVR::INPUT_INVERTED_HIGH,
+            false => INVR::NOT_INVERTED,
+            true => INVR::INVERTED,
         }
     }
-    #[doc = "Checks if the value of the field is `INPUT_NOT_INVERTED_`"]
+    #[doc = "Checks if the value of the field is `NOT_INVERTED`"]
     #[inline]
-    pub fn is_input_not_inverted_(&self) -> bool {
-        *self == INVR::INPUT_NOT_INVERTED_
+    pub fn is_not_inverted(&self) -> bool {
+        *self == INVR::NOT_INVERTED
     }
-    #[doc = "Checks if the value of the field is `INPUT_INVERTED_HIGH`"]
+    #[doc = "Checks if the value of the field is `INVERTED`"]
     #[inline]
-    pub fn is_input_inverted_high(&self) -> bool {
-        *self == INVR::INPUT_INVERTED_HIGH
+    pub fn is_inverted(&self) -> bool {
+        *self == INVR::INVERTED
     }
 }
 #[doc = "Possible values of the field `OD`"]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum ODR {
     #[doc = "Disable."]
-    DISABLE_,
+    DISABLED,
     #[doc = "Open-drain mode enabled.  This is not a true open-drain mode."]
-    OPEN_DRAIN_MODE_ENAB,
+    OPEN_DRAIN,
 }
 impl ODR {
     #[doc = r" Returns `true` if the bit is clear (0)"]
@@ -265,8 +265,8 @@ impl ODR {
     #[inline]
     pub fn bit(&self) -> bool {
         match *self {
-            ODR::DISABLE_ => false,
-            ODR::OPEN_DRAIN_MODE_ENAB => true,
+            ODR::DISABLED => false,
+            ODR::OPEN_DRAIN => true,
         }
     }
     #[allow(missing_docs)]
@@ -274,29 +274,29 @@ impl ODR {
     #[inline]
     pub fn _from(value: bool) -> ODR {
         match value {
-            false => ODR::DISABLE_,
-            true => ODR::OPEN_DRAIN_MODE_ENAB,
+            false => ODR::DISABLED,
+            true => ODR::OPEN_DRAIN,
         }
     }
-    #[doc = "Checks if the value of the field is `DISABLE_`"]
+    #[doc = "Checks if the value of the field is `DISABLED`"]
     #[inline]
-    pub fn is_disable_(&self) -> bool {
-        *self == ODR::DISABLE_
+    pub fn is_disabled(&self) -> bool {
+        *self == ODR::DISABLED
     }
-    #[doc = "Checks if the value of the field is `OPEN_DRAIN_MODE_ENAB`"]
+    #[doc = "Checks if the value of the field is `OPEN_DRAIN`"]
     #[inline]
-    pub fn is_open_drain_mode_enab(&self) -> bool {
-        *self == ODR::OPEN_DRAIN_MODE_ENAB
+    pub fn is_open_drain(&self) -> bool {
+        *self == ODR::OPEN_DRAIN
     }
 }
 #[doc = "Values that can be written to the field `FUNC`"]
 pub enum FUNCW {
     #[doc = "PIO0_21."]
-    PIO0_21_,
+    PIO0_21,
     #[doc = "CT16B1_MAT0."]
-    CT16B1_MAT0_,
+    CT16B1_MAT0,
     #[doc = "MOSI1."]
-    MOSI1_,
+    MOSI1,
 }
 impl FUNCW {
     #[allow(missing_docs)]
@@ -304,9 +304,9 @@ impl FUNCW {
     #[inline]
     pub fn _bits(&self) -> u8 {
         match *self {
-            FUNCW::PIO0_21_ => 0,
-            FUNCW::CT16B1_MAT0_ => 1,
-            FUNCW::MOSI1_ => 2,
+            FUNCW::PIO0_21 => 0,
+            FUNCW::CT16B1_MAT0 => 1,
+            FUNCW::MOSI1 => 2,
         }
     }
 }
@@ -322,18 +322,18 @@ impl<'a> _FUNCW<'a> {
     }
     #[doc = "PIO0_21."]
     #[inline]
-    pub fn pio0_21_(self) -> &'a mut W {
-        self.variant(FUNCW::PIO0_21_)
+    pub fn pio0_21(self) -> &'a mut W {
+        self.variant(FUNCW::PIO0_21)
     }
     #[doc = "CT16B1_MAT0."]
     #[inline]
-    pub fn ct16b1_mat0_(self) -> &'a mut W {
-        self.variant(FUNCW::CT16B1_MAT0_)
+    pub fn ct16b1_mat0(self) -> &'a mut W {
+        self.variant(FUNCW::CT16B1_MAT0)
     }
     #[doc = "MOSI1."]
     #[inline]
-    pub fn mosi1_(self) -> &'a mut W {
-        self.variant(FUNCW::MOSI1_)
+    pub fn mosi1(self) -> &'a mut W {
+        self.variant(FUNCW::MOSI1)
     }
     #[doc = r" Writes raw bits to the field"]
     #[inline]
@@ -348,13 +348,13 @@ impl<'a> _FUNCW<'a> {
 #[doc = "Values that can be written to the field `MODE`"]
 pub enum MODEW {
     #[doc = "Inactive (no pull-down/pull-up resistor enabled)."]
-    INACTIVE_NO_PULL_DO,
+    INACTIVE,
     #[doc = "Pull-down resistor enabled."]
-    PULL_DOWN_RESISTOR_E,
+    PULL_DOWN,
     #[doc = "Pull-up resistor enabled."]
-    PULL_UP_RESISTOR_ENA,
+    PULL_UP,
     #[doc = "Repeater mode."]
-    REPEATER_MODE_,
+    REPEATER,
 }
 impl MODEW {
     #[allow(missing_docs)]
@@ -362,10 +362,10 @@ impl MODEW {
     #[inline]
     pub fn _bits(&self) -> u8 {
         match *self {
-            MODEW::INACTIVE_NO_PULL_DO => 0,
-            MODEW::PULL_DOWN_RESISTOR_E => 1,
-            MODEW::PULL_UP_RESISTOR_ENA => 2,
-            MODEW::REPEATER_MODE_ => 3,
+            MODEW::INACTIVE => 0,
+            MODEW::PULL_DOWN => 1,
+            MODEW::PULL_UP => 2,
+            MODEW::REPEATER => 3,
         }
     }
 }
@@ -383,23 +383,23 @@ impl<'a> _MODEW<'a> {
     }
     #[doc = "Inactive (no pull-down/pull-up resistor enabled)."]
     #[inline]
-    pub fn inactive_no_pull_do(self) -> &'a mut W {
-        self.variant(MODEW::INACTIVE_NO_PULL_DO)
+    pub fn inactive(self) -> &'a mut W {
+        self.variant(MODEW::INACTIVE)
     }
     #[doc = "Pull-down resistor enabled."]
     #[inline]
-    pub fn pull_down_resistor_e(self) -> &'a mut W {
-        self.variant(MODEW::PULL_DOWN_RESISTOR_E)
+    pub fn pull_down(self) -> &'a mut W {
+        self.variant(MODEW::PULL_DOWN)
     }
     #[doc = "Pull-up resistor enabled."]
     #[inline]
-    pub fn pull_up_resistor_ena(self) -> &'a mut W {
-        self.variant(MODEW::PULL_UP_RESISTOR_ENA)
+    pub fn pull_up(self) -> &'a mut W {
+        self.variant(MODEW::PULL_UP)
     }
     #[doc = "Repeater mode."]
     #[inline]
-    pub fn repeater_mode_(self) -> &'a mut W {
-        self.variant(MODEW::REPEATER_MODE_)
+    pub fn repeater(self) -> &'a mut W {
+        self.variant(MODEW::REPEATER)
     }
     #[doc = r" Writes raw bits to the field"]
     #[inline]
@@ -414,9 +414,9 @@ impl<'a> _MODEW<'a> {
 #[doc = "Values that can be written to the field `HYS`"]
 pub enum HYSW {
     #[doc = "Disable."]
-    DISABLE_,
+    DISABLED,
     #[doc = "Enable."]
-    ENABLE_,
+    ENABLED,
 }
 impl HYSW {
     #[allow(missing_docs)]
@@ -424,8 +424,8 @@ impl HYSW {
     #[inline]
     pub fn _bits(&self) -> bool {
         match *self {
-            HYSW::DISABLE_ => false,
-            HYSW::ENABLE_ => true,
+            HYSW::DISABLED => false,
+            HYSW::ENABLED => true,
         }
     }
 }
@@ -443,13 +443,13 @@ impl<'a> _HYSW<'a> {
     }
     #[doc = "Disable."]
     #[inline]
-    pub fn disable_(self) -> &'a mut W {
-        self.variant(HYSW::DISABLE_)
+    pub fn disabled(self) -> &'a mut W {
+        self.variant(HYSW::DISABLED)
     }
     #[doc = "Enable."]
     #[inline]
-    pub fn enable_(self) -> &'a mut W {
-        self.variant(HYSW::ENABLE_)
+    pub fn enabled(self) -> &'a mut W {
+        self.variant(HYSW::ENABLED)
     }
     #[doc = r" Sets the field bit"]
     pub fn set_bit(self) -> &'a mut W {
@@ -472,9 +472,9 @@ impl<'a> _HYSW<'a> {
 #[doc = "Values that can be written to the field `INV`"]
 pub enum INVW {
     #[doc = "Input not inverted (HIGH on pin reads as 1, LOW on pin reads as 0)."]
-    INPUT_NOT_INVERTED_,
+    NOT_INVERTED,
     #[doc = "Input inverted (HIGH on pin reads as 0, LOW on pin reads as 1)."]
-    INPUT_INVERTED_HIGH,
+    INVERTED,
 }
 impl INVW {
     #[allow(missing_docs)]
@@ -482,8 +482,8 @@ impl INVW {
     #[inline]
     pub fn _bits(&self) -> bool {
         match *self {
-            INVW::INPUT_NOT_INVERTED_ => false,
-            INVW::INPUT_INVERTED_HIGH => true,
+            INVW::NOT_INVERTED => false,
+            INVW::INVERTED => true,
         }
     }
 }
@@ -501,13 +501,13 @@ impl<'a> _INVW<'a> {
     }
     #[doc = "Input not inverted (HIGH on pin reads as 1, LOW on pin reads as 0)."]
     #[inline]
-    pub fn input_not_inverted_(self) -> &'a mut W {
-        self.variant(INVW::INPUT_NOT_INVERTED_)
+    pub fn not_inverted(self) -> &'a mut W {
+        self.variant(INVW::NOT_INVERTED)
     }
     #[doc = "Input inverted (HIGH on pin reads as 0, LOW on pin reads as 1)."]
     #[inline]
-    pub fn input_inverted_high(self) -> &'a mut W {
-        self.variant(INVW::INPUT_INVERTED_HIGH)
+    pub fn inverted(self) -> &'a mut W {
+        self.variant(INVW::INVERTED)
     }
     #[doc = r" Sets the field bit"]
     pub fn set_bit(self) -> &'a mut W {
@@ -530,9 +530,9 @@ impl<'a> _INVW<'a> {
 #[doc = "Values that can be written to the field `OD`"]
 pub enum ODW {
     #[doc = "Disable."]
-    DISABLE_,
+    DISABLED,
     #[doc = "Open-drain mode enabled.  This is not a true open-drain mode."]
-    OPEN_DRAIN_MODE_ENAB,
+    OPEN_DRAIN,
 }
 impl ODW {
     #[allow(missing_docs)]
@@ -540,8 +540,8 @@ impl ODW {
     #[inline]
     pub fn _bits(&self) -> bool {
         match *self {
-            ODW::DISABLE_ => false,
-            ODW::OPEN_DRAIN_MODE_ENAB => true,
+            ODW::DISABLED => false,
+            ODW::OPEN_DRAIN => true,
         }
     }
 }
@@ -559,13 +559,13 @@ impl<'a> _ODW<'a> {
     }
     #[doc = "Disable."]
     #[inline]
-    pub fn disable_(self) -> &'a mut W {
-        self.variant(ODW::DISABLE_)
+    pub fn disabled(self) -> &'a mut W {
+        self.variant(ODW::DISABLED)
     }
     #[doc = "Open-drain mode enabled. This is not a true open-drain mode."]
     #[inline]
-    pub fn open_drain_mode_enab(self) -> &'a mut W {
-        self.variant(ODW::OPEN_DRAIN_MODE_ENAB)
+    pub fn open_drain(self) -> &'a mut W {
+        self.variant(ODW::OPEN_DRAIN)
     }
     #[doc = r" Sets the field bit"]
     pub fn set_bit(self) -> &'a mut W {

--- a/lpc11uxx/src/iocon/pio0_22.rs
+++ b/lpc11uxx/src/iocon/pio0_22.rs
@@ -46,13 +46,13 @@ impl super::PIO0_22 {
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum FUNCR {
     #[doc = "PIO0_22."]
-    PIO0_22_,
+    PIO0_22,
     #[doc = "AD6."]
-    AD6_,
+    AD6,
     #[doc = "CT16B1_MAT1."]
-    CT16B1_MAT1_,
+    CT16B1_MAT1,
     #[doc = "MISO1."]
-    MISO1_,
+    MISO1,
     #[doc = r" Reserved"]
     _Reserved(u8),
 }
@@ -61,10 +61,10 @@ impl FUNCR {
     #[inline]
     pub fn bits(&self) -> u8 {
         match *self {
-            FUNCR::PIO0_22_ => 0,
-            FUNCR::AD6_ => 1,
-            FUNCR::CT16B1_MAT1_ => 2,
-            FUNCR::MISO1_ => 3,
+            FUNCR::PIO0_22 => 0,
+            FUNCR::AD6 => 1,
+            FUNCR::CT16B1_MAT1 => 2,
+            FUNCR::MISO1 => 3,
             FUNCR::_Reserved(bits) => bits,
         }
     }
@@ -73,55 +73,55 @@ impl FUNCR {
     #[inline]
     pub fn _from(value: u8) -> FUNCR {
         match value {
-            0 => FUNCR::PIO0_22_,
-            1 => FUNCR::AD6_,
-            2 => FUNCR::CT16B1_MAT1_,
-            3 => FUNCR::MISO1_,
+            0 => FUNCR::PIO0_22,
+            1 => FUNCR::AD6,
+            2 => FUNCR::CT16B1_MAT1,
+            3 => FUNCR::MISO1,
             i => FUNCR::_Reserved(i),
         }
     }
-    #[doc = "Checks if the value of the field is `PIO0_22_`"]
+    #[doc = "Checks if the value of the field is `PIO0_22`"]
     #[inline]
-    pub fn is_pio0_22_(&self) -> bool {
-        *self == FUNCR::PIO0_22_
+    pub fn is_pio0_22(&self) -> bool {
+        *self == FUNCR::PIO0_22
     }
-    #[doc = "Checks if the value of the field is `AD6_`"]
+    #[doc = "Checks if the value of the field is `AD6`"]
     #[inline]
-    pub fn is_ad6_(&self) -> bool {
-        *self == FUNCR::AD6_
+    pub fn is_ad6(&self) -> bool {
+        *self == FUNCR::AD6
     }
-    #[doc = "Checks if the value of the field is `CT16B1_MAT1_`"]
+    #[doc = "Checks if the value of the field is `CT16B1_MAT1`"]
     #[inline]
-    pub fn is_ct16b1_mat1_(&self) -> bool {
-        *self == FUNCR::CT16B1_MAT1_
+    pub fn is_ct16b1_mat1(&self) -> bool {
+        *self == FUNCR::CT16B1_MAT1
     }
-    #[doc = "Checks if the value of the field is `MISO1_`"]
+    #[doc = "Checks if the value of the field is `MISO1`"]
     #[inline]
-    pub fn is_miso1_(&self) -> bool {
-        *self == FUNCR::MISO1_
+    pub fn is_miso1(&self) -> bool {
+        *self == FUNCR::MISO1
     }
 }
 #[doc = "Possible values of the field `MODE`"]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum MODER {
     #[doc = "Inactive (no pull-down/pull-up resistor enabled)."]
-    INACTIVE_NO_PULL_DO,
+    INACTIVE,
     #[doc = "Pull-down resistor enabled."]
-    PULL_DOWN_RESISTOR_E,
+    PULL_DOWN,
     #[doc = "Pull-up resistor enabled."]
-    PULL_UP_RESISTOR_ENA,
+    PULL_UP,
     #[doc = "Repeater mode."]
-    REPEATER_MODE_,
+    REPEATER,
 }
 impl MODER {
     #[doc = r" Value of the field as raw bits"]
     #[inline]
     pub fn bits(&self) -> u8 {
         match *self {
-            MODER::INACTIVE_NO_PULL_DO => 0,
-            MODER::PULL_DOWN_RESISTOR_E => 1,
-            MODER::PULL_UP_RESISTOR_ENA => 2,
-            MODER::REPEATER_MODE_ => 3,
+            MODER::INACTIVE => 0,
+            MODER::PULL_DOWN => 1,
+            MODER::PULL_UP => 2,
+            MODER::REPEATER => 3,
         }
     }
     #[allow(missing_docs)]
@@ -129,41 +129,41 @@ impl MODER {
     #[inline]
     pub fn _from(value: u8) -> MODER {
         match value {
-            0 => MODER::INACTIVE_NO_PULL_DO,
-            1 => MODER::PULL_DOWN_RESISTOR_E,
-            2 => MODER::PULL_UP_RESISTOR_ENA,
-            3 => MODER::REPEATER_MODE_,
+            0 => MODER::INACTIVE,
+            1 => MODER::PULL_DOWN,
+            2 => MODER::PULL_UP,
+            3 => MODER::REPEATER,
             _ => unreachable!(),
         }
     }
-    #[doc = "Checks if the value of the field is `INACTIVE_NO_PULL_DO`"]
+    #[doc = "Checks if the value of the field is `INACTIVE`"]
     #[inline]
-    pub fn is_inactive_no_pull_do(&self) -> bool {
-        *self == MODER::INACTIVE_NO_PULL_DO
+    pub fn is_inactive(&self) -> bool {
+        *self == MODER::INACTIVE
     }
-    #[doc = "Checks if the value of the field is `PULL_DOWN_RESISTOR_E`"]
+    #[doc = "Checks if the value of the field is `PULL_DOWN`"]
     #[inline]
-    pub fn is_pull_down_resistor_e(&self) -> bool {
-        *self == MODER::PULL_DOWN_RESISTOR_E
+    pub fn is_pull_down(&self) -> bool {
+        *self == MODER::PULL_DOWN
     }
-    #[doc = "Checks if the value of the field is `PULL_UP_RESISTOR_ENA`"]
+    #[doc = "Checks if the value of the field is `PULL_UP`"]
     #[inline]
-    pub fn is_pull_up_resistor_ena(&self) -> bool {
-        *self == MODER::PULL_UP_RESISTOR_ENA
+    pub fn is_pull_up(&self) -> bool {
+        *self == MODER::PULL_UP
     }
-    #[doc = "Checks if the value of the field is `REPEATER_MODE_`"]
+    #[doc = "Checks if the value of the field is `REPEATER`"]
     #[inline]
-    pub fn is_repeater_mode_(&self) -> bool {
-        *self == MODER::REPEATER_MODE_
+    pub fn is_repeater(&self) -> bool {
+        *self == MODER::REPEATER
     }
 }
 #[doc = "Possible values of the field `HYS`"]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum HYSR {
     #[doc = "Disable."]
-    DISABLE_,
+    DISABLED,
     #[doc = "Enable."]
-    ENABLE_,
+    ENABLED,
 }
 impl HYSR {
     #[doc = r" Returns `true` if the bit is clear (0)"]
@@ -180,8 +180,8 @@ impl HYSR {
     #[inline]
     pub fn bit(&self) -> bool {
         match *self {
-            HYSR::DISABLE_ => false,
-            HYSR::ENABLE_ => true,
+            HYSR::DISABLED => false,
+            HYSR::ENABLED => true,
         }
     }
     #[allow(missing_docs)]
@@ -189,28 +189,28 @@ impl HYSR {
     #[inline]
     pub fn _from(value: bool) -> HYSR {
         match value {
-            false => HYSR::DISABLE_,
-            true => HYSR::ENABLE_,
+            false => HYSR::DISABLED,
+            true => HYSR::ENABLED,
         }
     }
-    #[doc = "Checks if the value of the field is `DISABLE_`"]
+    #[doc = "Checks if the value of the field is `DISABLED`"]
     #[inline]
-    pub fn is_disable_(&self) -> bool {
-        *self == HYSR::DISABLE_
+    pub fn is_disabled(&self) -> bool {
+        *self == HYSR::DISABLED
     }
-    #[doc = "Checks if the value of the field is `ENABLE_`"]
+    #[doc = "Checks if the value of the field is `ENABLED`"]
     #[inline]
-    pub fn is_enable_(&self) -> bool {
-        *self == HYSR::ENABLE_
+    pub fn is_enabled(&self) -> bool {
+        *self == HYSR::ENABLED
     }
 }
 #[doc = "Possible values of the field `INV`"]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum INVR {
     #[doc = "Input not inverted (HIGH on pin reads as 1, LOW on pin reads as 0)."]
-    INPUT_NOT_INVERTED_,
+    NOT_INVERTED,
     #[doc = "Input inverted (HIGH on pin reads as 0, LOW on pin reads as 1)."]
-    INPUT_INVERTED_HIGH,
+    INVERTED,
 }
 impl INVR {
     #[doc = r" Returns `true` if the bit is clear (0)"]
@@ -227,8 +227,8 @@ impl INVR {
     #[inline]
     pub fn bit(&self) -> bool {
         match *self {
-            INVR::INPUT_NOT_INVERTED_ => false,
-            INVR::INPUT_INVERTED_HIGH => true,
+            INVR::NOT_INVERTED => false,
+            INVR::INVERTED => true,
         }
     }
     #[allow(missing_docs)]
@@ -236,28 +236,28 @@ impl INVR {
     #[inline]
     pub fn _from(value: bool) -> INVR {
         match value {
-            false => INVR::INPUT_NOT_INVERTED_,
-            true => INVR::INPUT_INVERTED_HIGH,
+            false => INVR::NOT_INVERTED,
+            true => INVR::INVERTED,
         }
     }
-    #[doc = "Checks if the value of the field is `INPUT_NOT_INVERTED_`"]
+    #[doc = "Checks if the value of the field is `NOT_INVERTED`"]
     #[inline]
-    pub fn is_input_not_inverted_(&self) -> bool {
-        *self == INVR::INPUT_NOT_INVERTED_
+    pub fn is_not_inverted(&self) -> bool {
+        *self == INVR::NOT_INVERTED
     }
-    #[doc = "Checks if the value of the field is `INPUT_INVERTED_HIGH`"]
+    #[doc = "Checks if the value of the field is `INVERTED`"]
     #[inline]
-    pub fn is_input_inverted_high(&self) -> bool {
-        *self == INVR::INPUT_INVERTED_HIGH
+    pub fn is_inverted(&self) -> bool {
+        *self == INVR::INVERTED
     }
 }
 #[doc = "Possible values of the field `ADMODE`"]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum ADMODER {
     #[doc = "Analog input mode."]
-    ANALOG_INPUT_MODE_,
+    ANALOG,
     #[doc = "Digital functional mode."]
-    DIGITAL_FUNCTIONAL_M,
+    DIGITAL,
 }
 impl ADMODER {
     #[doc = r" Returns `true` if the bit is clear (0)"]
@@ -274,8 +274,8 @@ impl ADMODER {
     #[inline]
     pub fn bit(&self) -> bool {
         match *self {
-            ADMODER::ANALOG_INPUT_MODE_ => false,
-            ADMODER::DIGITAL_FUNCTIONAL_M => true,
+            ADMODER::ANALOG => false,
+            ADMODER::DIGITAL => true,
         }
     }
     #[allow(missing_docs)]
@@ -283,28 +283,28 @@ impl ADMODER {
     #[inline]
     pub fn _from(value: bool) -> ADMODER {
         match value {
-            false => ADMODER::ANALOG_INPUT_MODE_,
-            true => ADMODER::DIGITAL_FUNCTIONAL_M,
+            false => ADMODER::ANALOG,
+            true => ADMODER::DIGITAL,
         }
     }
-    #[doc = "Checks if the value of the field is `ANALOG_INPUT_MODE_`"]
+    #[doc = "Checks if the value of the field is `ANALOG`"]
     #[inline]
-    pub fn is_analog_input_mode_(&self) -> bool {
-        *self == ADMODER::ANALOG_INPUT_MODE_
+    pub fn is_analog(&self) -> bool {
+        *self == ADMODER::ANALOG
     }
-    #[doc = "Checks if the value of the field is `DIGITAL_FUNCTIONAL_M`"]
+    #[doc = "Checks if the value of the field is `DIGITAL`"]
     #[inline]
-    pub fn is_digital_functional_m(&self) -> bool {
-        *self == ADMODER::DIGITAL_FUNCTIONAL_M
+    pub fn is_digital(&self) -> bool {
+        *self == ADMODER::DIGITAL
     }
 }
 #[doc = "Possible values of the field `FILTR`"]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum FILTRR {
     #[doc = "Filter enabled."]
-    FILTER_ENABLED_,
+    ENABLED,
     #[doc = "Filter disabled."]
-    FILTER_DISABLED_,
+    DISABLED,
 }
 impl FILTRR {
     #[doc = r" Returns `true` if the bit is clear (0)"]
@@ -321,8 +321,8 @@ impl FILTRR {
     #[inline]
     pub fn bit(&self) -> bool {
         match *self {
-            FILTRR::FILTER_ENABLED_ => false,
-            FILTRR::FILTER_DISABLED_ => true,
+            FILTRR::ENABLED => false,
+            FILTRR::DISABLED => true,
         }
     }
     #[allow(missing_docs)]
@@ -330,28 +330,28 @@ impl FILTRR {
     #[inline]
     pub fn _from(value: bool) -> FILTRR {
         match value {
-            false => FILTRR::FILTER_ENABLED_,
-            true => FILTRR::FILTER_DISABLED_,
+            false => FILTRR::ENABLED,
+            true => FILTRR::DISABLED,
         }
     }
-    #[doc = "Checks if the value of the field is `FILTER_ENABLED_`"]
+    #[doc = "Checks if the value of the field is `ENABLED`"]
     #[inline]
-    pub fn is_filter_enabled_(&self) -> bool {
-        *self == FILTRR::FILTER_ENABLED_
+    pub fn is_enabled(&self) -> bool {
+        *self == FILTRR::ENABLED
     }
-    #[doc = "Checks if the value of the field is `FILTER_DISABLED_`"]
+    #[doc = "Checks if the value of the field is `DISABLED`"]
     #[inline]
-    pub fn is_filter_disabled_(&self) -> bool {
-        *self == FILTRR::FILTER_DISABLED_
+    pub fn is_disabled(&self) -> bool {
+        *self == FILTRR::DISABLED
     }
 }
 #[doc = "Possible values of the field `OD`"]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum ODR {
     #[doc = "Disable."]
-    DISABLE_,
+    DISABLED,
     #[doc = "Open-drain mode enabled.  This is not a true open-drain mode."]
-    OPEN_DRAIN_MODE_ENAB,
+    OPEN_DRAIN,
 }
 impl ODR {
     #[doc = r" Returns `true` if the bit is clear (0)"]
@@ -368,8 +368,8 @@ impl ODR {
     #[inline]
     pub fn bit(&self) -> bool {
         match *self {
-            ODR::DISABLE_ => false,
-            ODR::OPEN_DRAIN_MODE_ENAB => true,
+            ODR::DISABLED => false,
+            ODR::OPEN_DRAIN => true,
         }
     }
     #[allow(missing_docs)]
@@ -377,31 +377,31 @@ impl ODR {
     #[inline]
     pub fn _from(value: bool) -> ODR {
         match value {
-            false => ODR::DISABLE_,
-            true => ODR::OPEN_DRAIN_MODE_ENAB,
+            false => ODR::DISABLED,
+            true => ODR::OPEN_DRAIN,
         }
     }
-    #[doc = "Checks if the value of the field is `DISABLE_`"]
+    #[doc = "Checks if the value of the field is `DISABLED`"]
     #[inline]
-    pub fn is_disable_(&self) -> bool {
-        *self == ODR::DISABLE_
+    pub fn is_disabled(&self) -> bool {
+        *self == ODR::DISABLED
     }
-    #[doc = "Checks if the value of the field is `OPEN_DRAIN_MODE_ENAB`"]
+    #[doc = "Checks if the value of the field is `OPEN_DRAIN`"]
     #[inline]
-    pub fn is_open_drain_mode_enab(&self) -> bool {
-        *self == ODR::OPEN_DRAIN_MODE_ENAB
+    pub fn is_open_drain(&self) -> bool {
+        *self == ODR::OPEN_DRAIN
     }
 }
 #[doc = "Values that can be written to the field `FUNC`"]
 pub enum FUNCW {
     #[doc = "PIO0_22."]
-    PIO0_22_,
+    PIO0_22,
     #[doc = "AD6."]
-    AD6_,
+    AD6,
     #[doc = "CT16B1_MAT1."]
-    CT16B1_MAT1_,
+    CT16B1_MAT1,
     #[doc = "MISO1."]
-    MISO1_,
+    MISO1,
 }
 impl FUNCW {
     #[allow(missing_docs)]
@@ -409,10 +409,10 @@ impl FUNCW {
     #[inline]
     pub fn _bits(&self) -> u8 {
         match *self {
-            FUNCW::PIO0_22_ => 0,
-            FUNCW::AD6_ => 1,
-            FUNCW::CT16B1_MAT1_ => 2,
-            FUNCW::MISO1_ => 3,
+            FUNCW::PIO0_22 => 0,
+            FUNCW::AD6 => 1,
+            FUNCW::CT16B1_MAT1 => 2,
+            FUNCW::MISO1 => 3,
         }
     }
 }
@@ -428,23 +428,23 @@ impl<'a> _FUNCW<'a> {
     }
     #[doc = "PIO0_22."]
     #[inline]
-    pub fn pio0_22_(self) -> &'a mut W {
-        self.variant(FUNCW::PIO0_22_)
+    pub fn pio0_22(self) -> &'a mut W {
+        self.variant(FUNCW::PIO0_22)
     }
     #[doc = "AD6."]
     #[inline]
-    pub fn ad6_(self) -> &'a mut W {
-        self.variant(FUNCW::AD6_)
+    pub fn ad6(self) -> &'a mut W {
+        self.variant(FUNCW::AD6)
     }
     #[doc = "CT16B1_MAT1."]
     #[inline]
-    pub fn ct16b1_mat1_(self) -> &'a mut W {
-        self.variant(FUNCW::CT16B1_MAT1_)
+    pub fn ct16b1_mat1(self) -> &'a mut W {
+        self.variant(FUNCW::CT16B1_MAT1)
     }
     #[doc = "MISO1."]
     #[inline]
-    pub fn miso1_(self) -> &'a mut W {
-        self.variant(FUNCW::MISO1_)
+    pub fn miso1(self) -> &'a mut W {
+        self.variant(FUNCW::MISO1)
     }
     #[doc = r" Writes raw bits to the field"]
     #[inline]
@@ -459,13 +459,13 @@ impl<'a> _FUNCW<'a> {
 #[doc = "Values that can be written to the field `MODE`"]
 pub enum MODEW {
     #[doc = "Inactive (no pull-down/pull-up resistor enabled)."]
-    INACTIVE_NO_PULL_DO,
+    INACTIVE,
     #[doc = "Pull-down resistor enabled."]
-    PULL_DOWN_RESISTOR_E,
+    PULL_DOWN,
     #[doc = "Pull-up resistor enabled."]
-    PULL_UP_RESISTOR_ENA,
+    PULL_UP,
     #[doc = "Repeater mode."]
-    REPEATER_MODE_,
+    REPEATER,
 }
 impl MODEW {
     #[allow(missing_docs)]
@@ -473,10 +473,10 @@ impl MODEW {
     #[inline]
     pub fn _bits(&self) -> u8 {
         match *self {
-            MODEW::INACTIVE_NO_PULL_DO => 0,
-            MODEW::PULL_DOWN_RESISTOR_E => 1,
-            MODEW::PULL_UP_RESISTOR_ENA => 2,
-            MODEW::REPEATER_MODE_ => 3,
+            MODEW::INACTIVE => 0,
+            MODEW::PULL_DOWN => 1,
+            MODEW::PULL_UP => 2,
+            MODEW::REPEATER => 3,
         }
     }
 }
@@ -494,23 +494,23 @@ impl<'a> _MODEW<'a> {
     }
     #[doc = "Inactive (no pull-down/pull-up resistor enabled)."]
     #[inline]
-    pub fn inactive_no_pull_do(self) -> &'a mut W {
-        self.variant(MODEW::INACTIVE_NO_PULL_DO)
+    pub fn inactive(self) -> &'a mut W {
+        self.variant(MODEW::INACTIVE)
     }
     #[doc = "Pull-down resistor enabled."]
     #[inline]
-    pub fn pull_down_resistor_e(self) -> &'a mut W {
-        self.variant(MODEW::PULL_DOWN_RESISTOR_E)
+    pub fn pull_down(self) -> &'a mut W {
+        self.variant(MODEW::PULL_DOWN)
     }
     #[doc = "Pull-up resistor enabled."]
     #[inline]
-    pub fn pull_up_resistor_ena(self) -> &'a mut W {
-        self.variant(MODEW::PULL_UP_RESISTOR_ENA)
+    pub fn pull_up(self) -> &'a mut W {
+        self.variant(MODEW::PULL_UP)
     }
     #[doc = "Repeater mode."]
     #[inline]
-    pub fn repeater_mode_(self) -> &'a mut W {
-        self.variant(MODEW::REPEATER_MODE_)
+    pub fn repeater(self) -> &'a mut W {
+        self.variant(MODEW::REPEATER)
     }
     #[doc = r" Writes raw bits to the field"]
     #[inline]
@@ -525,9 +525,9 @@ impl<'a> _MODEW<'a> {
 #[doc = "Values that can be written to the field `HYS`"]
 pub enum HYSW {
     #[doc = "Disable."]
-    DISABLE_,
+    DISABLED,
     #[doc = "Enable."]
-    ENABLE_,
+    ENABLED,
 }
 impl HYSW {
     #[allow(missing_docs)]
@@ -535,8 +535,8 @@ impl HYSW {
     #[inline]
     pub fn _bits(&self) -> bool {
         match *self {
-            HYSW::DISABLE_ => false,
-            HYSW::ENABLE_ => true,
+            HYSW::DISABLED => false,
+            HYSW::ENABLED => true,
         }
     }
 }
@@ -554,13 +554,13 @@ impl<'a> _HYSW<'a> {
     }
     #[doc = "Disable."]
     #[inline]
-    pub fn disable_(self) -> &'a mut W {
-        self.variant(HYSW::DISABLE_)
+    pub fn disabled(self) -> &'a mut W {
+        self.variant(HYSW::DISABLED)
     }
     #[doc = "Enable."]
     #[inline]
-    pub fn enable_(self) -> &'a mut W {
-        self.variant(HYSW::ENABLE_)
+    pub fn enabled(self) -> &'a mut W {
+        self.variant(HYSW::ENABLED)
     }
     #[doc = r" Sets the field bit"]
     pub fn set_bit(self) -> &'a mut W {
@@ -583,9 +583,9 @@ impl<'a> _HYSW<'a> {
 #[doc = "Values that can be written to the field `INV`"]
 pub enum INVW {
     #[doc = "Input not inverted (HIGH on pin reads as 1, LOW on pin reads as 0)."]
-    INPUT_NOT_INVERTED_,
+    NOT_INVERTED,
     #[doc = "Input inverted (HIGH on pin reads as 0, LOW on pin reads as 1)."]
-    INPUT_INVERTED_HIGH,
+    INVERTED,
 }
 impl INVW {
     #[allow(missing_docs)]
@@ -593,8 +593,8 @@ impl INVW {
     #[inline]
     pub fn _bits(&self) -> bool {
         match *self {
-            INVW::INPUT_NOT_INVERTED_ => false,
-            INVW::INPUT_INVERTED_HIGH => true,
+            INVW::NOT_INVERTED => false,
+            INVW::INVERTED => true,
         }
     }
 }
@@ -612,13 +612,13 @@ impl<'a> _INVW<'a> {
     }
     #[doc = "Input not inverted (HIGH on pin reads as 1, LOW on pin reads as 0)."]
     #[inline]
-    pub fn input_not_inverted_(self) -> &'a mut W {
-        self.variant(INVW::INPUT_NOT_INVERTED_)
+    pub fn not_inverted(self) -> &'a mut W {
+        self.variant(INVW::NOT_INVERTED)
     }
     #[doc = "Input inverted (HIGH on pin reads as 0, LOW on pin reads as 1)."]
     #[inline]
-    pub fn input_inverted_high(self) -> &'a mut W {
-        self.variant(INVW::INPUT_INVERTED_HIGH)
+    pub fn inverted(self) -> &'a mut W {
+        self.variant(INVW::INVERTED)
     }
     #[doc = r" Sets the field bit"]
     pub fn set_bit(self) -> &'a mut W {
@@ -641,9 +641,9 @@ impl<'a> _INVW<'a> {
 #[doc = "Values that can be written to the field `ADMODE`"]
 pub enum ADMODEW {
     #[doc = "Analog input mode."]
-    ANALOG_INPUT_MODE_,
+    ANALOG,
     #[doc = "Digital functional mode."]
-    DIGITAL_FUNCTIONAL_M,
+    DIGITAL,
 }
 impl ADMODEW {
     #[allow(missing_docs)]
@@ -651,8 +651,8 @@ impl ADMODEW {
     #[inline]
     pub fn _bits(&self) -> bool {
         match *self {
-            ADMODEW::ANALOG_INPUT_MODE_ => false,
-            ADMODEW::DIGITAL_FUNCTIONAL_M => true,
+            ADMODEW::ANALOG => false,
+            ADMODEW::DIGITAL => true,
         }
     }
 }
@@ -670,13 +670,13 @@ impl<'a> _ADMODEW<'a> {
     }
     #[doc = "Analog input mode."]
     #[inline]
-    pub fn analog_input_mode_(self) -> &'a mut W {
-        self.variant(ADMODEW::ANALOG_INPUT_MODE_)
+    pub fn analog(self) -> &'a mut W {
+        self.variant(ADMODEW::ANALOG)
     }
     #[doc = "Digital functional mode."]
     #[inline]
-    pub fn digital_functional_m(self) -> &'a mut W {
-        self.variant(ADMODEW::DIGITAL_FUNCTIONAL_M)
+    pub fn digital(self) -> &'a mut W {
+        self.variant(ADMODEW::DIGITAL)
     }
     #[doc = r" Sets the field bit"]
     pub fn set_bit(self) -> &'a mut W {
@@ -699,9 +699,9 @@ impl<'a> _ADMODEW<'a> {
 #[doc = "Values that can be written to the field `FILTR`"]
 pub enum FILTRW {
     #[doc = "Filter enabled."]
-    FILTER_ENABLED_,
+    ENABLED,
     #[doc = "Filter disabled."]
-    FILTER_DISABLED_,
+    DISABLED,
 }
 impl FILTRW {
     #[allow(missing_docs)]
@@ -709,8 +709,8 @@ impl FILTRW {
     #[inline]
     pub fn _bits(&self) -> bool {
         match *self {
-            FILTRW::FILTER_ENABLED_ => false,
-            FILTRW::FILTER_DISABLED_ => true,
+            FILTRW::ENABLED => false,
+            FILTRW::DISABLED => true,
         }
     }
 }
@@ -728,13 +728,13 @@ impl<'a> _FILTRW<'a> {
     }
     #[doc = "Filter enabled."]
     #[inline]
-    pub fn filter_enabled_(self) -> &'a mut W {
-        self.variant(FILTRW::FILTER_ENABLED_)
+    pub fn enabled(self) -> &'a mut W {
+        self.variant(FILTRW::ENABLED)
     }
     #[doc = "Filter disabled."]
     #[inline]
-    pub fn filter_disabled_(self) -> &'a mut W {
-        self.variant(FILTRW::FILTER_DISABLED_)
+    pub fn disabled(self) -> &'a mut W {
+        self.variant(FILTRW::DISABLED)
     }
     #[doc = r" Sets the field bit"]
     pub fn set_bit(self) -> &'a mut W {
@@ -757,9 +757,9 @@ impl<'a> _FILTRW<'a> {
 #[doc = "Values that can be written to the field `OD`"]
 pub enum ODW {
     #[doc = "Disable."]
-    DISABLE_,
+    DISABLED,
     #[doc = "Open-drain mode enabled.  This is not a true open-drain mode."]
-    OPEN_DRAIN_MODE_ENAB,
+    OPEN_DRAIN,
 }
 impl ODW {
     #[allow(missing_docs)]
@@ -767,8 +767,8 @@ impl ODW {
     #[inline]
     pub fn _bits(&self) -> bool {
         match *self {
-            ODW::DISABLE_ => false,
-            ODW::OPEN_DRAIN_MODE_ENAB => true,
+            ODW::DISABLED => false,
+            ODW::OPEN_DRAIN => true,
         }
     }
 }
@@ -786,13 +786,13 @@ impl<'a> _ODW<'a> {
     }
     #[doc = "Disable."]
     #[inline]
-    pub fn disable_(self) -> &'a mut W {
-        self.variant(ODW::DISABLE_)
+    pub fn disabled(self) -> &'a mut W {
+        self.variant(ODW::DISABLED)
     }
     #[doc = "Open-drain mode enabled. This is not a true open-drain mode."]
     #[inline]
-    pub fn open_drain_mode_enab(self) -> &'a mut W {
-        self.variant(ODW::OPEN_DRAIN_MODE_ENAB)
+    pub fn open_drain(self) -> &'a mut W {
+        self.variant(ODW::OPEN_DRAIN)
     }
     #[doc = r" Sets the field bit"]
     pub fn set_bit(self) -> &'a mut W {

--- a/lpc11uxx/src/iocon/pio0_23.rs
+++ b/lpc11uxx/src/iocon/pio0_23.rs
@@ -46,9 +46,9 @@ impl super::PIO0_23 {
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum FUNCR {
     #[doc = "PIO0_23."]
-    PIO0_23_,
+    PIO0_23,
     #[doc = "AD7."]
-    AD7_,
+    AD7,
     #[doc = r" Reserved"]
     _Reserved(u8),
 }
@@ -57,8 +57,8 @@ impl FUNCR {
     #[inline]
     pub fn bits(&self) -> u8 {
         match *self {
-            FUNCR::PIO0_23_ => 0,
-            FUNCR::AD7_ => 1,
+            FUNCR::PIO0_23 => 0,
+            FUNCR::AD7 => 1,
             FUNCR::_Reserved(bits) => bits,
         }
     }
@@ -67,43 +67,43 @@ impl FUNCR {
     #[inline]
     pub fn _from(value: u8) -> FUNCR {
         match value {
-            0 => FUNCR::PIO0_23_,
-            1 => FUNCR::AD7_,
+            0 => FUNCR::PIO0_23,
+            1 => FUNCR::AD7,
             i => FUNCR::_Reserved(i),
         }
     }
-    #[doc = "Checks if the value of the field is `PIO0_23_`"]
+    #[doc = "Checks if the value of the field is `PIO0_23`"]
     #[inline]
-    pub fn is_pio0_23_(&self) -> bool {
-        *self == FUNCR::PIO0_23_
+    pub fn is_pio0_23(&self) -> bool {
+        *self == FUNCR::PIO0_23
     }
-    #[doc = "Checks if the value of the field is `AD7_`"]
+    #[doc = "Checks if the value of the field is `AD7`"]
     #[inline]
-    pub fn is_ad7_(&self) -> bool {
-        *self == FUNCR::AD7_
+    pub fn is_ad7(&self) -> bool {
+        *self == FUNCR::AD7
     }
 }
 #[doc = "Possible values of the field `MODE`"]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum MODER {
     #[doc = "Inactive (no pull-down/pull-up resistor enabled)."]
-    INACTIVE_NO_PULL_DO,
+    INACTIVE,
     #[doc = "Pull-down resistor enabled."]
-    PULL_DOWN_RESISTOR_E,
+    PULL_DOWN,
     #[doc = "Pull-up resistor enabled."]
-    PULL_UP_RESISTOR_ENA,
+    PULL_UP,
     #[doc = "Repeater mode."]
-    REPEATER_MODE_,
+    REPEATER,
 }
 impl MODER {
     #[doc = r" Value of the field as raw bits"]
     #[inline]
     pub fn bits(&self) -> u8 {
         match *self {
-            MODER::INACTIVE_NO_PULL_DO => 0,
-            MODER::PULL_DOWN_RESISTOR_E => 1,
-            MODER::PULL_UP_RESISTOR_ENA => 2,
-            MODER::REPEATER_MODE_ => 3,
+            MODER::INACTIVE => 0,
+            MODER::PULL_DOWN => 1,
+            MODER::PULL_UP => 2,
+            MODER::REPEATER => 3,
         }
     }
     #[allow(missing_docs)]
@@ -111,41 +111,41 @@ impl MODER {
     #[inline]
     pub fn _from(value: u8) -> MODER {
         match value {
-            0 => MODER::INACTIVE_NO_PULL_DO,
-            1 => MODER::PULL_DOWN_RESISTOR_E,
-            2 => MODER::PULL_UP_RESISTOR_ENA,
-            3 => MODER::REPEATER_MODE_,
+            0 => MODER::INACTIVE,
+            1 => MODER::PULL_DOWN,
+            2 => MODER::PULL_UP,
+            3 => MODER::REPEATER,
             _ => unreachable!(),
         }
     }
-    #[doc = "Checks if the value of the field is `INACTIVE_NO_PULL_DO`"]
+    #[doc = "Checks if the value of the field is `INACTIVE`"]
     #[inline]
-    pub fn is_inactive_no_pull_do(&self) -> bool {
-        *self == MODER::INACTIVE_NO_PULL_DO
+    pub fn is_inactive(&self) -> bool {
+        *self == MODER::INACTIVE
     }
-    #[doc = "Checks if the value of the field is `PULL_DOWN_RESISTOR_E`"]
+    #[doc = "Checks if the value of the field is `PULL_DOWN`"]
     #[inline]
-    pub fn is_pull_down_resistor_e(&self) -> bool {
-        *self == MODER::PULL_DOWN_RESISTOR_E
+    pub fn is_pull_down(&self) -> bool {
+        *self == MODER::PULL_DOWN
     }
-    #[doc = "Checks if the value of the field is `PULL_UP_RESISTOR_ENA`"]
+    #[doc = "Checks if the value of the field is `PULL_UP`"]
     #[inline]
-    pub fn is_pull_up_resistor_ena(&self) -> bool {
-        *self == MODER::PULL_UP_RESISTOR_ENA
+    pub fn is_pull_up(&self) -> bool {
+        *self == MODER::PULL_UP
     }
-    #[doc = "Checks if the value of the field is `REPEATER_MODE_`"]
+    #[doc = "Checks if the value of the field is `REPEATER`"]
     #[inline]
-    pub fn is_repeater_mode_(&self) -> bool {
-        *self == MODER::REPEATER_MODE_
+    pub fn is_repeater(&self) -> bool {
+        *self == MODER::REPEATER
     }
 }
 #[doc = "Possible values of the field `HYS`"]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum HYSR {
     #[doc = "Disable."]
-    DISABLE_,
+    DISABLED,
     #[doc = "Enable."]
-    ENABLE_,
+    ENABLED,
 }
 impl HYSR {
     #[doc = r" Returns `true` if the bit is clear (0)"]
@@ -162,8 +162,8 @@ impl HYSR {
     #[inline]
     pub fn bit(&self) -> bool {
         match *self {
-            HYSR::DISABLE_ => false,
-            HYSR::ENABLE_ => true,
+            HYSR::DISABLED => false,
+            HYSR::ENABLED => true,
         }
     }
     #[allow(missing_docs)]
@@ -171,28 +171,28 @@ impl HYSR {
     #[inline]
     pub fn _from(value: bool) -> HYSR {
         match value {
-            false => HYSR::DISABLE_,
-            true => HYSR::ENABLE_,
+            false => HYSR::DISABLED,
+            true => HYSR::ENABLED,
         }
     }
-    #[doc = "Checks if the value of the field is `DISABLE_`"]
+    #[doc = "Checks if the value of the field is `DISABLED`"]
     #[inline]
-    pub fn is_disable_(&self) -> bool {
-        *self == HYSR::DISABLE_
+    pub fn is_disabled(&self) -> bool {
+        *self == HYSR::DISABLED
     }
-    #[doc = "Checks if the value of the field is `ENABLE_`"]
+    #[doc = "Checks if the value of the field is `ENABLED`"]
     #[inline]
-    pub fn is_enable_(&self) -> bool {
-        *self == HYSR::ENABLE_
+    pub fn is_enabled(&self) -> bool {
+        *self == HYSR::ENABLED
     }
 }
 #[doc = "Possible values of the field `INV`"]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum INVR {
     #[doc = "Input not inverted (HIGH on pin reads as 1, LOW on pin reads as 0)."]
-    INPUT_NOT_INVERTED_,
+    NOT_INVERTED,
     #[doc = "Input inverted (HIGH on pin reads as 0, LOW on pin reads as 1)."]
-    INPUT_INVERTED_HIGH,
+    INVERTED,
 }
 impl INVR {
     #[doc = r" Returns `true` if the bit is clear (0)"]
@@ -209,8 +209,8 @@ impl INVR {
     #[inline]
     pub fn bit(&self) -> bool {
         match *self {
-            INVR::INPUT_NOT_INVERTED_ => false,
-            INVR::INPUT_INVERTED_HIGH => true,
+            INVR::NOT_INVERTED => false,
+            INVR::INVERTED => true,
         }
     }
     #[allow(missing_docs)]
@@ -218,28 +218,28 @@ impl INVR {
     #[inline]
     pub fn _from(value: bool) -> INVR {
         match value {
-            false => INVR::INPUT_NOT_INVERTED_,
-            true => INVR::INPUT_INVERTED_HIGH,
+            false => INVR::NOT_INVERTED,
+            true => INVR::INVERTED,
         }
     }
-    #[doc = "Checks if the value of the field is `INPUT_NOT_INVERTED_`"]
+    #[doc = "Checks if the value of the field is `NOT_INVERTED`"]
     #[inline]
-    pub fn is_input_not_inverted_(&self) -> bool {
-        *self == INVR::INPUT_NOT_INVERTED_
+    pub fn is_not_inverted(&self) -> bool {
+        *self == INVR::NOT_INVERTED
     }
-    #[doc = "Checks if the value of the field is `INPUT_INVERTED_HIGH`"]
+    #[doc = "Checks if the value of the field is `INVERTED`"]
     #[inline]
-    pub fn is_input_inverted_high(&self) -> bool {
-        *self == INVR::INPUT_INVERTED_HIGH
+    pub fn is_inverted(&self) -> bool {
+        *self == INVR::INVERTED
     }
 }
 #[doc = "Possible values of the field `ADMODE`"]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum ADMODER {
     #[doc = "Analog input mode."]
-    ANALOG_INPUT_MODE_,
+    ANALOG,
     #[doc = "Digital functional mode."]
-    DIGITAL_FUNCTIONAL_M,
+    DIGITAL,
 }
 impl ADMODER {
     #[doc = r" Returns `true` if the bit is clear (0)"]
@@ -256,8 +256,8 @@ impl ADMODER {
     #[inline]
     pub fn bit(&self) -> bool {
         match *self {
-            ADMODER::ANALOG_INPUT_MODE_ => false,
-            ADMODER::DIGITAL_FUNCTIONAL_M => true,
+            ADMODER::ANALOG => false,
+            ADMODER::DIGITAL => true,
         }
     }
     #[allow(missing_docs)]
@@ -265,28 +265,28 @@ impl ADMODER {
     #[inline]
     pub fn _from(value: bool) -> ADMODER {
         match value {
-            false => ADMODER::ANALOG_INPUT_MODE_,
-            true => ADMODER::DIGITAL_FUNCTIONAL_M,
+            false => ADMODER::ANALOG,
+            true => ADMODER::DIGITAL,
         }
     }
-    #[doc = "Checks if the value of the field is `ANALOG_INPUT_MODE_`"]
+    #[doc = "Checks if the value of the field is `ANALOG`"]
     #[inline]
-    pub fn is_analog_input_mode_(&self) -> bool {
-        *self == ADMODER::ANALOG_INPUT_MODE_
+    pub fn is_analog(&self) -> bool {
+        *self == ADMODER::ANALOG
     }
-    #[doc = "Checks if the value of the field is `DIGITAL_FUNCTIONAL_M`"]
+    #[doc = "Checks if the value of the field is `DIGITAL`"]
     #[inline]
-    pub fn is_digital_functional_m(&self) -> bool {
-        *self == ADMODER::DIGITAL_FUNCTIONAL_M
+    pub fn is_digital(&self) -> bool {
+        *self == ADMODER::DIGITAL
     }
 }
 #[doc = "Possible values of the field `FILTR`"]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum FILTRR {
     #[doc = "Filter enabled."]
-    FILTER_ENABLED_,
+    ENABLED,
     #[doc = "Filter disabled."]
-    FILTER_DISABLED_,
+    DISABLED,
 }
 impl FILTRR {
     #[doc = r" Returns `true` if the bit is clear (0)"]
@@ -303,8 +303,8 @@ impl FILTRR {
     #[inline]
     pub fn bit(&self) -> bool {
         match *self {
-            FILTRR::FILTER_ENABLED_ => false,
-            FILTRR::FILTER_DISABLED_ => true,
+            FILTRR::ENABLED => false,
+            FILTRR::DISABLED => true,
         }
     }
     #[allow(missing_docs)]
@@ -312,28 +312,28 @@ impl FILTRR {
     #[inline]
     pub fn _from(value: bool) -> FILTRR {
         match value {
-            false => FILTRR::FILTER_ENABLED_,
-            true => FILTRR::FILTER_DISABLED_,
+            false => FILTRR::ENABLED,
+            true => FILTRR::DISABLED,
         }
     }
-    #[doc = "Checks if the value of the field is `FILTER_ENABLED_`"]
+    #[doc = "Checks if the value of the field is `ENABLED`"]
     #[inline]
-    pub fn is_filter_enabled_(&self) -> bool {
-        *self == FILTRR::FILTER_ENABLED_
+    pub fn is_enabled(&self) -> bool {
+        *self == FILTRR::ENABLED
     }
-    #[doc = "Checks if the value of the field is `FILTER_DISABLED_`"]
+    #[doc = "Checks if the value of the field is `DISABLED`"]
     #[inline]
-    pub fn is_filter_disabled_(&self) -> bool {
-        *self == FILTRR::FILTER_DISABLED_
+    pub fn is_disabled(&self) -> bool {
+        *self == FILTRR::DISABLED
     }
 }
 #[doc = "Possible values of the field `OD`"]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum ODR {
     #[doc = "Disable."]
-    DISABLE_,
+    DISABLED,
     #[doc = "Open-drain mode enabled.  This is not a true open-drain mode."]
-    OPEN_DRAIN_MODE_ENAB,
+    OPEN_DRAIN,
 }
 impl ODR {
     #[doc = r" Returns `true` if the bit is clear (0)"]
@@ -350,8 +350,8 @@ impl ODR {
     #[inline]
     pub fn bit(&self) -> bool {
         match *self {
-            ODR::DISABLE_ => false,
-            ODR::OPEN_DRAIN_MODE_ENAB => true,
+            ODR::DISABLED => false,
+            ODR::OPEN_DRAIN => true,
         }
     }
     #[allow(missing_docs)]
@@ -359,27 +359,27 @@ impl ODR {
     #[inline]
     pub fn _from(value: bool) -> ODR {
         match value {
-            false => ODR::DISABLE_,
-            true => ODR::OPEN_DRAIN_MODE_ENAB,
+            false => ODR::DISABLED,
+            true => ODR::OPEN_DRAIN,
         }
     }
-    #[doc = "Checks if the value of the field is `DISABLE_`"]
+    #[doc = "Checks if the value of the field is `DISABLED`"]
     #[inline]
-    pub fn is_disable_(&self) -> bool {
-        *self == ODR::DISABLE_
+    pub fn is_disabled(&self) -> bool {
+        *self == ODR::DISABLED
     }
-    #[doc = "Checks if the value of the field is `OPEN_DRAIN_MODE_ENAB`"]
+    #[doc = "Checks if the value of the field is `OPEN_DRAIN`"]
     #[inline]
-    pub fn is_open_drain_mode_enab(&self) -> bool {
-        *self == ODR::OPEN_DRAIN_MODE_ENAB
+    pub fn is_open_drain(&self) -> bool {
+        *self == ODR::OPEN_DRAIN
     }
 }
 #[doc = "Values that can be written to the field `FUNC`"]
 pub enum FUNCW {
     #[doc = "PIO0_23."]
-    PIO0_23_,
+    PIO0_23,
     #[doc = "AD7."]
-    AD7_,
+    AD7,
 }
 impl FUNCW {
     #[allow(missing_docs)]
@@ -387,8 +387,8 @@ impl FUNCW {
     #[inline]
     pub fn _bits(&self) -> u8 {
         match *self {
-            FUNCW::PIO0_23_ => 0,
-            FUNCW::AD7_ => 1,
+            FUNCW::PIO0_23 => 0,
+            FUNCW::AD7 => 1,
         }
     }
 }
@@ -404,13 +404,13 @@ impl<'a> _FUNCW<'a> {
     }
     #[doc = "PIO0_23."]
     #[inline]
-    pub fn pio0_23_(self) -> &'a mut W {
-        self.variant(FUNCW::PIO0_23_)
+    pub fn pio0_23(self) -> &'a mut W {
+        self.variant(FUNCW::PIO0_23)
     }
     #[doc = "AD7."]
     #[inline]
-    pub fn ad7_(self) -> &'a mut W {
-        self.variant(FUNCW::AD7_)
+    pub fn ad7(self) -> &'a mut W {
+        self.variant(FUNCW::AD7)
     }
     #[doc = r" Writes raw bits to the field"]
     #[inline]
@@ -425,13 +425,13 @@ impl<'a> _FUNCW<'a> {
 #[doc = "Values that can be written to the field `MODE`"]
 pub enum MODEW {
     #[doc = "Inactive (no pull-down/pull-up resistor enabled)."]
-    INACTIVE_NO_PULL_DO,
+    INACTIVE,
     #[doc = "Pull-down resistor enabled."]
-    PULL_DOWN_RESISTOR_E,
+    PULL_DOWN,
     #[doc = "Pull-up resistor enabled."]
-    PULL_UP_RESISTOR_ENA,
+    PULL_UP,
     #[doc = "Repeater mode."]
-    REPEATER_MODE_,
+    REPEATER,
 }
 impl MODEW {
     #[allow(missing_docs)]
@@ -439,10 +439,10 @@ impl MODEW {
     #[inline]
     pub fn _bits(&self) -> u8 {
         match *self {
-            MODEW::INACTIVE_NO_PULL_DO => 0,
-            MODEW::PULL_DOWN_RESISTOR_E => 1,
-            MODEW::PULL_UP_RESISTOR_ENA => 2,
-            MODEW::REPEATER_MODE_ => 3,
+            MODEW::INACTIVE => 0,
+            MODEW::PULL_DOWN => 1,
+            MODEW::PULL_UP => 2,
+            MODEW::REPEATER => 3,
         }
     }
 }
@@ -460,23 +460,23 @@ impl<'a> _MODEW<'a> {
     }
     #[doc = "Inactive (no pull-down/pull-up resistor enabled)."]
     #[inline]
-    pub fn inactive_no_pull_do(self) -> &'a mut W {
-        self.variant(MODEW::INACTIVE_NO_PULL_DO)
+    pub fn inactive(self) -> &'a mut W {
+        self.variant(MODEW::INACTIVE)
     }
     #[doc = "Pull-down resistor enabled."]
     #[inline]
-    pub fn pull_down_resistor_e(self) -> &'a mut W {
-        self.variant(MODEW::PULL_DOWN_RESISTOR_E)
+    pub fn pull_down(self) -> &'a mut W {
+        self.variant(MODEW::PULL_DOWN)
     }
     #[doc = "Pull-up resistor enabled."]
     #[inline]
-    pub fn pull_up_resistor_ena(self) -> &'a mut W {
-        self.variant(MODEW::PULL_UP_RESISTOR_ENA)
+    pub fn pull_up(self) -> &'a mut W {
+        self.variant(MODEW::PULL_UP)
     }
     #[doc = "Repeater mode."]
     #[inline]
-    pub fn repeater_mode_(self) -> &'a mut W {
-        self.variant(MODEW::REPEATER_MODE_)
+    pub fn repeater(self) -> &'a mut W {
+        self.variant(MODEW::REPEATER)
     }
     #[doc = r" Writes raw bits to the field"]
     #[inline]
@@ -491,9 +491,9 @@ impl<'a> _MODEW<'a> {
 #[doc = "Values that can be written to the field `HYS`"]
 pub enum HYSW {
     #[doc = "Disable."]
-    DISABLE_,
+    DISABLED,
     #[doc = "Enable."]
-    ENABLE_,
+    ENABLED,
 }
 impl HYSW {
     #[allow(missing_docs)]
@@ -501,8 +501,8 @@ impl HYSW {
     #[inline]
     pub fn _bits(&self) -> bool {
         match *self {
-            HYSW::DISABLE_ => false,
-            HYSW::ENABLE_ => true,
+            HYSW::DISABLED => false,
+            HYSW::ENABLED => true,
         }
     }
 }
@@ -520,13 +520,13 @@ impl<'a> _HYSW<'a> {
     }
     #[doc = "Disable."]
     #[inline]
-    pub fn disable_(self) -> &'a mut W {
-        self.variant(HYSW::DISABLE_)
+    pub fn disabled(self) -> &'a mut W {
+        self.variant(HYSW::DISABLED)
     }
     #[doc = "Enable."]
     #[inline]
-    pub fn enable_(self) -> &'a mut W {
-        self.variant(HYSW::ENABLE_)
+    pub fn enabled(self) -> &'a mut W {
+        self.variant(HYSW::ENABLED)
     }
     #[doc = r" Sets the field bit"]
     pub fn set_bit(self) -> &'a mut W {
@@ -549,9 +549,9 @@ impl<'a> _HYSW<'a> {
 #[doc = "Values that can be written to the field `INV`"]
 pub enum INVW {
     #[doc = "Input not inverted (HIGH on pin reads as 1, LOW on pin reads as 0)."]
-    INPUT_NOT_INVERTED_,
+    NOT_INVERTED,
     #[doc = "Input inverted (HIGH on pin reads as 0, LOW on pin reads as 1)."]
-    INPUT_INVERTED_HIGH,
+    INVERTED,
 }
 impl INVW {
     #[allow(missing_docs)]
@@ -559,8 +559,8 @@ impl INVW {
     #[inline]
     pub fn _bits(&self) -> bool {
         match *self {
-            INVW::INPUT_NOT_INVERTED_ => false,
-            INVW::INPUT_INVERTED_HIGH => true,
+            INVW::NOT_INVERTED => false,
+            INVW::INVERTED => true,
         }
     }
 }
@@ -578,13 +578,13 @@ impl<'a> _INVW<'a> {
     }
     #[doc = "Input not inverted (HIGH on pin reads as 1, LOW on pin reads as 0)."]
     #[inline]
-    pub fn input_not_inverted_(self) -> &'a mut W {
-        self.variant(INVW::INPUT_NOT_INVERTED_)
+    pub fn not_inverted(self) -> &'a mut W {
+        self.variant(INVW::NOT_INVERTED)
     }
     #[doc = "Input inverted (HIGH on pin reads as 0, LOW on pin reads as 1)."]
     #[inline]
-    pub fn input_inverted_high(self) -> &'a mut W {
-        self.variant(INVW::INPUT_INVERTED_HIGH)
+    pub fn inverted(self) -> &'a mut W {
+        self.variant(INVW::INVERTED)
     }
     #[doc = r" Sets the field bit"]
     pub fn set_bit(self) -> &'a mut W {
@@ -607,9 +607,9 @@ impl<'a> _INVW<'a> {
 #[doc = "Values that can be written to the field `ADMODE`"]
 pub enum ADMODEW {
     #[doc = "Analog input mode."]
-    ANALOG_INPUT_MODE_,
+    ANALOG,
     #[doc = "Digital functional mode."]
-    DIGITAL_FUNCTIONAL_M,
+    DIGITAL,
 }
 impl ADMODEW {
     #[allow(missing_docs)]
@@ -617,8 +617,8 @@ impl ADMODEW {
     #[inline]
     pub fn _bits(&self) -> bool {
         match *self {
-            ADMODEW::ANALOG_INPUT_MODE_ => false,
-            ADMODEW::DIGITAL_FUNCTIONAL_M => true,
+            ADMODEW::ANALOG => false,
+            ADMODEW::DIGITAL => true,
         }
     }
 }
@@ -636,13 +636,13 @@ impl<'a> _ADMODEW<'a> {
     }
     #[doc = "Analog input mode."]
     #[inline]
-    pub fn analog_input_mode_(self) -> &'a mut W {
-        self.variant(ADMODEW::ANALOG_INPUT_MODE_)
+    pub fn analog(self) -> &'a mut W {
+        self.variant(ADMODEW::ANALOG)
     }
     #[doc = "Digital functional mode."]
     #[inline]
-    pub fn digital_functional_m(self) -> &'a mut W {
-        self.variant(ADMODEW::DIGITAL_FUNCTIONAL_M)
+    pub fn digital(self) -> &'a mut W {
+        self.variant(ADMODEW::DIGITAL)
     }
     #[doc = r" Sets the field bit"]
     pub fn set_bit(self) -> &'a mut W {
@@ -665,9 +665,9 @@ impl<'a> _ADMODEW<'a> {
 #[doc = "Values that can be written to the field `FILTR`"]
 pub enum FILTRW {
     #[doc = "Filter enabled."]
-    FILTER_ENABLED_,
+    ENABLED,
     #[doc = "Filter disabled."]
-    FILTER_DISABLED_,
+    DISABLED,
 }
 impl FILTRW {
     #[allow(missing_docs)]
@@ -675,8 +675,8 @@ impl FILTRW {
     #[inline]
     pub fn _bits(&self) -> bool {
         match *self {
-            FILTRW::FILTER_ENABLED_ => false,
-            FILTRW::FILTER_DISABLED_ => true,
+            FILTRW::ENABLED => false,
+            FILTRW::DISABLED => true,
         }
     }
 }
@@ -694,13 +694,13 @@ impl<'a> _FILTRW<'a> {
     }
     #[doc = "Filter enabled."]
     #[inline]
-    pub fn filter_enabled_(self) -> &'a mut W {
-        self.variant(FILTRW::FILTER_ENABLED_)
+    pub fn enabled(self) -> &'a mut W {
+        self.variant(FILTRW::ENABLED)
     }
     #[doc = "Filter disabled."]
     #[inline]
-    pub fn filter_disabled_(self) -> &'a mut W {
-        self.variant(FILTRW::FILTER_DISABLED_)
+    pub fn disabled(self) -> &'a mut W {
+        self.variant(FILTRW::DISABLED)
     }
     #[doc = r" Sets the field bit"]
     pub fn set_bit(self) -> &'a mut W {
@@ -723,9 +723,9 @@ impl<'a> _FILTRW<'a> {
 #[doc = "Values that can be written to the field `OD`"]
 pub enum ODW {
     #[doc = "Disable."]
-    DISABLE_,
+    DISABLED,
     #[doc = "Open-drain mode enabled.  This is not a true open-drain mode."]
-    OPEN_DRAIN_MODE_ENAB,
+    OPEN_DRAIN,
 }
 impl ODW {
     #[allow(missing_docs)]
@@ -733,8 +733,8 @@ impl ODW {
     #[inline]
     pub fn _bits(&self) -> bool {
         match *self {
-            ODW::DISABLE_ => false,
-            ODW::OPEN_DRAIN_MODE_ENAB => true,
+            ODW::DISABLED => false,
+            ODW::OPEN_DRAIN => true,
         }
     }
 }
@@ -752,13 +752,13 @@ impl<'a> _ODW<'a> {
     }
     #[doc = "Disable."]
     #[inline]
-    pub fn disable_(self) -> &'a mut W {
-        self.variant(ODW::DISABLE_)
+    pub fn disabled(self) -> &'a mut W {
+        self.variant(ODW::DISABLED)
     }
     #[doc = "Open-drain mode enabled. This is not a true open-drain mode."]
     #[inline]
-    pub fn open_drain_mode_enab(self) -> &'a mut W {
-        self.variant(ODW::OPEN_DRAIN_MODE_ENAB)
+    pub fn open_drain(self) -> &'a mut W {
+        self.variant(ODW::OPEN_DRAIN)
     }
     #[doc = r" Sets the field bit"]
     pub fn set_bit(self) -> &'a mut W {

--- a/lpc11uxx/src/iocon/pio0_3.rs
+++ b/lpc11uxx/src/iocon/pio0_3.rs
@@ -46,9 +46,9 @@ impl super::PIO0_3 {
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum FUNCR {
     #[doc = "PIO0_3."]
-    PIO0_3_,
+    PIO0_3,
     #[doc = "USB_VBUS."]
-    USB_VBUS_,
+    USB_VBUS,
     #[doc = r" Reserved"]
     _Reserved(u8),
 }
@@ -57,8 +57,8 @@ impl FUNCR {
     #[inline]
     pub fn bits(&self) -> u8 {
         match *self {
-            FUNCR::PIO0_3_ => 0,
-            FUNCR::USB_VBUS_ => 1,
+            FUNCR::PIO0_3 => 0,
+            FUNCR::USB_VBUS => 1,
             FUNCR::_Reserved(bits) => bits,
         }
     }
@@ -67,43 +67,43 @@ impl FUNCR {
     #[inline]
     pub fn _from(value: u8) -> FUNCR {
         match value {
-            0 => FUNCR::PIO0_3_,
-            1 => FUNCR::USB_VBUS_,
+            0 => FUNCR::PIO0_3,
+            1 => FUNCR::USB_VBUS,
             i => FUNCR::_Reserved(i),
         }
     }
-    #[doc = "Checks if the value of the field is `PIO0_3_`"]
+    #[doc = "Checks if the value of the field is `PIO0_3`"]
     #[inline]
-    pub fn is_pio0_3_(&self) -> bool {
-        *self == FUNCR::PIO0_3_
+    pub fn is_pio0_3(&self) -> bool {
+        *self == FUNCR::PIO0_3
     }
-    #[doc = "Checks if the value of the field is `USB_VBUS_`"]
+    #[doc = "Checks if the value of the field is `USB_VBUS`"]
     #[inline]
-    pub fn is_usb_vbus_(&self) -> bool {
-        *self == FUNCR::USB_VBUS_
+    pub fn is_usb_vbus(&self) -> bool {
+        *self == FUNCR::USB_VBUS
     }
 }
 #[doc = "Possible values of the field `MODE`"]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum MODER {
     #[doc = "Inactive (no pull-down/pull-up resistor enabled)."]
-    INACTIVE_NO_PULL_DO,
+    INACTIVE,
     #[doc = "Pull-down resistor enabled."]
-    PULL_DOWN_RESISTOR_E,
+    PULL_DOWN,
     #[doc = "Pull-up resistor enabled."]
-    PULL_UP_RESISTOR_ENA,
+    PULL_UP,
     #[doc = "Repeater mode."]
-    REPEATER_MODE_,
+    REPEATER,
 }
 impl MODER {
     #[doc = r" Value of the field as raw bits"]
     #[inline]
     pub fn bits(&self) -> u8 {
         match *self {
-            MODER::INACTIVE_NO_PULL_DO => 0,
-            MODER::PULL_DOWN_RESISTOR_E => 1,
-            MODER::PULL_UP_RESISTOR_ENA => 2,
-            MODER::REPEATER_MODE_ => 3,
+            MODER::INACTIVE => 0,
+            MODER::PULL_DOWN => 1,
+            MODER::PULL_UP => 2,
+            MODER::REPEATER => 3,
         }
     }
     #[allow(missing_docs)]
@@ -111,41 +111,41 @@ impl MODER {
     #[inline]
     pub fn _from(value: u8) -> MODER {
         match value {
-            0 => MODER::INACTIVE_NO_PULL_DO,
-            1 => MODER::PULL_DOWN_RESISTOR_E,
-            2 => MODER::PULL_UP_RESISTOR_ENA,
-            3 => MODER::REPEATER_MODE_,
+            0 => MODER::INACTIVE,
+            1 => MODER::PULL_DOWN,
+            2 => MODER::PULL_UP,
+            3 => MODER::REPEATER,
             _ => unreachable!(),
         }
     }
-    #[doc = "Checks if the value of the field is `INACTIVE_NO_PULL_DO`"]
+    #[doc = "Checks if the value of the field is `INACTIVE`"]
     #[inline]
-    pub fn is_inactive_no_pull_do(&self) -> bool {
-        *self == MODER::INACTIVE_NO_PULL_DO
+    pub fn is_inactive(&self) -> bool {
+        *self == MODER::INACTIVE
     }
-    #[doc = "Checks if the value of the field is `PULL_DOWN_RESISTOR_E`"]
+    #[doc = "Checks if the value of the field is `PULL_DOWN`"]
     #[inline]
-    pub fn is_pull_down_resistor_e(&self) -> bool {
-        *self == MODER::PULL_DOWN_RESISTOR_E
+    pub fn is_pull_down(&self) -> bool {
+        *self == MODER::PULL_DOWN
     }
-    #[doc = "Checks if the value of the field is `PULL_UP_RESISTOR_ENA`"]
+    #[doc = "Checks if the value of the field is `PULL_UP`"]
     #[inline]
-    pub fn is_pull_up_resistor_ena(&self) -> bool {
-        *self == MODER::PULL_UP_RESISTOR_ENA
+    pub fn is_pull_up(&self) -> bool {
+        *self == MODER::PULL_UP
     }
-    #[doc = "Checks if the value of the field is `REPEATER_MODE_`"]
+    #[doc = "Checks if the value of the field is `REPEATER`"]
     #[inline]
-    pub fn is_repeater_mode_(&self) -> bool {
-        *self == MODER::REPEATER_MODE_
+    pub fn is_repeater(&self) -> bool {
+        *self == MODER::REPEATER
     }
 }
 #[doc = "Possible values of the field `HYS`"]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum HYSR {
     #[doc = "Disable."]
-    DISABLE_,
+    DISABLED,
     #[doc = "Enable."]
-    ENABLE_,
+    ENABLED,
 }
 impl HYSR {
     #[doc = r" Returns `true` if the bit is clear (0)"]
@@ -162,8 +162,8 @@ impl HYSR {
     #[inline]
     pub fn bit(&self) -> bool {
         match *self {
-            HYSR::DISABLE_ => false,
-            HYSR::ENABLE_ => true,
+            HYSR::DISABLED => false,
+            HYSR::ENABLED => true,
         }
     }
     #[allow(missing_docs)]
@@ -171,28 +171,28 @@ impl HYSR {
     #[inline]
     pub fn _from(value: bool) -> HYSR {
         match value {
-            false => HYSR::DISABLE_,
-            true => HYSR::ENABLE_,
+            false => HYSR::DISABLED,
+            true => HYSR::ENABLED,
         }
     }
-    #[doc = "Checks if the value of the field is `DISABLE_`"]
+    #[doc = "Checks if the value of the field is `DISABLED`"]
     #[inline]
-    pub fn is_disable_(&self) -> bool {
-        *self == HYSR::DISABLE_
+    pub fn is_disabled(&self) -> bool {
+        *self == HYSR::DISABLED
     }
-    #[doc = "Checks if the value of the field is `ENABLE_`"]
+    #[doc = "Checks if the value of the field is `ENABLED`"]
     #[inline]
-    pub fn is_enable_(&self) -> bool {
-        *self == HYSR::ENABLE_
+    pub fn is_enabled(&self) -> bool {
+        *self == HYSR::ENABLED
     }
 }
 #[doc = "Possible values of the field `INV`"]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum INVR {
     #[doc = "Input not inverted (HIGH on pin reads as 1, LOW on pin reads as 0)."]
-    INPUT_NOT_INVERTED_,
+    NOT_INVERTED,
     #[doc = "Input inverted (HIGH on pin reads as 0, LOW on pin reads as 1)."]
-    INPUT_INVERTED_HIGH,
+    INVERTED,
 }
 impl INVR {
     #[doc = r" Returns `true` if the bit is clear (0)"]
@@ -209,8 +209,8 @@ impl INVR {
     #[inline]
     pub fn bit(&self) -> bool {
         match *self {
-            INVR::INPUT_NOT_INVERTED_ => false,
-            INVR::INPUT_INVERTED_HIGH => true,
+            INVR::NOT_INVERTED => false,
+            INVR::INVERTED => true,
         }
     }
     #[allow(missing_docs)]
@@ -218,28 +218,28 @@ impl INVR {
     #[inline]
     pub fn _from(value: bool) -> INVR {
         match value {
-            false => INVR::INPUT_NOT_INVERTED_,
-            true => INVR::INPUT_INVERTED_HIGH,
+            false => INVR::NOT_INVERTED,
+            true => INVR::INVERTED,
         }
     }
-    #[doc = "Checks if the value of the field is `INPUT_NOT_INVERTED_`"]
+    #[doc = "Checks if the value of the field is `NOT_INVERTED`"]
     #[inline]
-    pub fn is_input_not_inverted_(&self) -> bool {
-        *self == INVR::INPUT_NOT_INVERTED_
+    pub fn is_not_inverted(&self) -> bool {
+        *self == INVR::NOT_INVERTED
     }
-    #[doc = "Checks if the value of the field is `INPUT_INVERTED_HIGH`"]
+    #[doc = "Checks if the value of the field is `INVERTED`"]
     #[inline]
-    pub fn is_input_inverted_high(&self) -> bool {
-        *self == INVR::INPUT_INVERTED_HIGH
+    pub fn is_inverted(&self) -> bool {
+        *self == INVR::INVERTED
     }
 }
 #[doc = "Possible values of the field `OD`"]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum ODR {
     #[doc = "Disable."]
-    DISABLE_,
+    DISABLED,
     #[doc = "Open-drain mode enabled.  This is not a true open-drain mode."]
-    OPEN_DRAIN_MODE_ENAB,
+    OPEN_DRAIN,
 }
 impl ODR {
     #[doc = r" Returns `true` if the bit is clear (0)"]
@@ -256,8 +256,8 @@ impl ODR {
     #[inline]
     pub fn bit(&self) -> bool {
         match *self {
-            ODR::DISABLE_ => false,
-            ODR::OPEN_DRAIN_MODE_ENAB => true,
+            ODR::DISABLED => false,
+            ODR::OPEN_DRAIN => true,
         }
     }
     #[allow(missing_docs)]
@@ -265,27 +265,27 @@ impl ODR {
     #[inline]
     pub fn _from(value: bool) -> ODR {
         match value {
-            false => ODR::DISABLE_,
-            true => ODR::OPEN_DRAIN_MODE_ENAB,
+            false => ODR::DISABLED,
+            true => ODR::OPEN_DRAIN,
         }
     }
-    #[doc = "Checks if the value of the field is `DISABLE_`"]
+    #[doc = "Checks if the value of the field is `DISABLED`"]
     #[inline]
-    pub fn is_disable_(&self) -> bool {
-        *self == ODR::DISABLE_
+    pub fn is_disabled(&self) -> bool {
+        *self == ODR::DISABLED
     }
-    #[doc = "Checks if the value of the field is `OPEN_DRAIN_MODE_ENAB`"]
+    #[doc = "Checks if the value of the field is `OPEN_DRAIN`"]
     #[inline]
-    pub fn is_open_drain_mode_enab(&self) -> bool {
-        *self == ODR::OPEN_DRAIN_MODE_ENAB
+    pub fn is_open_drain(&self) -> bool {
+        *self == ODR::OPEN_DRAIN
     }
 }
 #[doc = "Values that can be written to the field `FUNC`"]
 pub enum FUNCW {
     #[doc = "PIO0_3."]
-    PIO0_3_,
+    PIO0_3,
     #[doc = "USB_VBUS."]
-    USB_VBUS_,
+    USB_VBUS,
 }
 impl FUNCW {
     #[allow(missing_docs)]
@@ -293,8 +293,8 @@ impl FUNCW {
     #[inline]
     pub fn _bits(&self) -> u8 {
         match *self {
-            FUNCW::PIO0_3_ => 0,
-            FUNCW::USB_VBUS_ => 1,
+            FUNCW::PIO0_3 => 0,
+            FUNCW::USB_VBUS => 1,
         }
     }
 }
@@ -310,13 +310,13 @@ impl<'a> _FUNCW<'a> {
     }
     #[doc = "PIO0_3."]
     #[inline]
-    pub fn pio0_3_(self) -> &'a mut W {
-        self.variant(FUNCW::PIO0_3_)
+    pub fn pio0_3(self) -> &'a mut W {
+        self.variant(FUNCW::PIO0_3)
     }
     #[doc = "USB_VBUS."]
     #[inline]
-    pub fn usb_vbus_(self) -> &'a mut W {
-        self.variant(FUNCW::USB_VBUS_)
+    pub fn usb_vbus(self) -> &'a mut W {
+        self.variant(FUNCW::USB_VBUS)
     }
     #[doc = r" Writes raw bits to the field"]
     #[inline]
@@ -331,13 +331,13 @@ impl<'a> _FUNCW<'a> {
 #[doc = "Values that can be written to the field `MODE`"]
 pub enum MODEW {
     #[doc = "Inactive (no pull-down/pull-up resistor enabled)."]
-    INACTIVE_NO_PULL_DO,
+    INACTIVE,
     #[doc = "Pull-down resistor enabled."]
-    PULL_DOWN_RESISTOR_E,
+    PULL_DOWN,
     #[doc = "Pull-up resistor enabled."]
-    PULL_UP_RESISTOR_ENA,
+    PULL_UP,
     #[doc = "Repeater mode."]
-    REPEATER_MODE_,
+    REPEATER,
 }
 impl MODEW {
     #[allow(missing_docs)]
@@ -345,10 +345,10 @@ impl MODEW {
     #[inline]
     pub fn _bits(&self) -> u8 {
         match *self {
-            MODEW::INACTIVE_NO_PULL_DO => 0,
-            MODEW::PULL_DOWN_RESISTOR_E => 1,
-            MODEW::PULL_UP_RESISTOR_ENA => 2,
-            MODEW::REPEATER_MODE_ => 3,
+            MODEW::INACTIVE => 0,
+            MODEW::PULL_DOWN => 1,
+            MODEW::PULL_UP => 2,
+            MODEW::REPEATER => 3,
         }
     }
 }
@@ -366,23 +366,23 @@ impl<'a> _MODEW<'a> {
     }
     #[doc = "Inactive (no pull-down/pull-up resistor enabled)."]
     #[inline]
-    pub fn inactive_no_pull_do(self) -> &'a mut W {
-        self.variant(MODEW::INACTIVE_NO_PULL_DO)
+    pub fn inactive(self) -> &'a mut W {
+        self.variant(MODEW::INACTIVE)
     }
     #[doc = "Pull-down resistor enabled."]
     #[inline]
-    pub fn pull_down_resistor_e(self) -> &'a mut W {
-        self.variant(MODEW::PULL_DOWN_RESISTOR_E)
+    pub fn pull_down(self) -> &'a mut W {
+        self.variant(MODEW::PULL_DOWN)
     }
     #[doc = "Pull-up resistor enabled."]
     #[inline]
-    pub fn pull_up_resistor_ena(self) -> &'a mut W {
-        self.variant(MODEW::PULL_UP_RESISTOR_ENA)
+    pub fn pull_up(self) -> &'a mut W {
+        self.variant(MODEW::PULL_UP)
     }
     #[doc = "Repeater mode."]
     #[inline]
-    pub fn repeater_mode_(self) -> &'a mut W {
-        self.variant(MODEW::REPEATER_MODE_)
+    pub fn repeater(self) -> &'a mut W {
+        self.variant(MODEW::REPEATER)
     }
     #[doc = r" Writes raw bits to the field"]
     #[inline]
@@ -397,9 +397,9 @@ impl<'a> _MODEW<'a> {
 #[doc = "Values that can be written to the field `HYS`"]
 pub enum HYSW {
     #[doc = "Disable."]
-    DISABLE_,
+    DISABLED,
     #[doc = "Enable."]
-    ENABLE_,
+    ENABLED,
 }
 impl HYSW {
     #[allow(missing_docs)]
@@ -407,8 +407,8 @@ impl HYSW {
     #[inline]
     pub fn _bits(&self) -> bool {
         match *self {
-            HYSW::DISABLE_ => false,
-            HYSW::ENABLE_ => true,
+            HYSW::DISABLED => false,
+            HYSW::ENABLED => true,
         }
     }
 }
@@ -426,13 +426,13 @@ impl<'a> _HYSW<'a> {
     }
     #[doc = "Disable."]
     #[inline]
-    pub fn disable_(self) -> &'a mut W {
-        self.variant(HYSW::DISABLE_)
+    pub fn disabled(self) -> &'a mut W {
+        self.variant(HYSW::DISABLED)
     }
     #[doc = "Enable."]
     #[inline]
-    pub fn enable_(self) -> &'a mut W {
-        self.variant(HYSW::ENABLE_)
+    pub fn enabled(self) -> &'a mut W {
+        self.variant(HYSW::ENABLED)
     }
     #[doc = r" Sets the field bit"]
     pub fn set_bit(self) -> &'a mut W {
@@ -455,9 +455,9 @@ impl<'a> _HYSW<'a> {
 #[doc = "Values that can be written to the field `INV`"]
 pub enum INVW {
     #[doc = "Input not inverted (HIGH on pin reads as 1, LOW on pin reads as 0)."]
-    INPUT_NOT_INVERTED_,
+    NOT_INVERTED,
     #[doc = "Input inverted (HIGH on pin reads as 0, LOW on pin reads as 1)."]
-    INPUT_INVERTED_HIGH,
+    INVERTED,
 }
 impl INVW {
     #[allow(missing_docs)]
@@ -465,8 +465,8 @@ impl INVW {
     #[inline]
     pub fn _bits(&self) -> bool {
         match *self {
-            INVW::INPUT_NOT_INVERTED_ => false,
-            INVW::INPUT_INVERTED_HIGH => true,
+            INVW::NOT_INVERTED => false,
+            INVW::INVERTED => true,
         }
     }
 }
@@ -484,13 +484,13 @@ impl<'a> _INVW<'a> {
     }
     #[doc = "Input not inverted (HIGH on pin reads as 1, LOW on pin reads as 0)."]
     #[inline]
-    pub fn input_not_inverted_(self) -> &'a mut W {
-        self.variant(INVW::INPUT_NOT_INVERTED_)
+    pub fn not_inverted(self) -> &'a mut W {
+        self.variant(INVW::NOT_INVERTED)
     }
     #[doc = "Input inverted (HIGH on pin reads as 0, LOW on pin reads as 1)."]
     #[inline]
-    pub fn input_inverted_high(self) -> &'a mut W {
-        self.variant(INVW::INPUT_INVERTED_HIGH)
+    pub fn inverted(self) -> &'a mut W {
+        self.variant(INVW::INVERTED)
     }
     #[doc = r" Sets the field bit"]
     pub fn set_bit(self) -> &'a mut W {
@@ -513,9 +513,9 @@ impl<'a> _INVW<'a> {
 #[doc = "Values that can be written to the field `OD`"]
 pub enum ODW {
     #[doc = "Disable."]
-    DISABLE_,
+    DISABLED,
     #[doc = "Open-drain mode enabled.  This is not a true open-drain mode."]
-    OPEN_DRAIN_MODE_ENAB,
+    OPEN_DRAIN,
 }
 impl ODW {
     #[allow(missing_docs)]
@@ -523,8 +523,8 @@ impl ODW {
     #[inline]
     pub fn _bits(&self) -> bool {
         match *self {
-            ODW::DISABLE_ => false,
-            ODW::OPEN_DRAIN_MODE_ENAB => true,
+            ODW::DISABLED => false,
+            ODW::OPEN_DRAIN => true,
         }
     }
 }
@@ -542,13 +542,13 @@ impl<'a> _ODW<'a> {
     }
     #[doc = "Disable."]
     #[inline]
-    pub fn disable_(self) -> &'a mut W {
-        self.variant(ODW::DISABLE_)
+    pub fn disabled(self) -> &'a mut W {
+        self.variant(ODW::DISABLED)
     }
     #[doc = "Open-drain mode enabled. This is not a true open-drain mode."]
     #[inline]
-    pub fn open_drain_mode_enab(self) -> &'a mut W {
-        self.variant(ODW::OPEN_DRAIN_MODE_ENAB)
+    pub fn open_drain(self) -> &'a mut W {
+        self.variant(ODW::OPEN_DRAIN)
     }
     #[doc = r" Sets the field bit"]
     pub fn set_bit(self) -> &'a mut W {

--- a/lpc11uxx/src/iocon/pio0_4.rs
+++ b/lpc11uxx/src/iocon/pio0_4.rs
@@ -46,9 +46,9 @@ impl super::PIO0_4 {
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum FUNCR {
     #[doc = "PIO0_4 (open-drain pin)."]
-    PIO0_4_OPEN_DRAIN_P,
+    PIO0_4,
     #[doc = "I2C SCL (open-drain pin)."]
-    I2C_SCL_OPEN_DRAIN_,
+    I2C_SCL,
     #[doc = r" Reserved"]
     _Reserved(u8),
 }
@@ -57,8 +57,8 @@ impl FUNCR {
     #[inline]
     pub fn bits(&self) -> u8 {
         match *self {
-            FUNCR::PIO0_4_OPEN_DRAIN_P => 0,
-            FUNCR::I2C_SCL_OPEN_DRAIN_ => 1,
+            FUNCR::PIO0_4 => 0,
+            FUNCR::I2C_SCL => 1,
             FUNCR::_Reserved(bits) => bits,
         }
     }
@@ -67,43 +67,40 @@ impl FUNCR {
     #[inline]
     pub fn _from(value: u8) -> FUNCR {
         match value {
-            0 => FUNCR::PIO0_4_OPEN_DRAIN_P,
-            1 => FUNCR::I2C_SCL_OPEN_DRAIN_,
+            0 => FUNCR::PIO0_4,
+            1 => FUNCR::I2C_SCL,
             i => FUNCR::_Reserved(i),
         }
     }
-    #[doc = "Checks if the value of the field is `PIO0_4_OPEN_DRAIN_P`"]
+    #[doc = "Checks if the value of the field is `PIO0_4`"]
     #[inline]
-    pub fn is_pio0_4_open_drain_p(&self) -> bool {
-        *self == FUNCR::PIO0_4_OPEN_DRAIN_P
+    pub fn is_pio0_4(&self) -> bool {
+        *self == FUNCR::PIO0_4
     }
-    #[doc = "Checks if the value of the field is `I2C_SCL_OPEN_DRAIN_`"]
+    #[doc = "Checks if the value of the field is `I2C_SCL`"]
     #[inline]
-    pub fn is_i2c_scl_open_drain_(&self) -> bool {
-        *self == FUNCR::I2C_SCL_OPEN_DRAIN_
+    pub fn is_i2c_scl(&self) -> bool {
+        *self == FUNCR::I2C_SCL
     }
 }
 #[doc = "Possible values of the field `I2CMODE`"]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum I2CMODER {
     #[doc = "Standard mode/ Fast-mode I2C."]
-    STANDARD_MODE_FAST_,
+    STANDARD_MODE,
     #[doc = "Standard I/O functionality"]
-    STANDARD_IO_FUNCTIO,
+    STANDARD_IO,
     #[doc = "Fast-mode Plus I2C"]
-    FAST_MODE_PLUS_I2C,
-    #[doc = "Reserved."]
-    RESERVED_3,
+    FAST_MODE_PLUS,
 }
 impl I2CMODER {
     #[doc = r" Value of the field as raw bits"]
     #[inline]
     pub fn bits(&self) -> u8 {
         match *self {
-            I2CMODER::STANDARD_MODE_FAST_ => 0,
-            I2CMODER::STANDARD_IO_FUNCTIO => 1,
-            I2CMODER::FAST_MODE_PLUS_I2C => 2,
-            I2CMODER::RESERVED_3 => 3,
+            I2CMODER::STANDARD_MODE => 0,
+            I2CMODER::STANDARD_IO => 1,
+            I2CMODER::FAST_MODE_PLUS => 2,
         }
     }
     #[allow(missing_docs)]
@@ -111,40 +108,34 @@ impl I2CMODER {
     #[inline]
     pub fn _from(value: u8) -> I2CMODER {
         match value {
-            0 => I2CMODER::STANDARD_MODE_FAST_,
-            1 => I2CMODER::STANDARD_IO_FUNCTIO,
-            2 => I2CMODER::FAST_MODE_PLUS_I2C,
-            3 => I2CMODER::RESERVED_3,
+            0 => I2CMODER::STANDARD_MODE,
+            1 => I2CMODER::STANDARD_IO,
+            2 => I2CMODER::FAST_MODE_PLUS,
             _ => unreachable!(),
         }
     }
-    #[doc = "Checks if the value of the field is `STANDARD_MODE_FAST_`"]
+    #[doc = "Checks if the value of the field is `STANDARD_MODE`"]
     #[inline]
-    pub fn is_standard_mode_fast_(&self) -> bool {
-        *self == I2CMODER::STANDARD_MODE_FAST_
+    pub fn is_standard_mode(&self) -> bool {
+        *self == I2CMODER::STANDARD_MODE
     }
-    #[doc = "Checks if the value of the field is `STANDARD_IO_FUNCTIO`"]
+    #[doc = "Checks if the value of the field is `STANDARD_IO`"]
     #[inline]
-    pub fn is_standard_io_functio(&self) -> bool {
-        *self == I2CMODER::STANDARD_IO_FUNCTIO
+    pub fn is_standard_io(&self) -> bool {
+        *self == I2CMODER::STANDARD_IO
     }
-    #[doc = "Checks if the value of the field is `FAST_MODE_PLUS_I2C`"]
+    #[doc = "Checks if the value of the field is `FAST_MODE_PLUS`"]
     #[inline]
-    pub fn is_fast_mode_plus_i2c(&self) -> bool {
-        *self == I2CMODER::FAST_MODE_PLUS_I2C
-    }
-    #[doc = "Checks if the value of the field is `RESERVED_3`"]
-    #[inline]
-    pub fn is_reserved_3(&self) -> bool {
-        *self == I2CMODER::RESERVED_3
+    pub fn is_fast_mode_plus(&self) -> bool {
+        *self == I2CMODER::FAST_MODE_PLUS
     }
 }
 #[doc = "Values that can be written to the field `FUNC`"]
 pub enum FUNCW {
     #[doc = "PIO0_4 (open-drain pin)."]
-    PIO0_4_OPEN_DRAIN_P,
+    PIO0_4,
     #[doc = "I2C SCL (open-drain pin)."]
-    I2C_SCL_OPEN_DRAIN_,
+    I2C_SCL,
 }
 impl FUNCW {
     #[allow(missing_docs)]
@@ -152,8 +143,8 @@ impl FUNCW {
     #[inline]
     pub fn _bits(&self) -> u8 {
         match *self {
-            FUNCW::PIO0_4_OPEN_DRAIN_P => 0,
-            FUNCW::I2C_SCL_OPEN_DRAIN_ => 1,
+            FUNCW::PIO0_4 => 0,
+            FUNCW::I2C_SCL => 1,
         }
     }
 }
@@ -169,13 +160,13 @@ impl<'a> _FUNCW<'a> {
     }
     #[doc = "PIO0_4 (open-drain pin)."]
     #[inline]
-    pub fn pio0_4_open_drain_p(self) -> &'a mut W {
-        self.variant(FUNCW::PIO0_4_OPEN_DRAIN_P)
+    pub fn pio0_4(self) -> &'a mut W {
+        self.variant(FUNCW::PIO0_4)
     }
     #[doc = "I2C SCL (open-drain pin)."]
     #[inline]
-    pub fn i2c_scl_open_drain_(self) -> &'a mut W {
-        self.variant(FUNCW::I2C_SCL_OPEN_DRAIN_)
+    pub fn i2c_scl(self) -> &'a mut W {
+        self.variant(FUNCW::I2C_SCL)
     }
     #[doc = r" Writes raw bits to the field"]
     #[inline]
@@ -190,13 +181,11 @@ impl<'a> _FUNCW<'a> {
 #[doc = "Values that can be written to the field `I2CMODE`"]
 pub enum I2CMODEW {
     #[doc = "Standard mode/ Fast-mode I2C."]
-    STANDARD_MODE_FAST_,
+    STANDARD_MODE,
     #[doc = "Standard I/O functionality"]
-    STANDARD_IO_FUNCTIO,
+    STANDARD_IO,
     #[doc = "Fast-mode Plus I2C"]
-    FAST_MODE_PLUS_I2C,
-    #[doc = "Reserved."]
-    RESERVED_3,
+    FAST_MODE_PLUS,
 }
 impl I2CMODEW {
     #[allow(missing_docs)]
@@ -204,10 +193,9 @@ impl I2CMODEW {
     #[inline]
     pub fn _bits(&self) -> u8 {
         match *self {
-            I2CMODEW::STANDARD_MODE_FAST_ => 0,
-            I2CMODEW::STANDARD_IO_FUNCTIO => 1,
-            I2CMODEW::FAST_MODE_PLUS_I2C => 2,
-            I2CMODEW::RESERVED_3 => 3,
+            I2CMODEW::STANDARD_MODE => 0,
+            I2CMODEW::STANDARD_IO => 1,
+            I2CMODEW::FAST_MODE_PLUS => 2,
         }
     }
 }
@@ -219,33 +207,26 @@ impl<'a> _I2CMODEW<'a> {
     #[doc = r" Writes `variant` to the field"]
     #[inline]
     pub fn variant(self, variant: I2CMODEW) -> &'a mut W {
-        {
-            self.bits(variant._bits())
-        }
+        unsafe { self.bits(variant._bits()) }
     }
     #[doc = "Standard mode/ Fast-mode I2C."]
     #[inline]
-    pub fn standard_mode_fast_(self) -> &'a mut W {
-        self.variant(I2CMODEW::STANDARD_MODE_FAST_)
+    pub fn standard_mode(self) -> &'a mut W {
+        self.variant(I2CMODEW::STANDARD_MODE)
     }
     #[doc = "Standard I/O functionality"]
     #[inline]
-    pub fn standard_io_functio(self) -> &'a mut W {
-        self.variant(I2CMODEW::STANDARD_IO_FUNCTIO)
+    pub fn standard_io(self) -> &'a mut W {
+        self.variant(I2CMODEW::STANDARD_IO)
     }
     #[doc = "Fast-mode Plus I2C"]
     #[inline]
-    pub fn fast_mode_plus_i2c(self) -> &'a mut W {
-        self.variant(I2CMODEW::FAST_MODE_PLUS_I2C)
-    }
-    #[doc = "Reserved."]
-    #[inline]
-    pub fn reserved_3(self) -> &'a mut W {
-        self.variant(I2CMODEW::RESERVED_3)
+    pub fn fast_mode_plus(self) -> &'a mut W {
+        self.variant(I2CMODEW::FAST_MODE_PLUS)
     }
     #[doc = r" Writes raw bits to the field"]
     #[inline]
-    pub fn bits(self, value: u8) -> &'a mut W {
+    pub unsafe fn bits(self, value: u8) -> &'a mut W {
         const MASK: u8 = 3;
         const OFFSET: u8 = 8;
         self.w.bits &= !((MASK as u32) << OFFSET);

--- a/lpc11uxx/src/iocon/pio0_5.rs
+++ b/lpc11uxx/src/iocon/pio0_5.rs
@@ -46,9 +46,9 @@ impl super::PIO0_5 {
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum FUNCR {
     #[doc = "PIO0_5 (open-drain pin)."]
-    PIO0_5_OPEN_DRAIN_P,
+    PIO0_5,
     #[doc = "I2C SDA (open-drain pin)."]
-    I2C_SDA_OPEN_DRAIN_,
+    I2C_SDA,
     #[doc = r" Reserved"]
     _Reserved(u8),
 }
@@ -57,8 +57,8 @@ impl FUNCR {
     #[inline]
     pub fn bits(&self) -> u8 {
         match *self {
-            FUNCR::PIO0_5_OPEN_DRAIN_P => 0,
-            FUNCR::I2C_SDA_OPEN_DRAIN_ => 1,
+            FUNCR::PIO0_5 => 0,
+            FUNCR::I2C_SDA => 1,
             FUNCR::_Reserved(bits) => bits,
         }
     }
@@ -67,43 +67,40 @@ impl FUNCR {
     #[inline]
     pub fn _from(value: u8) -> FUNCR {
         match value {
-            0 => FUNCR::PIO0_5_OPEN_DRAIN_P,
-            1 => FUNCR::I2C_SDA_OPEN_DRAIN_,
+            0 => FUNCR::PIO0_5,
+            1 => FUNCR::I2C_SDA,
             i => FUNCR::_Reserved(i),
         }
     }
-    #[doc = "Checks if the value of the field is `PIO0_5_OPEN_DRAIN_P`"]
+    #[doc = "Checks if the value of the field is `PIO0_5`"]
     #[inline]
-    pub fn is_pio0_5_open_drain_p(&self) -> bool {
-        *self == FUNCR::PIO0_5_OPEN_DRAIN_P
+    pub fn is_pio0_5(&self) -> bool {
+        *self == FUNCR::PIO0_5
     }
-    #[doc = "Checks if the value of the field is `I2C_SDA_OPEN_DRAIN_`"]
+    #[doc = "Checks if the value of the field is `I2C_SDA`"]
     #[inline]
-    pub fn is_i2c_sda_open_drain_(&self) -> bool {
-        *self == FUNCR::I2C_SDA_OPEN_DRAIN_
+    pub fn is_i2c_sda(&self) -> bool {
+        *self == FUNCR::I2C_SDA
     }
 }
 #[doc = "Possible values of the field `I2CMODE`"]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum I2CMODER {
     #[doc = "Standard mode/ Fast-mode I2C."]
-    STANDARD_MODE_FAST_,
+    STANDARD_MODE,
     #[doc = "Standard I/O functionality"]
-    STANDARD_IO_FUNCTIO,
+    STANDARD_IO,
     #[doc = "Fast-mode Plus I2C"]
-    FAST_MODE_PLUS_I2C,
-    #[doc = "Reserved."]
-    RESERVED_3,
+    FAST_MODE_PLUS,
 }
 impl I2CMODER {
     #[doc = r" Value of the field as raw bits"]
     #[inline]
     pub fn bits(&self) -> u8 {
         match *self {
-            I2CMODER::STANDARD_MODE_FAST_ => 0,
-            I2CMODER::STANDARD_IO_FUNCTIO => 1,
-            I2CMODER::FAST_MODE_PLUS_I2C => 2,
-            I2CMODER::RESERVED_3 => 3,
+            I2CMODER::STANDARD_MODE => 0,
+            I2CMODER::STANDARD_IO => 1,
+            I2CMODER::FAST_MODE_PLUS => 2,
         }
     }
     #[allow(missing_docs)]
@@ -111,40 +108,34 @@ impl I2CMODER {
     #[inline]
     pub fn _from(value: u8) -> I2CMODER {
         match value {
-            0 => I2CMODER::STANDARD_MODE_FAST_,
-            1 => I2CMODER::STANDARD_IO_FUNCTIO,
-            2 => I2CMODER::FAST_MODE_PLUS_I2C,
-            3 => I2CMODER::RESERVED_3,
+            0 => I2CMODER::STANDARD_MODE,
+            1 => I2CMODER::STANDARD_IO,
+            2 => I2CMODER::FAST_MODE_PLUS,
             _ => unreachable!(),
         }
     }
-    #[doc = "Checks if the value of the field is `STANDARD_MODE_FAST_`"]
+    #[doc = "Checks if the value of the field is `STANDARD_MODE`"]
     #[inline]
-    pub fn is_standard_mode_fast_(&self) -> bool {
-        *self == I2CMODER::STANDARD_MODE_FAST_
+    pub fn is_standard_mode(&self) -> bool {
+        *self == I2CMODER::STANDARD_MODE
     }
-    #[doc = "Checks if the value of the field is `STANDARD_IO_FUNCTIO`"]
+    #[doc = "Checks if the value of the field is `STANDARD_IO`"]
     #[inline]
-    pub fn is_standard_io_functio(&self) -> bool {
-        *self == I2CMODER::STANDARD_IO_FUNCTIO
+    pub fn is_standard_io(&self) -> bool {
+        *self == I2CMODER::STANDARD_IO
     }
-    #[doc = "Checks if the value of the field is `FAST_MODE_PLUS_I2C`"]
+    #[doc = "Checks if the value of the field is `FAST_MODE_PLUS`"]
     #[inline]
-    pub fn is_fast_mode_plus_i2c(&self) -> bool {
-        *self == I2CMODER::FAST_MODE_PLUS_I2C
-    }
-    #[doc = "Checks if the value of the field is `RESERVED_3`"]
-    #[inline]
-    pub fn is_reserved_3(&self) -> bool {
-        *self == I2CMODER::RESERVED_3
+    pub fn is_fast_mode_plus(&self) -> bool {
+        *self == I2CMODER::FAST_MODE_PLUS
     }
 }
 #[doc = "Values that can be written to the field `FUNC`"]
 pub enum FUNCW {
     #[doc = "PIO0_5 (open-drain pin)."]
-    PIO0_5_OPEN_DRAIN_P,
+    PIO0_5,
     #[doc = "I2C SDA (open-drain pin)."]
-    I2C_SDA_OPEN_DRAIN_,
+    I2C_SDA,
 }
 impl FUNCW {
     #[allow(missing_docs)]
@@ -152,8 +143,8 @@ impl FUNCW {
     #[inline]
     pub fn _bits(&self) -> u8 {
         match *self {
-            FUNCW::PIO0_5_OPEN_DRAIN_P => 0,
-            FUNCW::I2C_SDA_OPEN_DRAIN_ => 1,
+            FUNCW::PIO0_5 => 0,
+            FUNCW::I2C_SDA => 1,
         }
     }
 }
@@ -169,13 +160,13 @@ impl<'a> _FUNCW<'a> {
     }
     #[doc = "PIO0_5 (open-drain pin)."]
     #[inline]
-    pub fn pio0_5_open_drain_p(self) -> &'a mut W {
-        self.variant(FUNCW::PIO0_5_OPEN_DRAIN_P)
+    pub fn pio0_5(self) -> &'a mut W {
+        self.variant(FUNCW::PIO0_5)
     }
     #[doc = "I2C SDA (open-drain pin)."]
     #[inline]
-    pub fn i2c_sda_open_drain_(self) -> &'a mut W {
-        self.variant(FUNCW::I2C_SDA_OPEN_DRAIN_)
+    pub fn i2c_sda(self) -> &'a mut W {
+        self.variant(FUNCW::I2C_SDA)
     }
     #[doc = r" Writes raw bits to the field"]
     #[inline]
@@ -190,13 +181,11 @@ impl<'a> _FUNCW<'a> {
 #[doc = "Values that can be written to the field `I2CMODE`"]
 pub enum I2CMODEW {
     #[doc = "Standard mode/ Fast-mode I2C."]
-    STANDARD_MODE_FAST_,
+    STANDARD_MODE,
     #[doc = "Standard I/O functionality"]
-    STANDARD_IO_FUNCTIO,
+    STANDARD_IO,
     #[doc = "Fast-mode Plus I2C"]
-    FAST_MODE_PLUS_I2C,
-    #[doc = "Reserved."]
-    RESERVED_3,
+    FAST_MODE_PLUS,
 }
 impl I2CMODEW {
     #[allow(missing_docs)]
@@ -204,10 +193,9 @@ impl I2CMODEW {
     #[inline]
     pub fn _bits(&self) -> u8 {
         match *self {
-            I2CMODEW::STANDARD_MODE_FAST_ => 0,
-            I2CMODEW::STANDARD_IO_FUNCTIO => 1,
-            I2CMODEW::FAST_MODE_PLUS_I2C => 2,
-            I2CMODEW::RESERVED_3 => 3,
+            I2CMODEW::STANDARD_MODE => 0,
+            I2CMODEW::STANDARD_IO => 1,
+            I2CMODEW::FAST_MODE_PLUS => 2,
         }
     }
 }
@@ -219,33 +207,26 @@ impl<'a> _I2CMODEW<'a> {
     #[doc = r" Writes `variant` to the field"]
     #[inline]
     pub fn variant(self, variant: I2CMODEW) -> &'a mut W {
-        {
-            self.bits(variant._bits())
-        }
+        unsafe { self.bits(variant._bits()) }
     }
     #[doc = "Standard mode/ Fast-mode I2C."]
     #[inline]
-    pub fn standard_mode_fast_(self) -> &'a mut W {
-        self.variant(I2CMODEW::STANDARD_MODE_FAST_)
+    pub fn standard_mode(self) -> &'a mut W {
+        self.variant(I2CMODEW::STANDARD_MODE)
     }
     #[doc = "Standard I/O functionality"]
     #[inline]
-    pub fn standard_io_functio(self) -> &'a mut W {
-        self.variant(I2CMODEW::STANDARD_IO_FUNCTIO)
+    pub fn standard_io(self) -> &'a mut W {
+        self.variant(I2CMODEW::STANDARD_IO)
     }
     #[doc = "Fast-mode Plus I2C"]
     #[inline]
-    pub fn fast_mode_plus_i2c(self) -> &'a mut W {
-        self.variant(I2CMODEW::FAST_MODE_PLUS_I2C)
-    }
-    #[doc = "Reserved."]
-    #[inline]
-    pub fn reserved_3(self) -> &'a mut W {
-        self.variant(I2CMODEW::RESERVED_3)
+    pub fn fast_mode_plus(self) -> &'a mut W {
+        self.variant(I2CMODEW::FAST_MODE_PLUS)
     }
     #[doc = r" Writes raw bits to the field"]
     #[inline]
-    pub fn bits(self, value: u8) -> &'a mut W {
+    pub unsafe fn bits(self, value: u8) -> &'a mut W {
         const MASK: u8 = 3;
         const OFFSET: u8 = 8;
         self.w.bits &= !((MASK as u32) << OFFSET);

--- a/lpc11uxx/src/iocon/pio0_6.rs
+++ b/lpc11uxx/src/iocon/pio0_6.rs
@@ -46,11 +46,11 @@ impl super::PIO0_6 {
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum FUNCR {
     #[doc = "PIO0_6."]
-    PIO0_6_,
+    PIO0_6,
     #[doc = "USB_CONNECT."]
-    USB_CONNECT_,
+    USB_CONNECT,
     #[doc = "SCK0."]
-    SCK0_,
+    SCK0,
     #[doc = r" Reserved"]
     _Reserved(u8),
 }
@@ -59,9 +59,9 @@ impl FUNCR {
     #[inline]
     pub fn bits(&self) -> u8 {
         match *self {
-            FUNCR::PIO0_6_ => 0,
-            FUNCR::USB_CONNECT_ => 1,
-            FUNCR::SCK0_ => 2,
+            FUNCR::PIO0_6 => 0,
+            FUNCR::USB_CONNECT => 1,
+            FUNCR::SCK0 => 2,
             FUNCR::_Reserved(bits) => bits,
         }
     }
@@ -70,49 +70,49 @@ impl FUNCR {
     #[inline]
     pub fn _from(value: u8) -> FUNCR {
         match value {
-            0 => FUNCR::PIO0_6_,
-            1 => FUNCR::USB_CONNECT_,
-            2 => FUNCR::SCK0_,
+            0 => FUNCR::PIO0_6,
+            1 => FUNCR::USB_CONNECT,
+            2 => FUNCR::SCK0,
             i => FUNCR::_Reserved(i),
         }
     }
-    #[doc = "Checks if the value of the field is `PIO0_6_`"]
+    #[doc = "Checks if the value of the field is `PIO0_6`"]
     #[inline]
-    pub fn is_pio0_6_(&self) -> bool {
-        *self == FUNCR::PIO0_6_
+    pub fn is_pio0_6(&self) -> bool {
+        *self == FUNCR::PIO0_6
     }
-    #[doc = "Checks if the value of the field is `USB_CONNECT_`"]
+    #[doc = "Checks if the value of the field is `USB_CONNECT`"]
     #[inline]
-    pub fn is_usb_connect_(&self) -> bool {
-        *self == FUNCR::USB_CONNECT_
+    pub fn is_usb_connect(&self) -> bool {
+        *self == FUNCR::USB_CONNECT
     }
-    #[doc = "Checks if the value of the field is `SCK0_`"]
+    #[doc = "Checks if the value of the field is `SCK0`"]
     #[inline]
-    pub fn is_sck0_(&self) -> bool {
-        *self == FUNCR::SCK0_
+    pub fn is_sck0(&self) -> bool {
+        *self == FUNCR::SCK0
     }
 }
 #[doc = "Possible values of the field `MODE`"]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum MODER {
     #[doc = "Inactive (no pull-down/pull-up resistor enabled)."]
-    INACTIVE_NO_PULL_DO,
+    INACTIVE,
     #[doc = "Pull-down resistor enabled."]
-    PULL_DOWN_RESISTOR_E,
+    PULL_DOWN,
     #[doc = "Pull-up resistor enabled."]
-    PULL_UP_RESISTOR_ENA,
+    PULL_UP,
     #[doc = "Repeater mode."]
-    REPEATER_MODE_,
+    REPEATER,
 }
 impl MODER {
     #[doc = r" Value of the field as raw bits"]
     #[inline]
     pub fn bits(&self) -> u8 {
         match *self {
-            MODER::INACTIVE_NO_PULL_DO => 0,
-            MODER::PULL_DOWN_RESISTOR_E => 1,
-            MODER::PULL_UP_RESISTOR_ENA => 2,
-            MODER::REPEATER_MODE_ => 3,
+            MODER::INACTIVE => 0,
+            MODER::PULL_DOWN => 1,
+            MODER::PULL_UP => 2,
+            MODER::REPEATER => 3,
         }
     }
     #[allow(missing_docs)]
@@ -120,41 +120,41 @@ impl MODER {
     #[inline]
     pub fn _from(value: u8) -> MODER {
         match value {
-            0 => MODER::INACTIVE_NO_PULL_DO,
-            1 => MODER::PULL_DOWN_RESISTOR_E,
-            2 => MODER::PULL_UP_RESISTOR_ENA,
-            3 => MODER::REPEATER_MODE_,
+            0 => MODER::INACTIVE,
+            1 => MODER::PULL_DOWN,
+            2 => MODER::PULL_UP,
+            3 => MODER::REPEATER,
             _ => unreachable!(),
         }
     }
-    #[doc = "Checks if the value of the field is `INACTIVE_NO_PULL_DO`"]
+    #[doc = "Checks if the value of the field is `INACTIVE`"]
     #[inline]
-    pub fn is_inactive_no_pull_do(&self) -> bool {
-        *self == MODER::INACTIVE_NO_PULL_DO
+    pub fn is_inactive(&self) -> bool {
+        *self == MODER::INACTIVE
     }
-    #[doc = "Checks if the value of the field is `PULL_DOWN_RESISTOR_E`"]
+    #[doc = "Checks if the value of the field is `PULL_DOWN`"]
     #[inline]
-    pub fn is_pull_down_resistor_e(&self) -> bool {
-        *self == MODER::PULL_DOWN_RESISTOR_E
+    pub fn is_pull_down(&self) -> bool {
+        *self == MODER::PULL_DOWN
     }
-    #[doc = "Checks if the value of the field is `PULL_UP_RESISTOR_ENA`"]
+    #[doc = "Checks if the value of the field is `PULL_UP`"]
     #[inline]
-    pub fn is_pull_up_resistor_ena(&self) -> bool {
-        *self == MODER::PULL_UP_RESISTOR_ENA
+    pub fn is_pull_up(&self) -> bool {
+        *self == MODER::PULL_UP
     }
-    #[doc = "Checks if the value of the field is `REPEATER_MODE_`"]
+    #[doc = "Checks if the value of the field is `REPEATER`"]
     #[inline]
-    pub fn is_repeater_mode_(&self) -> bool {
-        *self == MODER::REPEATER_MODE_
+    pub fn is_repeater(&self) -> bool {
+        *self == MODER::REPEATER
     }
 }
 #[doc = "Possible values of the field `HYS`"]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum HYSR {
     #[doc = "Disable."]
-    DISABLE_,
+    DISABLED,
     #[doc = "Enable."]
-    ENABLE_,
+    ENABLED,
 }
 impl HYSR {
     #[doc = r" Returns `true` if the bit is clear (0)"]
@@ -171,8 +171,8 @@ impl HYSR {
     #[inline]
     pub fn bit(&self) -> bool {
         match *self {
-            HYSR::DISABLE_ => false,
-            HYSR::ENABLE_ => true,
+            HYSR::DISABLED => false,
+            HYSR::ENABLED => true,
         }
     }
     #[allow(missing_docs)]
@@ -180,28 +180,28 @@ impl HYSR {
     #[inline]
     pub fn _from(value: bool) -> HYSR {
         match value {
-            false => HYSR::DISABLE_,
-            true => HYSR::ENABLE_,
+            false => HYSR::DISABLED,
+            true => HYSR::ENABLED,
         }
     }
-    #[doc = "Checks if the value of the field is `DISABLE_`"]
+    #[doc = "Checks if the value of the field is `DISABLED`"]
     #[inline]
-    pub fn is_disable_(&self) -> bool {
-        *self == HYSR::DISABLE_
+    pub fn is_disabled(&self) -> bool {
+        *self == HYSR::DISABLED
     }
-    #[doc = "Checks if the value of the field is `ENABLE_`"]
+    #[doc = "Checks if the value of the field is `ENABLED`"]
     #[inline]
-    pub fn is_enable_(&self) -> bool {
-        *self == HYSR::ENABLE_
+    pub fn is_enabled(&self) -> bool {
+        *self == HYSR::ENABLED
     }
 }
 #[doc = "Possible values of the field `INV`"]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum INVR {
     #[doc = "Input not inverted (HIGH on pin reads as 1, LOW on pin reads as 0)."]
-    INPUT_NOT_INVERTED_,
+    NOT_INVERTED,
     #[doc = "Input inverted (HIGH on pin reads as 0, LOW on pin reads as 1)."]
-    INPUT_INVERTED_HIGH,
+    INVERTED,
 }
 impl INVR {
     #[doc = r" Returns `true` if the bit is clear (0)"]
@@ -218,8 +218,8 @@ impl INVR {
     #[inline]
     pub fn bit(&self) -> bool {
         match *self {
-            INVR::INPUT_NOT_INVERTED_ => false,
-            INVR::INPUT_INVERTED_HIGH => true,
+            INVR::NOT_INVERTED => false,
+            INVR::INVERTED => true,
         }
     }
     #[allow(missing_docs)]
@@ -227,28 +227,28 @@ impl INVR {
     #[inline]
     pub fn _from(value: bool) -> INVR {
         match value {
-            false => INVR::INPUT_NOT_INVERTED_,
-            true => INVR::INPUT_INVERTED_HIGH,
+            false => INVR::NOT_INVERTED,
+            true => INVR::INVERTED,
         }
     }
-    #[doc = "Checks if the value of the field is `INPUT_NOT_INVERTED_`"]
+    #[doc = "Checks if the value of the field is `NOT_INVERTED`"]
     #[inline]
-    pub fn is_input_not_inverted_(&self) -> bool {
-        *self == INVR::INPUT_NOT_INVERTED_
+    pub fn is_not_inverted(&self) -> bool {
+        *self == INVR::NOT_INVERTED
     }
-    #[doc = "Checks if the value of the field is `INPUT_INVERTED_HIGH`"]
+    #[doc = "Checks if the value of the field is `INVERTED`"]
     #[inline]
-    pub fn is_input_inverted_high(&self) -> bool {
-        *self == INVR::INPUT_INVERTED_HIGH
+    pub fn is_inverted(&self) -> bool {
+        *self == INVR::INVERTED
     }
 }
 #[doc = "Possible values of the field `OD`"]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum ODR {
     #[doc = "Disable."]
-    DISABLE_,
+    DISABLED,
     #[doc = "Open-drain mode enabled.  This is not a true open-drain mode."]
-    OPEN_DRAIN_MODE_ENAB,
+    OPEN_DRAIN,
 }
 impl ODR {
     #[doc = r" Returns `true` if the bit is clear (0)"]
@@ -265,8 +265,8 @@ impl ODR {
     #[inline]
     pub fn bit(&self) -> bool {
         match *self {
-            ODR::DISABLE_ => false,
-            ODR::OPEN_DRAIN_MODE_ENAB => true,
+            ODR::DISABLED => false,
+            ODR::OPEN_DRAIN => true,
         }
     }
     #[allow(missing_docs)]
@@ -274,29 +274,29 @@ impl ODR {
     #[inline]
     pub fn _from(value: bool) -> ODR {
         match value {
-            false => ODR::DISABLE_,
-            true => ODR::OPEN_DRAIN_MODE_ENAB,
+            false => ODR::DISABLED,
+            true => ODR::OPEN_DRAIN,
         }
     }
-    #[doc = "Checks if the value of the field is `DISABLE_`"]
+    #[doc = "Checks if the value of the field is `DISABLED`"]
     #[inline]
-    pub fn is_disable_(&self) -> bool {
-        *self == ODR::DISABLE_
+    pub fn is_disabled(&self) -> bool {
+        *self == ODR::DISABLED
     }
-    #[doc = "Checks if the value of the field is `OPEN_DRAIN_MODE_ENAB`"]
+    #[doc = "Checks if the value of the field is `OPEN_DRAIN`"]
     #[inline]
-    pub fn is_open_drain_mode_enab(&self) -> bool {
-        *self == ODR::OPEN_DRAIN_MODE_ENAB
+    pub fn is_open_drain(&self) -> bool {
+        *self == ODR::OPEN_DRAIN
     }
 }
 #[doc = "Values that can be written to the field `FUNC`"]
 pub enum FUNCW {
     #[doc = "PIO0_6."]
-    PIO0_6_,
+    PIO0_6,
     #[doc = "USB_CONNECT."]
-    USB_CONNECT_,
+    USB_CONNECT,
     #[doc = "SCK0."]
-    SCK0_,
+    SCK0,
 }
 impl FUNCW {
     #[allow(missing_docs)]
@@ -304,9 +304,9 @@ impl FUNCW {
     #[inline]
     pub fn _bits(&self) -> u8 {
         match *self {
-            FUNCW::PIO0_6_ => 0,
-            FUNCW::USB_CONNECT_ => 1,
-            FUNCW::SCK0_ => 2,
+            FUNCW::PIO0_6 => 0,
+            FUNCW::USB_CONNECT => 1,
+            FUNCW::SCK0 => 2,
         }
     }
 }
@@ -322,18 +322,18 @@ impl<'a> _FUNCW<'a> {
     }
     #[doc = "PIO0_6."]
     #[inline]
-    pub fn pio0_6_(self) -> &'a mut W {
-        self.variant(FUNCW::PIO0_6_)
+    pub fn pio0_6(self) -> &'a mut W {
+        self.variant(FUNCW::PIO0_6)
     }
     #[doc = "USB_CONNECT."]
     #[inline]
-    pub fn usb_connect_(self) -> &'a mut W {
-        self.variant(FUNCW::USB_CONNECT_)
+    pub fn usb_connect(self) -> &'a mut W {
+        self.variant(FUNCW::USB_CONNECT)
     }
     #[doc = "SCK0."]
     #[inline]
-    pub fn sck0_(self) -> &'a mut W {
-        self.variant(FUNCW::SCK0_)
+    pub fn sck0(self) -> &'a mut W {
+        self.variant(FUNCW::SCK0)
     }
     #[doc = r" Writes raw bits to the field"]
     #[inline]
@@ -348,13 +348,13 @@ impl<'a> _FUNCW<'a> {
 #[doc = "Values that can be written to the field `MODE`"]
 pub enum MODEW {
     #[doc = "Inactive (no pull-down/pull-up resistor enabled)."]
-    INACTIVE_NO_PULL_DO,
+    INACTIVE,
     #[doc = "Pull-down resistor enabled."]
-    PULL_DOWN_RESISTOR_E,
+    PULL_DOWN,
     #[doc = "Pull-up resistor enabled."]
-    PULL_UP_RESISTOR_ENA,
+    PULL_UP,
     #[doc = "Repeater mode."]
-    REPEATER_MODE_,
+    REPEATER,
 }
 impl MODEW {
     #[allow(missing_docs)]
@@ -362,10 +362,10 @@ impl MODEW {
     #[inline]
     pub fn _bits(&self) -> u8 {
         match *self {
-            MODEW::INACTIVE_NO_PULL_DO => 0,
-            MODEW::PULL_DOWN_RESISTOR_E => 1,
-            MODEW::PULL_UP_RESISTOR_ENA => 2,
-            MODEW::REPEATER_MODE_ => 3,
+            MODEW::INACTIVE => 0,
+            MODEW::PULL_DOWN => 1,
+            MODEW::PULL_UP => 2,
+            MODEW::REPEATER => 3,
         }
     }
 }
@@ -383,23 +383,23 @@ impl<'a> _MODEW<'a> {
     }
     #[doc = "Inactive (no pull-down/pull-up resistor enabled)."]
     #[inline]
-    pub fn inactive_no_pull_do(self) -> &'a mut W {
-        self.variant(MODEW::INACTIVE_NO_PULL_DO)
+    pub fn inactive(self) -> &'a mut W {
+        self.variant(MODEW::INACTIVE)
     }
     #[doc = "Pull-down resistor enabled."]
     #[inline]
-    pub fn pull_down_resistor_e(self) -> &'a mut W {
-        self.variant(MODEW::PULL_DOWN_RESISTOR_E)
+    pub fn pull_down(self) -> &'a mut W {
+        self.variant(MODEW::PULL_DOWN)
     }
     #[doc = "Pull-up resistor enabled."]
     #[inline]
-    pub fn pull_up_resistor_ena(self) -> &'a mut W {
-        self.variant(MODEW::PULL_UP_RESISTOR_ENA)
+    pub fn pull_up(self) -> &'a mut W {
+        self.variant(MODEW::PULL_UP)
     }
     #[doc = "Repeater mode."]
     #[inline]
-    pub fn repeater_mode_(self) -> &'a mut W {
-        self.variant(MODEW::REPEATER_MODE_)
+    pub fn repeater(self) -> &'a mut W {
+        self.variant(MODEW::REPEATER)
     }
     #[doc = r" Writes raw bits to the field"]
     #[inline]
@@ -414,9 +414,9 @@ impl<'a> _MODEW<'a> {
 #[doc = "Values that can be written to the field `HYS`"]
 pub enum HYSW {
     #[doc = "Disable."]
-    DISABLE_,
+    DISABLED,
     #[doc = "Enable."]
-    ENABLE_,
+    ENABLED,
 }
 impl HYSW {
     #[allow(missing_docs)]
@@ -424,8 +424,8 @@ impl HYSW {
     #[inline]
     pub fn _bits(&self) -> bool {
         match *self {
-            HYSW::DISABLE_ => false,
-            HYSW::ENABLE_ => true,
+            HYSW::DISABLED => false,
+            HYSW::ENABLED => true,
         }
     }
 }
@@ -443,13 +443,13 @@ impl<'a> _HYSW<'a> {
     }
     #[doc = "Disable."]
     #[inline]
-    pub fn disable_(self) -> &'a mut W {
-        self.variant(HYSW::DISABLE_)
+    pub fn disabled(self) -> &'a mut W {
+        self.variant(HYSW::DISABLED)
     }
     #[doc = "Enable."]
     #[inline]
-    pub fn enable_(self) -> &'a mut W {
-        self.variant(HYSW::ENABLE_)
+    pub fn enabled(self) -> &'a mut W {
+        self.variant(HYSW::ENABLED)
     }
     #[doc = r" Sets the field bit"]
     pub fn set_bit(self) -> &'a mut W {
@@ -472,9 +472,9 @@ impl<'a> _HYSW<'a> {
 #[doc = "Values that can be written to the field `INV`"]
 pub enum INVW {
     #[doc = "Input not inverted (HIGH on pin reads as 1, LOW on pin reads as 0)."]
-    INPUT_NOT_INVERTED_,
+    NOT_INVERTED,
     #[doc = "Input inverted (HIGH on pin reads as 0, LOW on pin reads as 1)."]
-    INPUT_INVERTED_HIGH,
+    INVERTED,
 }
 impl INVW {
     #[allow(missing_docs)]
@@ -482,8 +482,8 @@ impl INVW {
     #[inline]
     pub fn _bits(&self) -> bool {
         match *self {
-            INVW::INPUT_NOT_INVERTED_ => false,
-            INVW::INPUT_INVERTED_HIGH => true,
+            INVW::NOT_INVERTED => false,
+            INVW::INVERTED => true,
         }
     }
 }
@@ -501,13 +501,13 @@ impl<'a> _INVW<'a> {
     }
     #[doc = "Input not inverted (HIGH on pin reads as 1, LOW on pin reads as 0)."]
     #[inline]
-    pub fn input_not_inverted_(self) -> &'a mut W {
-        self.variant(INVW::INPUT_NOT_INVERTED_)
+    pub fn not_inverted(self) -> &'a mut W {
+        self.variant(INVW::NOT_INVERTED)
     }
     #[doc = "Input inverted (HIGH on pin reads as 0, LOW on pin reads as 1)."]
     #[inline]
-    pub fn input_inverted_high(self) -> &'a mut W {
-        self.variant(INVW::INPUT_INVERTED_HIGH)
+    pub fn inverted(self) -> &'a mut W {
+        self.variant(INVW::INVERTED)
     }
     #[doc = r" Sets the field bit"]
     pub fn set_bit(self) -> &'a mut W {
@@ -530,9 +530,9 @@ impl<'a> _INVW<'a> {
 #[doc = "Values that can be written to the field `OD`"]
 pub enum ODW {
     #[doc = "Disable."]
-    DISABLE_,
+    DISABLED,
     #[doc = "Open-drain mode enabled.  This is not a true open-drain mode."]
-    OPEN_DRAIN_MODE_ENAB,
+    OPEN_DRAIN,
 }
 impl ODW {
     #[allow(missing_docs)]
@@ -540,8 +540,8 @@ impl ODW {
     #[inline]
     pub fn _bits(&self) -> bool {
         match *self {
-            ODW::DISABLE_ => false,
-            ODW::OPEN_DRAIN_MODE_ENAB => true,
+            ODW::DISABLED => false,
+            ODW::OPEN_DRAIN => true,
         }
     }
 }
@@ -559,13 +559,13 @@ impl<'a> _ODW<'a> {
     }
     #[doc = "Disable."]
     #[inline]
-    pub fn disable_(self) -> &'a mut W {
-        self.variant(ODW::DISABLE_)
+    pub fn disabled(self) -> &'a mut W {
+        self.variant(ODW::DISABLED)
     }
     #[doc = "Open-drain mode enabled. This is not a true open-drain mode."]
     #[inline]
-    pub fn open_drain_mode_enab(self) -> &'a mut W {
-        self.variant(ODW::OPEN_DRAIN_MODE_ENAB)
+    pub fn open_drain(self) -> &'a mut W {
+        self.variant(ODW::OPEN_DRAIN)
     }
     #[doc = r" Sets the field bit"]
     pub fn set_bit(self) -> &'a mut W {

--- a/lpc11uxx/src/iocon/pio0_7.rs
+++ b/lpc11uxx/src/iocon/pio0_7.rs
@@ -46,9 +46,9 @@ impl super::PIO0_7 {
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum FUNCR {
     #[doc = "PIO0_7."]
-    PIO0_7_,
+    PIO0_7,
     #[doc = "CTS."]
-    CTS_,
+    CTS,
     #[doc = r" Reserved"]
     _Reserved(u8),
 }
@@ -57,8 +57,8 @@ impl FUNCR {
     #[inline]
     pub fn bits(&self) -> u8 {
         match *self {
-            FUNCR::PIO0_7_ => 0,
-            FUNCR::CTS_ => 1,
+            FUNCR::PIO0_7 => 0,
+            FUNCR::CTS => 1,
             FUNCR::_Reserved(bits) => bits,
         }
     }
@@ -67,43 +67,43 @@ impl FUNCR {
     #[inline]
     pub fn _from(value: u8) -> FUNCR {
         match value {
-            0 => FUNCR::PIO0_7_,
-            1 => FUNCR::CTS_,
+            0 => FUNCR::PIO0_7,
+            1 => FUNCR::CTS,
             i => FUNCR::_Reserved(i),
         }
     }
-    #[doc = "Checks if the value of the field is `PIO0_7_`"]
+    #[doc = "Checks if the value of the field is `PIO0_7`"]
     #[inline]
-    pub fn is_pio0_7_(&self) -> bool {
-        *self == FUNCR::PIO0_7_
+    pub fn is_pio0_7(&self) -> bool {
+        *self == FUNCR::PIO0_7
     }
-    #[doc = "Checks if the value of the field is `CTS_`"]
+    #[doc = "Checks if the value of the field is `CTS`"]
     #[inline]
-    pub fn is_cts_(&self) -> bool {
-        *self == FUNCR::CTS_
+    pub fn is_cts(&self) -> bool {
+        *self == FUNCR::CTS
     }
 }
 #[doc = "Possible values of the field `MODE`"]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum MODER {
     #[doc = "Inactive (no pull-down/pull-up resistor enabled)."]
-    INACTIVE_NO_PULL_DO,
+    INACTIVE,
     #[doc = "Pull-down resistor enabled."]
-    PULL_DOWN_RESISTOR_E,
+    PULL_DOWN,
     #[doc = "Pull-up resistor enabled."]
-    PULL_UP_RESISTOR_ENA,
+    PULL_UP,
     #[doc = "Repeater mode."]
-    REPEATER_MODE_,
+    REPEATER,
 }
 impl MODER {
     #[doc = r" Value of the field as raw bits"]
     #[inline]
     pub fn bits(&self) -> u8 {
         match *self {
-            MODER::INACTIVE_NO_PULL_DO => 0,
-            MODER::PULL_DOWN_RESISTOR_E => 1,
-            MODER::PULL_UP_RESISTOR_ENA => 2,
-            MODER::REPEATER_MODE_ => 3,
+            MODER::INACTIVE => 0,
+            MODER::PULL_DOWN => 1,
+            MODER::PULL_UP => 2,
+            MODER::REPEATER => 3,
         }
     }
     #[allow(missing_docs)]
@@ -111,41 +111,41 @@ impl MODER {
     #[inline]
     pub fn _from(value: u8) -> MODER {
         match value {
-            0 => MODER::INACTIVE_NO_PULL_DO,
-            1 => MODER::PULL_DOWN_RESISTOR_E,
-            2 => MODER::PULL_UP_RESISTOR_ENA,
-            3 => MODER::REPEATER_MODE_,
+            0 => MODER::INACTIVE,
+            1 => MODER::PULL_DOWN,
+            2 => MODER::PULL_UP,
+            3 => MODER::REPEATER,
             _ => unreachable!(),
         }
     }
-    #[doc = "Checks if the value of the field is `INACTIVE_NO_PULL_DO`"]
+    #[doc = "Checks if the value of the field is `INACTIVE`"]
     #[inline]
-    pub fn is_inactive_no_pull_do(&self) -> bool {
-        *self == MODER::INACTIVE_NO_PULL_DO
+    pub fn is_inactive(&self) -> bool {
+        *self == MODER::INACTIVE
     }
-    #[doc = "Checks if the value of the field is `PULL_DOWN_RESISTOR_E`"]
+    #[doc = "Checks if the value of the field is `PULL_DOWN`"]
     #[inline]
-    pub fn is_pull_down_resistor_e(&self) -> bool {
-        *self == MODER::PULL_DOWN_RESISTOR_E
+    pub fn is_pull_down(&self) -> bool {
+        *self == MODER::PULL_DOWN
     }
-    #[doc = "Checks if the value of the field is `PULL_UP_RESISTOR_ENA`"]
+    #[doc = "Checks if the value of the field is `PULL_UP`"]
     #[inline]
-    pub fn is_pull_up_resistor_ena(&self) -> bool {
-        *self == MODER::PULL_UP_RESISTOR_ENA
+    pub fn is_pull_up(&self) -> bool {
+        *self == MODER::PULL_UP
     }
-    #[doc = "Checks if the value of the field is `REPEATER_MODE_`"]
+    #[doc = "Checks if the value of the field is `REPEATER`"]
     #[inline]
-    pub fn is_repeater_mode_(&self) -> bool {
-        *self == MODER::REPEATER_MODE_
+    pub fn is_repeater(&self) -> bool {
+        *self == MODER::REPEATER
     }
 }
 #[doc = "Possible values of the field `HYS`"]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum HYSR {
     #[doc = "Disable."]
-    DISABLE_,
+    DISABLED,
     #[doc = "Enable."]
-    ENABLE_,
+    ENABLED,
 }
 impl HYSR {
     #[doc = r" Returns `true` if the bit is clear (0)"]
@@ -162,8 +162,8 @@ impl HYSR {
     #[inline]
     pub fn bit(&self) -> bool {
         match *self {
-            HYSR::DISABLE_ => false,
-            HYSR::ENABLE_ => true,
+            HYSR::DISABLED => false,
+            HYSR::ENABLED => true,
         }
     }
     #[allow(missing_docs)]
@@ -171,28 +171,28 @@ impl HYSR {
     #[inline]
     pub fn _from(value: bool) -> HYSR {
         match value {
-            false => HYSR::DISABLE_,
-            true => HYSR::ENABLE_,
+            false => HYSR::DISABLED,
+            true => HYSR::ENABLED,
         }
     }
-    #[doc = "Checks if the value of the field is `DISABLE_`"]
+    #[doc = "Checks if the value of the field is `DISABLED`"]
     #[inline]
-    pub fn is_disable_(&self) -> bool {
-        *self == HYSR::DISABLE_
+    pub fn is_disabled(&self) -> bool {
+        *self == HYSR::DISABLED
     }
-    #[doc = "Checks if the value of the field is `ENABLE_`"]
+    #[doc = "Checks if the value of the field is `ENABLED`"]
     #[inline]
-    pub fn is_enable_(&self) -> bool {
-        *self == HYSR::ENABLE_
+    pub fn is_enabled(&self) -> bool {
+        *self == HYSR::ENABLED
     }
 }
 #[doc = "Possible values of the field `INV`"]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum INVR {
     #[doc = "Input not inverted (HIGH on pin reads as 1, LOW on pin reads as 0)."]
-    INPUT_NOT_INVERTED_,
+    NOT_INVERTED,
     #[doc = "Input inverted (HIGH on pin reads as 0, LOW on pin reads as 1)."]
-    INPUT_INVERTED_HIGH,
+    INVERTED,
 }
 impl INVR {
     #[doc = r" Returns `true` if the bit is clear (0)"]
@@ -209,8 +209,8 @@ impl INVR {
     #[inline]
     pub fn bit(&self) -> bool {
         match *self {
-            INVR::INPUT_NOT_INVERTED_ => false,
-            INVR::INPUT_INVERTED_HIGH => true,
+            INVR::NOT_INVERTED => false,
+            INVR::INVERTED => true,
         }
     }
     #[allow(missing_docs)]
@@ -218,28 +218,28 @@ impl INVR {
     #[inline]
     pub fn _from(value: bool) -> INVR {
         match value {
-            false => INVR::INPUT_NOT_INVERTED_,
-            true => INVR::INPUT_INVERTED_HIGH,
+            false => INVR::NOT_INVERTED,
+            true => INVR::INVERTED,
         }
     }
-    #[doc = "Checks if the value of the field is `INPUT_NOT_INVERTED_`"]
+    #[doc = "Checks if the value of the field is `NOT_INVERTED`"]
     #[inline]
-    pub fn is_input_not_inverted_(&self) -> bool {
-        *self == INVR::INPUT_NOT_INVERTED_
+    pub fn is_not_inverted(&self) -> bool {
+        *self == INVR::NOT_INVERTED
     }
-    #[doc = "Checks if the value of the field is `INPUT_INVERTED_HIGH`"]
+    #[doc = "Checks if the value of the field is `INVERTED`"]
     #[inline]
-    pub fn is_input_inverted_high(&self) -> bool {
-        *self == INVR::INPUT_INVERTED_HIGH
+    pub fn is_inverted(&self) -> bool {
+        *self == INVR::INVERTED
     }
 }
 #[doc = "Possible values of the field `OD`"]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum ODR {
     #[doc = "Disable."]
-    DISABLE_,
+    DISABLED,
     #[doc = "Open-drain mode enabled.  This is not a true open-drain mode."]
-    OPEN_DRAIN_MODE_ENAB,
+    OPEN_DRAIN,
 }
 impl ODR {
     #[doc = r" Returns `true` if the bit is clear (0)"]
@@ -256,8 +256,8 @@ impl ODR {
     #[inline]
     pub fn bit(&self) -> bool {
         match *self {
-            ODR::DISABLE_ => false,
-            ODR::OPEN_DRAIN_MODE_ENAB => true,
+            ODR::DISABLED => false,
+            ODR::OPEN_DRAIN => true,
         }
     }
     #[allow(missing_docs)]
@@ -265,27 +265,27 @@ impl ODR {
     #[inline]
     pub fn _from(value: bool) -> ODR {
         match value {
-            false => ODR::DISABLE_,
-            true => ODR::OPEN_DRAIN_MODE_ENAB,
+            false => ODR::DISABLED,
+            true => ODR::OPEN_DRAIN,
         }
     }
-    #[doc = "Checks if the value of the field is `DISABLE_`"]
+    #[doc = "Checks if the value of the field is `DISABLED`"]
     #[inline]
-    pub fn is_disable_(&self) -> bool {
-        *self == ODR::DISABLE_
+    pub fn is_disabled(&self) -> bool {
+        *self == ODR::DISABLED
     }
-    #[doc = "Checks if the value of the field is `OPEN_DRAIN_MODE_ENAB`"]
+    #[doc = "Checks if the value of the field is `OPEN_DRAIN`"]
     #[inline]
-    pub fn is_open_drain_mode_enab(&self) -> bool {
-        *self == ODR::OPEN_DRAIN_MODE_ENAB
+    pub fn is_open_drain(&self) -> bool {
+        *self == ODR::OPEN_DRAIN
     }
 }
 #[doc = "Values that can be written to the field `FUNC`"]
 pub enum FUNCW {
     #[doc = "PIO0_7."]
-    PIO0_7_,
+    PIO0_7,
     #[doc = "CTS."]
-    CTS_,
+    CTS,
 }
 impl FUNCW {
     #[allow(missing_docs)]
@@ -293,8 +293,8 @@ impl FUNCW {
     #[inline]
     pub fn _bits(&self) -> u8 {
         match *self {
-            FUNCW::PIO0_7_ => 0,
-            FUNCW::CTS_ => 1,
+            FUNCW::PIO0_7 => 0,
+            FUNCW::CTS => 1,
         }
     }
 }
@@ -310,13 +310,13 @@ impl<'a> _FUNCW<'a> {
     }
     #[doc = "PIO0_7."]
     #[inline]
-    pub fn pio0_7_(self) -> &'a mut W {
-        self.variant(FUNCW::PIO0_7_)
+    pub fn pio0_7(self) -> &'a mut W {
+        self.variant(FUNCW::PIO0_7)
     }
     #[doc = "CTS."]
     #[inline]
-    pub fn cts_(self) -> &'a mut W {
-        self.variant(FUNCW::CTS_)
+    pub fn cts(self) -> &'a mut W {
+        self.variant(FUNCW::CTS)
     }
     #[doc = r" Writes raw bits to the field"]
     #[inline]
@@ -331,13 +331,13 @@ impl<'a> _FUNCW<'a> {
 #[doc = "Values that can be written to the field `MODE`"]
 pub enum MODEW {
     #[doc = "Inactive (no pull-down/pull-up resistor enabled)."]
-    INACTIVE_NO_PULL_DO,
+    INACTIVE,
     #[doc = "Pull-down resistor enabled."]
-    PULL_DOWN_RESISTOR_E,
+    PULL_DOWN,
     #[doc = "Pull-up resistor enabled."]
-    PULL_UP_RESISTOR_ENA,
+    PULL_UP,
     #[doc = "Repeater mode."]
-    REPEATER_MODE_,
+    REPEATER,
 }
 impl MODEW {
     #[allow(missing_docs)]
@@ -345,10 +345,10 @@ impl MODEW {
     #[inline]
     pub fn _bits(&self) -> u8 {
         match *self {
-            MODEW::INACTIVE_NO_PULL_DO => 0,
-            MODEW::PULL_DOWN_RESISTOR_E => 1,
-            MODEW::PULL_UP_RESISTOR_ENA => 2,
-            MODEW::REPEATER_MODE_ => 3,
+            MODEW::INACTIVE => 0,
+            MODEW::PULL_DOWN => 1,
+            MODEW::PULL_UP => 2,
+            MODEW::REPEATER => 3,
         }
     }
 }
@@ -366,23 +366,23 @@ impl<'a> _MODEW<'a> {
     }
     #[doc = "Inactive (no pull-down/pull-up resistor enabled)."]
     #[inline]
-    pub fn inactive_no_pull_do(self) -> &'a mut W {
-        self.variant(MODEW::INACTIVE_NO_PULL_DO)
+    pub fn inactive(self) -> &'a mut W {
+        self.variant(MODEW::INACTIVE)
     }
     #[doc = "Pull-down resistor enabled."]
     #[inline]
-    pub fn pull_down_resistor_e(self) -> &'a mut W {
-        self.variant(MODEW::PULL_DOWN_RESISTOR_E)
+    pub fn pull_down(self) -> &'a mut W {
+        self.variant(MODEW::PULL_DOWN)
     }
     #[doc = "Pull-up resistor enabled."]
     #[inline]
-    pub fn pull_up_resistor_ena(self) -> &'a mut W {
-        self.variant(MODEW::PULL_UP_RESISTOR_ENA)
+    pub fn pull_up(self) -> &'a mut W {
+        self.variant(MODEW::PULL_UP)
     }
     #[doc = "Repeater mode."]
     #[inline]
-    pub fn repeater_mode_(self) -> &'a mut W {
-        self.variant(MODEW::REPEATER_MODE_)
+    pub fn repeater(self) -> &'a mut W {
+        self.variant(MODEW::REPEATER)
     }
     #[doc = r" Writes raw bits to the field"]
     #[inline]
@@ -397,9 +397,9 @@ impl<'a> _MODEW<'a> {
 #[doc = "Values that can be written to the field `HYS`"]
 pub enum HYSW {
     #[doc = "Disable."]
-    DISABLE_,
+    DISABLED,
     #[doc = "Enable."]
-    ENABLE_,
+    ENABLED,
 }
 impl HYSW {
     #[allow(missing_docs)]
@@ -407,8 +407,8 @@ impl HYSW {
     #[inline]
     pub fn _bits(&self) -> bool {
         match *self {
-            HYSW::DISABLE_ => false,
-            HYSW::ENABLE_ => true,
+            HYSW::DISABLED => false,
+            HYSW::ENABLED => true,
         }
     }
 }
@@ -426,13 +426,13 @@ impl<'a> _HYSW<'a> {
     }
     #[doc = "Disable."]
     #[inline]
-    pub fn disable_(self) -> &'a mut W {
-        self.variant(HYSW::DISABLE_)
+    pub fn disabled(self) -> &'a mut W {
+        self.variant(HYSW::DISABLED)
     }
     #[doc = "Enable."]
     #[inline]
-    pub fn enable_(self) -> &'a mut W {
-        self.variant(HYSW::ENABLE_)
+    pub fn enabled(self) -> &'a mut W {
+        self.variant(HYSW::ENABLED)
     }
     #[doc = r" Sets the field bit"]
     pub fn set_bit(self) -> &'a mut W {
@@ -455,9 +455,9 @@ impl<'a> _HYSW<'a> {
 #[doc = "Values that can be written to the field `INV`"]
 pub enum INVW {
     #[doc = "Input not inverted (HIGH on pin reads as 1, LOW on pin reads as 0)."]
-    INPUT_NOT_INVERTED_,
+    NOT_INVERTED,
     #[doc = "Input inverted (HIGH on pin reads as 0, LOW on pin reads as 1)."]
-    INPUT_INVERTED_HIGH,
+    INVERTED,
 }
 impl INVW {
     #[allow(missing_docs)]
@@ -465,8 +465,8 @@ impl INVW {
     #[inline]
     pub fn _bits(&self) -> bool {
         match *self {
-            INVW::INPUT_NOT_INVERTED_ => false,
-            INVW::INPUT_INVERTED_HIGH => true,
+            INVW::NOT_INVERTED => false,
+            INVW::INVERTED => true,
         }
     }
 }
@@ -484,13 +484,13 @@ impl<'a> _INVW<'a> {
     }
     #[doc = "Input not inverted (HIGH on pin reads as 1, LOW on pin reads as 0)."]
     #[inline]
-    pub fn input_not_inverted_(self) -> &'a mut W {
-        self.variant(INVW::INPUT_NOT_INVERTED_)
+    pub fn not_inverted(self) -> &'a mut W {
+        self.variant(INVW::NOT_INVERTED)
     }
     #[doc = "Input inverted (HIGH on pin reads as 0, LOW on pin reads as 1)."]
     #[inline]
-    pub fn input_inverted_high(self) -> &'a mut W {
-        self.variant(INVW::INPUT_INVERTED_HIGH)
+    pub fn inverted(self) -> &'a mut W {
+        self.variant(INVW::INVERTED)
     }
     #[doc = r" Sets the field bit"]
     pub fn set_bit(self) -> &'a mut W {
@@ -513,9 +513,9 @@ impl<'a> _INVW<'a> {
 #[doc = "Values that can be written to the field `OD`"]
 pub enum ODW {
     #[doc = "Disable."]
-    DISABLE_,
+    DISABLED,
     #[doc = "Open-drain mode enabled.  This is not a true open-drain mode."]
-    OPEN_DRAIN_MODE_ENAB,
+    OPEN_DRAIN,
 }
 impl ODW {
     #[allow(missing_docs)]
@@ -523,8 +523,8 @@ impl ODW {
     #[inline]
     pub fn _bits(&self) -> bool {
         match *self {
-            ODW::DISABLE_ => false,
-            ODW::OPEN_DRAIN_MODE_ENAB => true,
+            ODW::DISABLED => false,
+            ODW::OPEN_DRAIN => true,
         }
     }
 }
@@ -542,13 +542,13 @@ impl<'a> _ODW<'a> {
     }
     #[doc = "Disable."]
     #[inline]
-    pub fn disable_(self) -> &'a mut W {
-        self.variant(ODW::DISABLE_)
+    pub fn disabled(self) -> &'a mut W {
+        self.variant(ODW::DISABLED)
     }
     #[doc = "Open-drain mode enabled. This is not a true open-drain mode."]
     #[inline]
-    pub fn open_drain_mode_enab(self) -> &'a mut W {
-        self.variant(ODW::OPEN_DRAIN_MODE_ENAB)
+    pub fn open_drain(self) -> &'a mut W {
+        self.variant(ODW::OPEN_DRAIN)
     }
     #[doc = r" Sets the field bit"]
     pub fn set_bit(self) -> &'a mut W {

--- a/lpc11uxx/src/iocon/pio0_8.rs
+++ b/lpc11uxx/src/iocon/pio0_8.rs
@@ -46,11 +46,11 @@ impl super::PIO0_8 {
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum FUNCR {
     #[doc = "PIO0_8."]
-    PIO0_8_,
+    PIO0_8,
     #[doc = "MISO0."]
-    MISO0_,
+    MISO0,
     #[doc = "CT16B0_MAT0."]
-    CT16B0_MAT0_,
+    CT16B0_MAT0,
     #[doc = r" Reserved"]
     _Reserved(u8),
 }
@@ -59,9 +59,9 @@ impl FUNCR {
     #[inline]
     pub fn bits(&self) -> u8 {
         match *self {
-            FUNCR::PIO0_8_ => 0,
-            FUNCR::MISO0_ => 1,
-            FUNCR::CT16B0_MAT0_ => 2,
+            FUNCR::PIO0_8 => 0,
+            FUNCR::MISO0 => 1,
+            FUNCR::CT16B0_MAT0 => 2,
             FUNCR::_Reserved(bits) => bits,
         }
     }
@@ -70,49 +70,49 @@ impl FUNCR {
     #[inline]
     pub fn _from(value: u8) -> FUNCR {
         match value {
-            0 => FUNCR::PIO0_8_,
-            1 => FUNCR::MISO0_,
-            2 => FUNCR::CT16B0_MAT0_,
+            0 => FUNCR::PIO0_8,
+            1 => FUNCR::MISO0,
+            2 => FUNCR::CT16B0_MAT0,
             i => FUNCR::_Reserved(i),
         }
     }
-    #[doc = "Checks if the value of the field is `PIO0_8_`"]
+    #[doc = "Checks if the value of the field is `PIO0_8`"]
     #[inline]
-    pub fn is_pio0_8_(&self) -> bool {
-        *self == FUNCR::PIO0_8_
+    pub fn is_pio0_8(&self) -> bool {
+        *self == FUNCR::PIO0_8
     }
-    #[doc = "Checks if the value of the field is `MISO0_`"]
+    #[doc = "Checks if the value of the field is `MISO0`"]
     #[inline]
-    pub fn is_miso0_(&self) -> bool {
-        *self == FUNCR::MISO0_
+    pub fn is_miso0(&self) -> bool {
+        *self == FUNCR::MISO0
     }
-    #[doc = "Checks if the value of the field is `CT16B0_MAT0_`"]
+    #[doc = "Checks if the value of the field is `CT16B0_MAT0`"]
     #[inline]
-    pub fn is_ct16b0_mat0_(&self) -> bool {
-        *self == FUNCR::CT16B0_MAT0_
+    pub fn is_ct16b0_mat0(&self) -> bool {
+        *self == FUNCR::CT16B0_MAT0
     }
 }
 #[doc = "Possible values of the field `MODE`"]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum MODER {
     #[doc = "Inactive (no pull-down/pull-up resistor enabled)."]
-    INACTIVE_NO_PULL_DO,
+    INACTIVE,
     #[doc = "Pull-down resistor enabled."]
-    PULL_DOWN_RESISTOR_E,
+    PULL_DOWN,
     #[doc = "Pull-up resistor enabled."]
-    PULL_UP_RESISTOR_ENA,
+    PULL_UP,
     #[doc = "Repeater mode."]
-    REPEATER_MODE_,
+    REPEATER,
 }
 impl MODER {
     #[doc = r" Value of the field as raw bits"]
     #[inline]
     pub fn bits(&self) -> u8 {
         match *self {
-            MODER::INACTIVE_NO_PULL_DO => 0,
-            MODER::PULL_DOWN_RESISTOR_E => 1,
-            MODER::PULL_UP_RESISTOR_ENA => 2,
-            MODER::REPEATER_MODE_ => 3,
+            MODER::INACTIVE => 0,
+            MODER::PULL_DOWN => 1,
+            MODER::PULL_UP => 2,
+            MODER::REPEATER => 3,
         }
     }
     #[allow(missing_docs)]
@@ -120,41 +120,41 @@ impl MODER {
     #[inline]
     pub fn _from(value: u8) -> MODER {
         match value {
-            0 => MODER::INACTIVE_NO_PULL_DO,
-            1 => MODER::PULL_DOWN_RESISTOR_E,
-            2 => MODER::PULL_UP_RESISTOR_ENA,
-            3 => MODER::REPEATER_MODE_,
+            0 => MODER::INACTIVE,
+            1 => MODER::PULL_DOWN,
+            2 => MODER::PULL_UP,
+            3 => MODER::REPEATER,
             _ => unreachable!(),
         }
     }
-    #[doc = "Checks if the value of the field is `INACTIVE_NO_PULL_DO`"]
+    #[doc = "Checks if the value of the field is `INACTIVE`"]
     #[inline]
-    pub fn is_inactive_no_pull_do(&self) -> bool {
-        *self == MODER::INACTIVE_NO_PULL_DO
+    pub fn is_inactive(&self) -> bool {
+        *self == MODER::INACTIVE
     }
-    #[doc = "Checks if the value of the field is `PULL_DOWN_RESISTOR_E`"]
+    #[doc = "Checks if the value of the field is `PULL_DOWN`"]
     #[inline]
-    pub fn is_pull_down_resistor_e(&self) -> bool {
-        *self == MODER::PULL_DOWN_RESISTOR_E
+    pub fn is_pull_down(&self) -> bool {
+        *self == MODER::PULL_DOWN
     }
-    #[doc = "Checks if the value of the field is `PULL_UP_RESISTOR_ENA`"]
+    #[doc = "Checks if the value of the field is `PULL_UP`"]
     #[inline]
-    pub fn is_pull_up_resistor_ena(&self) -> bool {
-        *self == MODER::PULL_UP_RESISTOR_ENA
+    pub fn is_pull_up(&self) -> bool {
+        *self == MODER::PULL_UP
     }
-    #[doc = "Checks if the value of the field is `REPEATER_MODE_`"]
+    #[doc = "Checks if the value of the field is `REPEATER`"]
     #[inline]
-    pub fn is_repeater_mode_(&self) -> bool {
-        *self == MODER::REPEATER_MODE_
+    pub fn is_repeater(&self) -> bool {
+        *self == MODER::REPEATER
     }
 }
 #[doc = "Possible values of the field `HYS`"]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum HYSR {
     #[doc = "Disable."]
-    DISABLE_,
+    DISABLED,
     #[doc = "Enable."]
-    ENABLE_,
+    ENABLED,
 }
 impl HYSR {
     #[doc = r" Returns `true` if the bit is clear (0)"]
@@ -171,8 +171,8 @@ impl HYSR {
     #[inline]
     pub fn bit(&self) -> bool {
         match *self {
-            HYSR::DISABLE_ => false,
-            HYSR::ENABLE_ => true,
+            HYSR::DISABLED => false,
+            HYSR::ENABLED => true,
         }
     }
     #[allow(missing_docs)]
@@ -180,28 +180,28 @@ impl HYSR {
     #[inline]
     pub fn _from(value: bool) -> HYSR {
         match value {
-            false => HYSR::DISABLE_,
-            true => HYSR::ENABLE_,
+            false => HYSR::DISABLED,
+            true => HYSR::ENABLED,
         }
     }
-    #[doc = "Checks if the value of the field is `DISABLE_`"]
+    #[doc = "Checks if the value of the field is `DISABLED`"]
     #[inline]
-    pub fn is_disable_(&self) -> bool {
-        *self == HYSR::DISABLE_
+    pub fn is_disabled(&self) -> bool {
+        *self == HYSR::DISABLED
     }
-    #[doc = "Checks if the value of the field is `ENABLE_`"]
+    #[doc = "Checks if the value of the field is `ENABLED`"]
     #[inline]
-    pub fn is_enable_(&self) -> bool {
-        *self == HYSR::ENABLE_
+    pub fn is_enabled(&self) -> bool {
+        *self == HYSR::ENABLED
     }
 }
 #[doc = "Possible values of the field `INV`"]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum INVR {
     #[doc = "Input not inverted (HIGH on pin reads as 1, LOW on pin reads as 0)."]
-    INPUT_NOT_INVERTED_,
+    NOT_INVERTED,
     #[doc = "Input inverted (HIGH on pin reads as 0, LOW on pin reads as 1)."]
-    INPUT_INVERTED_HIGH,
+    INVERTED,
 }
 impl INVR {
     #[doc = r" Returns `true` if the bit is clear (0)"]
@@ -218,8 +218,8 @@ impl INVR {
     #[inline]
     pub fn bit(&self) -> bool {
         match *self {
-            INVR::INPUT_NOT_INVERTED_ => false,
-            INVR::INPUT_INVERTED_HIGH => true,
+            INVR::NOT_INVERTED => false,
+            INVR::INVERTED => true,
         }
     }
     #[allow(missing_docs)]
@@ -227,28 +227,28 @@ impl INVR {
     #[inline]
     pub fn _from(value: bool) -> INVR {
         match value {
-            false => INVR::INPUT_NOT_INVERTED_,
-            true => INVR::INPUT_INVERTED_HIGH,
+            false => INVR::NOT_INVERTED,
+            true => INVR::INVERTED,
         }
     }
-    #[doc = "Checks if the value of the field is `INPUT_NOT_INVERTED_`"]
+    #[doc = "Checks if the value of the field is `NOT_INVERTED`"]
     #[inline]
-    pub fn is_input_not_inverted_(&self) -> bool {
-        *self == INVR::INPUT_NOT_INVERTED_
+    pub fn is_not_inverted(&self) -> bool {
+        *self == INVR::NOT_INVERTED
     }
-    #[doc = "Checks if the value of the field is `INPUT_INVERTED_HIGH`"]
+    #[doc = "Checks if the value of the field is `INVERTED`"]
     #[inline]
-    pub fn is_input_inverted_high(&self) -> bool {
-        *self == INVR::INPUT_INVERTED_HIGH
+    pub fn is_inverted(&self) -> bool {
+        *self == INVR::INVERTED
     }
 }
 #[doc = "Possible values of the field `OD`"]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum ODR {
     #[doc = "Disable."]
-    DISABLE_,
+    DISABLED,
     #[doc = "Open-drain mode enabled.  This is not a true open-drain mode."]
-    OPEN_DRAIN_MODE_ENAB,
+    OPEN_DRAIN,
 }
 impl ODR {
     #[doc = r" Returns `true` if the bit is clear (0)"]
@@ -265,8 +265,8 @@ impl ODR {
     #[inline]
     pub fn bit(&self) -> bool {
         match *self {
-            ODR::DISABLE_ => false,
-            ODR::OPEN_DRAIN_MODE_ENAB => true,
+            ODR::DISABLED => false,
+            ODR::OPEN_DRAIN => true,
         }
     }
     #[allow(missing_docs)]
@@ -274,29 +274,29 @@ impl ODR {
     #[inline]
     pub fn _from(value: bool) -> ODR {
         match value {
-            false => ODR::DISABLE_,
-            true => ODR::OPEN_DRAIN_MODE_ENAB,
+            false => ODR::DISABLED,
+            true => ODR::OPEN_DRAIN,
         }
     }
-    #[doc = "Checks if the value of the field is `DISABLE_`"]
+    #[doc = "Checks if the value of the field is `DISABLED`"]
     #[inline]
-    pub fn is_disable_(&self) -> bool {
-        *self == ODR::DISABLE_
+    pub fn is_disabled(&self) -> bool {
+        *self == ODR::DISABLED
     }
-    #[doc = "Checks if the value of the field is `OPEN_DRAIN_MODE_ENAB`"]
+    #[doc = "Checks if the value of the field is `OPEN_DRAIN`"]
     #[inline]
-    pub fn is_open_drain_mode_enab(&self) -> bool {
-        *self == ODR::OPEN_DRAIN_MODE_ENAB
+    pub fn is_open_drain(&self) -> bool {
+        *self == ODR::OPEN_DRAIN
     }
 }
 #[doc = "Values that can be written to the field `FUNC`"]
 pub enum FUNCW {
     #[doc = "PIO0_8."]
-    PIO0_8_,
+    PIO0_8,
     #[doc = "MISO0."]
-    MISO0_,
+    MISO0,
     #[doc = "CT16B0_MAT0."]
-    CT16B0_MAT0_,
+    CT16B0_MAT0,
 }
 impl FUNCW {
     #[allow(missing_docs)]
@@ -304,9 +304,9 @@ impl FUNCW {
     #[inline]
     pub fn _bits(&self) -> u8 {
         match *self {
-            FUNCW::PIO0_8_ => 0,
-            FUNCW::MISO0_ => 1,
-            FUNCW::CT16B0_MAT0_ => 2,
+            FUNCW::PIO0_8 => 0,
+            FUNCW::MISO0 => 1,
+            FUNCW::CT16B0_MAT0 => 2,
         }
     }
 }
@@ -322,18 +322,18 @@ impl<'a> _FUNCW<'a> {
     }
     #[doc = "PIO0_8."]
     #[inline]
-    pub fn pio0_8_(self) -> &'a mut W {
-        self.variant(FUNCW::PIO0_8_)
+    pub fn pio0_8(self) -> &'a mut W {
+        self.variant(FUNCW::PIO0_8)
     }
     #[doc = "MISO0."]
     #[inline]
-    pub fn miso0_(self) -> &'a mut W {
-        self.variant(FUNCW::MISO0_)
+    pub fn miso0(self) -> &'a mut W {
+        self.variant(FUNCW::MISO0)
     }
     #[doc = "CT16B0_MAT0."]
     #[inline]
-    pub fn ct16b0_mat0_(self) -> &'a mut W {
-        self.variant(FUNCW::CT16B0_MAT0_)
+    pub fn ct16b0_mat0(self) -> &'a mut W {
+        self.variant(FUNCW::CT16B0_MAT0)
     }
     #[doc = r" Writes raw bits to the field"]
     #[inline]
@@ -348,13 +348,13 @@ impl<'a> _FUNCW<'a> {
 #[doc = "Values that can be written to the field `MODE`"]
 pub enum MODEW {
     #[doc = "Inactive (no pull-down/pull-up resistor enabled)."]
-    INACTIVE_NO_PULL_DO,
+    INACTIVE,
     #[doc = "Pull-down resistor enabled."]
-    PULL_DOWN_RESISTOR_E,
+    PULL_DOWN,
     #[doc = "Pull-up resistor enabled."]
-    PULL_UP_RESISTOR_ENA,
+    PULL_UP,
     #[doc = "Repeater mode."]
-    REPEATER_MODE_,
+    REPEATER,
 }
 impl MODEW {
     #[allow(missing_docs)]
@@ -362,10 +362,10 @@ impl MODEW {
     #[inline]
     pub fn _bits(&self) -> u8 {
         match *self {
-            MODEW::INACTIVE_NO_PULL_DO => 0,
-            MODEW::PULL_DOWN_RESISTOR_E => 1,
-            MODEW::PULL_UP_RESISTOR_ENA => 2,
-            MODEW::REPEATER_MODE_ => 3,
+            MODEW::INACTIVE => 0,
+            MODEW::PULL_DOWN => 1,
+            MODEW::PULL_UP => 2,
+            MODEW::REPEATER => 3,
         }
     }
 }
@@ -383,23 +383,23 @@ impl<'a> _MODEW<'a> {
     }
     #[doc = "Inactive (no pull-down/pull-up resistor enabled)."]
     #[inline]
-    pub fn inactive_no_pull_do(self) -> &'a mut W {
-        self.variant(MODEW::INACTIVE_NO_PULL_DO)
+    pub fn inactive(self) -> &'a mut W {
+        self.variant(MODEW::INACTIVE)
     }
     #[doc = "Pull-down resistor enabled."]
     #[inline]
-    pub fn pull_down_resistor_e(self) -> &'a mut W {
-        self.variant(MODEW::PULL_DOWN_RESISTOR_E)
+    pub fn pull_down(self) -> &'a mut W {
+        self.variant(MODEW::PULL_DOWN)
     }
     #[doc = "Pull-up resistor enabled."]
     #[inline]
-    pub fn pull_up_resistor_ena(self) -> &'a mut W {
-        self.variant(MODEW::PULL_UP_RESISTOR_ENA)
+    pub fn pull_up(self) -> &'a mut W {
+        self.variant(MODEW::PULL_UP)
     }
     #[doc = "Repeater mode."]
     #[inline]
-    pub fn repeater_mode_(self) -> &'a mut W {
-        self.variant(MODEW::REPEATER_MODE_)
+    pub fn repeater(self) -> &'a mut W {
+        self.variant(MODEW::REPEATER)
     }
     #[doc = r" Writes raw bits to the field"]
     #[inline]
@@ -414,9 +414,9 @@ impl<'a> _MODEW<'a> {
 #[doc = "Values that can be written to the field `HYS`"]
 pub enum HYSW {
     #[doc = "Disable."]
-    DISABLE_,
+    DISABLED,
     #[doc = "Enable."]
-    ENABLE_,
+    ENABLED,
 }
 impl HYSW {
     #[allow(missing_docs)]
@@ -424,8 +424,8 @@ impl HYSW {
     #[inline]
     pub fn _bits(&self) -> bool {
         match *self {
-            HYSW::DISABLE_ => false,
-            HYSW::ENABLE_ => true,
+            HYSW::DISABLED => false,
+            HYSW::ENABLED => true,
         }
     }
 }
@@ -443,13 +443,13 @@ impl<'a> _HYSW<'a> {
     }
     #[doc = "Disable."]
     #[inline]
-    pub fn disable_(self) -> &'a mut W {
-        self.variant(HYSW::DISABLE_)
+    pub fn disabled(self) -> &'a mut W {
+        self.variant(HYSW::DISABLED)
     }
     #[doc = "Enable."]
     #[inline]
-    pub fn enable_(self) -> &'a mut W {
-        self.variant(HYSW::ENABLE_)
+    pub fn enabled(self) -> &'a mut W {
+        self.variant(HYSW::ENABLED)
     }
     #[doc = r" Sets the field bit"]
     pub fn set_bit(self) -> &'a mut W {
@@ -472,9 +472,9 @@ impl<'a> _HYSW<'a> {
 #[doc = "Values that can be written to the field `INV`"]
 pub enum INVW {
     #[doc = "Input not inverted (HIGH on pin reads as 1, LOW on pin reads as 0)."]
-    INPUT_NOT_INVERTED_,
+    NOT_INVERTED,
     #[doc = "Input inverted (HIGH on pin reads as 0, LOW on pin reads as 1)."]
-    INPUT_INVERTED_HIGH,
+    INVERTED,
 }
 impl INVW {
     #[allow(missing_docs)]
@@ -482,8 +482,8 @@ impl INVW {
     #[inline]
     pub fn _bits(&self) -> bool {
         match *self {
-            INVW::INPUT_NOT_INVERTED_ => false,
-            INVW::INPUT_INVERTED_HIGH => true,
+            INVW::NOT_INVERTED => false,
+            INVW::INVERTED => true,
         }
     }
 }
@@ -501,13 +501,13 @@ impl<'a> _INVW<'a> {
     }
     #[doc = "Input not inverted (HIGH on pin reads as 1, LOW on pin reads as 0)."]
     #[inline]
-    pub fn input_not_inverted_(self) -> &'a mut W {
-        self.variant(INVW::INPUT_NOT_INVERTED_)
+    pub fn not_inverted(self) -> &'a mut W {
+        self.variant(INVW::NOT_INVERTED)
     }
     #[doc = "Input inverted (HIGH on pin reads as 0, LOW on pin reads as 1)."]
     #[inline]
-    pub fn input_inverted_high(self) -> &'a mut W {
-        self.variant(INVW::INPUT_INVERTED_HIGH)
+    pub fn inverted(self) -> &'a mut W {
+        self.variant(INVW::INVERTED)
     }
     #[doc = r" Sets the field bit"]
     pub fn set_bit(self) -> &'a mut W {
@@ -530,9 +530,9 @@ impl<'a> _INVW<'a> {
 #[doc = "Values that can be written to the field `OD`"]
 pub enum ODW {
     #[doc = "Disable."]
-    DISABLE_,
+    DISABLED,
     #[doc = "Open-drain mode enabled.  This is not a true open-drain mode."]
-    OPEN_DRAIN_MODE_ENAB,
+    OPEN_DRAIN,
 }
 impl ODW {
     #[allow(missing_docs)]
@@ -540,8 +540,8 @@ impl ODW {
     #[inline]
     pub fn _bits(&self) -> bool {
         match *self {
-            ODW::DISABLE_ => false,
-            ODW::OPEN_DRAIN_MODE_ENAB => true,
+            ODW::DISABLED => false,
+            ODW::OPEN_DRAIN => true,
         }
     }
 }
@@ -559,13 +559,13 @@ impl<'a> _ODW<'a> {
     }
     #[doc = "Disable."]
     #[inline]
-    pub fn disable_(self) -> &'a mut W {
-        self.variant(ODW::DISABLE_)
+    pub fn disabled(self) -> &'a mut W {
+        self.variant(ODW::DISABLED)
     }
     #[doc = "Open-drain mode enabled. This is not a true open-drain mode."]
     #[inline]
-    pub fn open_drain_mode_enab(self) -> &'a mut W {
-        self.variant(ODW::OPEN_DRAIN_MODE_ENAB)
+    pub fn open_drain(self) -> &'a mut W {
+        self.variant(ODW::OPEN_DRAIN)
     }
     #[doc = r" Sets the field bit"]
     pub fn set_bit(self) -> &'a mut W {

--- a/lpc11uxx/src/iocon/pio0_9.rs
+++ b/lpc11uxx/src/iocon/pio0_9.rs
@@ -46,11 +46,11 @@ impl super::PIO0_9 {
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum FUNCR {
     #[doc = "PIO0_9."]
-    PIO0_9_,
+    PIO0_9,
     #[doc = "MOSI0."]
-    MOSI0_,
+    MOSI0,
     #[doc = "CT16B0_MAT1."]
-    CT16B0_MAT1_,
+    CT16B0_MAT1,
     #[doc = r" Reserved"]
     _Reserved(u8),
 }
@@ -59,9 +59,9 @@ impl FUNCR {
     #[inline]
     pub fn bits(&self) -> u8 {
         match *self {
-            FUNCR::PIO0_9_ => 0,
-            FUNCR::MOSI0_ => 1,
-            FUNCR::CT16B0_MAT1_ => 2,
+            FUNCR::PIO0_9 => 0,
+            FUNCR::MOSI0 => 1,
+            FUNCR::CT16B0_MAT1 => 2,
             FUNCR::_Reserved(bits) => bits,
         }
     }
@@ -70,49 +70,49 @@ impl FUNCR {
     #[inline]
     pub fn _from(value: u8) -> FUNCR {
         match value {
-            0 => FUNCR::PIO0_9_,
-            1 => FUNCR::MOSI0_,
-            2 => FUNCR::CT16B0_MAT1_,
+            0 => FUNCR::PIO0_9,
+            1 => FUNCR::MOSI0,
+            2 => FUNCR::CT16B0_MAT1,
             i => FUNCR::_Reserved(i),
         }
     }
-    #[doc = "Checks if the value of the field is `PIO0_9_`"]
+    #[doc = "Checks if the value of the field is `PIO0_9`"]
     #[inline]
-    pub fn is_pio0_9_(&self) -> bool {
-        *self == FUNCR::PIO0_9_
+    pub fn is_pio0_9(&self) -> bool {
+        *self == FUNCR::PIO0_9
     }
-    #[doc = "Checks if the value of the field is `MOSI0_`"]
+    #[doc = "Checks if the value of the field is `MOSI0`"]
     #[inline]
-    pub fn is_mosi0_(&self) -> bool {
-        *self == FUNCR::MOSI0_
+    pub fn is_mosi0(&self) -> bool {
+        *self == FUNCR::MOSI0
     }
-    #[doc = "Checks if the value of the field is `CT16B0_MAT1_`"]
+    #[doc = "Checks if the value of the field is `CT16B0_MAT1`"]
     #[inline]
-    pub fn is_ct16b0_mat1_(&self) -> bool {
-        *self == FUNCR::CT16B0_MAT1_
+    pub fn is_ct16b0_mat1(&self) -> bool {
+        *self == FUNCR::CT16B0_MAT1
     }
 }
 #[doc = "Possible values of the field `MODE`"]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum MODER {
     #[doc = "Inactive (no pull-down/pull-up resistor enabled)."]
-    INACTIVE_NO_PULL_DO,
+    INACTIVE,
     #[doc = "Pull-down resistor enabled."]
-    PULL_DOWN_RESISTOR_E,
+    PULL_DOWN,
     #[doc = "Pull-up resistor enabled."]
-    PULL_UP_RESISTOR_ENA,
+    PULL_UP,
     #[doc = "Repeater mode."]
-    REPEATER_MODE_,
+    REPEATER,
 }
 impl MODER {
     #[doc = r" Value of the field as raw bits"]
     #[inline]
     pub fn bits(&self) -> u8 {
         match *self {
-            MODER::INACTIVE_NO_PULL_DO => 0,
-            MODER::PULL_DOWN_RESISTOR_E => 1,
-            MODER::PULL_UP_RESISTOR_ENA => 2,
-            MODER::REPEATER_MODE_ => 3,
+            MODER::INACTIVE => 0,
+            MODER::PULL_DOWN => 1,
+            MODER::PULL_UP => 2,
+            MODER::REPEATER => 3,
         }
     }
     #[allow(missing_docs)]
@@ -120,41 +120,41 @@ impl MODER {
     #[inline]
     pub fn _from(value: u8) -> MODER {
         match value {
-            0 => MODER::INACTIVE_NO_PULL_DO,
-            1 => MODER::PULL_DOWN_RESISTOR_E,
-            2 => MODER::PULL_UP_RESISTOR_ENA,
-            3 => MODER::REPEATER_MODE_,
+            0 => MODER::INACTIVE,
+            1 => MODER::PULL_DOWN,
+            2 => MODER::PULL_UP,
+            3 => MODER::REPEATER,
             _ => unreachable!(),
         }
     }
-    #[doc = "Checks if the value of the field is `INACTIVE_NO_PULL_DO`"]
+    #[doc = "Checks if the value of the field is `INACTIVE`"]
     #[inline]
-    pub fn is_inactive_no_pull_do(&self) -> bool {
-        *self == MODER::INACTIVE_NO_PULL_DO
+    pub fn is_inactive(&self) -> bool {
+        *self == MODER::INACTIVE
     }
-    #[doc = "Checks if the value of the field is `PULL_DOWN_RESISTOR_E`"]
+    #[doc = "Checks if the value of the field is `PULL_DOWN`"]
     #[inline]
-    pub fn is_pull_down_resistor_e(&self) -> bool {
-        *self == MODER::PULL_DOWN_RESISTOR_E
+    pub fn is_pull_down(&self) -> bool {
+        *self == MODER::PULL_DOWN
     }
-    #[doc = "Checks if the value of the field is `PULL_UP_RESISTOR_ENA`"]
+    #[doc = "Checks if the value of the field is `PULL_UP`"]
     #[inline]
-    pub fn is_pull_up_resistor_ena(&self) -> bool {
-        *self == MODER::PULL_UP_RESISTOR_ENA
+    pub fn is_pull_up(&self) -> bool {
+        *self == MODER::PULL_UP
     }
-    #[doc = "Checks if the value of the field is `REPEATER_MODE_`"]
+    #[doc = "Checks if the value of the field is `REPEATER`"]
     #[inline]
-    pub fn is_repeater_mode_(&self) -> bool {
-        *self == MODER::REPEATER_MODE_
+    pub fn is_repeater(&self) -> bool {
+        *self == MODER::REPEATER
     }
 }
 #[doc = "Possible values of the field `HYS`"]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum HYSR {
     #[doc = "Disable."]
-    DISABLE_,
+    DISABLED,
     #[doc = "Enable."]
-    ENABLE_,
+    ENABLED,
 }
 impl HYSR {
     #[doc = r" Returns `true` if the bit is clear (0)"]
@@ -171,8 +171,8 @@ impl HYSR {
     #[inline]
     pub fn bit(&self) -> bool {
         match *self {
-            HYSR::DISABLE_ => false,
-            HYSR::ENABLE_ => true,
+            HYSR::DISABLED => false,
+            HYSR::ENABLED => true,
         }
     }
     #[allow(missing_docs)]
@@ -180,28 +180,28 @@ impl HYSR {
     #[inline]
     pub fn _from(value: bool) -> HYSR {
         match value {
-            false => HYSR::DISABLE_,
-            true => HYSR::ENABLE_,
+            false => HYSR::DISABLED,
+            true => HYSR::ENABLED,
         }
     }
-    #[doc = "Checks if the value of the field is `DISABLE_`"]
+    #[doc = "Checks if the value of the field is `DISABLED`"]
     #[inline]
-    pub fn is_disable_(&self) -> bool {
-        *self == HYSR::DISABLE_
+    pub fn is_disabled(&self) -> bool {
+        *self == HYSR::DISABLED
     }
-    #[doc = "Checks if the value of the field is `ENABLE_`"]
+    #[doc = "Checks if the value of the field is `ENABLED`"]
     #[inline]
-    pub fn is_enable_(&self) -> bool {
-        *self == HYSR::ENABLE_
+    pub fn is_enabled(&self) -> bool {
+        *self == HYSR::ENABLED
     }
 }
 #[doc = "Possible values of the field `INV`"]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum INVR {
     #[doc = "Input not inverted (HIGH on pin reads as 1, LOW on pin reads as 0)."]
-    INPUT_NOT_INVERTED_,
+    NOT_INVERTED,
     #[doc = "Input inverted (HIGH on pin reads as 0, LOW on pin reads as 1)."]
-    INPUT_INVERTED_HIGH,
+    INVERTED,
 }
 impl INVR {
     #[doc = r" Returns `true` if the bit is clear (0)"]
@@ -218,8 +218,8 @@ impl INVR {
     #[inline]
     pub fn bit(&self) -> bool {
         match *self {
-            INVR::INPUT_NOT_INVERTED_ => false,
-            INVR::INPUT_INVERTED_HIGH => true,
+            INVR::NOT_INVERTED => false,
+            INVR::INVERTED => true,
         }
     }
     #[allow(missing_docs)]
@@ -227,28 +227,28 @@ impl INVR {
     #[inline]
     pub fn _from(value: bool) -> INVR {
         match value {
-            false => INVR::INPUT_NOT_INVERTED_,
-            true => INVR::INPUT_INVERTED_HIGH,
+            false => INVR::NOT_INVERTED,
+            true => INVR::INVERTED,
         }
     }
-    #[doc = "Checks if the value of the field is `INPUT_NOT_INVERTED_`"]
+    #[doc = "Checks if the value of the field is `NOT_INVERTED`"]
     #[inline]
-    pub fn is_input_not_inverted_(&self) -> bool {
-        *self == INVR::INPUT_NOT_INVERTED_
+    pub fn is_not_inverted(&self) -> bool {
+        *self == INVR::NOT_INVERTED
     }
-    #[doc = "Checks if the value of the field is `INPUT_INVERTED_HIGH`"]
+    #[doc = "Checks if the value of the field is `INVERTED`"]
     #[inline]
-    pub fn is_input_inverted_high(&self) -> bool {
-        *self == INVR::INPUT_INVERTED_HIGH
+    pub fn is_inverted(&self) -> bool {
+        *self == INVR::INVERTED
     }
 }
 #[doc = "Possible values of the field `OD`"]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum ODR {
     #[doc = "Disable."]
-    DISABLE_,
+    DISABLED,
     #[doc = "Open-drain mode enabled.  This is not a true open-drain mode."]
-    OPEN_DRAIN_MODE_ENAB,
+    OPEN_DRAIN,
 }
 impl ODR {
     #[doc = r" Returns `true` if the bit is clear (0)"]
@@ -265,8 +265,8 @@ impl ODR {
     #[inline]
     pub fn bit(&self) -> bool {
         match *self {
-            ODR::DISABLE_ => false,
-            ODR::OPEN_DRAIN_MODE_ENAB => true,
+            ODR::DISABLED => false,
+            ODR::OPEN_DRAIN => true,
         }
     }
     #[allow(missing_docs)]
@@ -274,29 +274,29 @@ impl ODR {
     #[inline]
     pub fn _from(value: bool) -> ODR {
         match value {
-            false => ODR::DISABLE_,
-            true => ODR::OPEN_DRAIN_MODE_ENAB,
+            false => ODR::DISABLED,
+            true => ODR::OPEN_DRAIN,
         }
     }
-    #[doc = "Checks if the value of the field is `DISABLE_`"]
+    #[doc = "Checks if the value of the field is `DISABLED`"]
     #[inline]
-    pub fn is_disable_(&self) -> bool {
-        *self == ODR::DISABLE_
+    pub fn is_disabled(&self) -> bool {
+        *self == ODR::DISABLED
     }
-    #[doc = "Checks if the value of the field is `OPEN_DRAIN_MODE_ENAB`"]
+    #[doc = "Checks if the value of the field is `OPEN_DRAIN`"]
     #[inline]
-    pub fn is_open_drain_mode_enab(&self) -> bool {
-        *self == ODR::OPEN_DRAIN_MODE_ENAB
+    pub fn is_open_drain(&self) -> bool {
+        *self == ODR::OPEN_DRAIN
     }
 }
 #[doc = "Values that can be written to the field `FUNC`"]
 pub enum FUNCW {
     #[doc = "PIO0_9."]
-    PIO0_9_,
+    PIO0_9,
     #[doc = "MOSI0."]
-    MOSI0_,
+    MOSI0,
     #[doc = "CT16B0_MAT1."]
-    CT16B0_MAT1_,
+    CT16B0_MAT1,
 }
 impl FUNCW {
     #[allow(missing_docs)]
@@ -304,9 +304,9 @@ impl FUNCW {
     #[inline]
     pub fn _bits(&self) -> u8 {
         match *self {
-            FUNCW::PIO0_9_ => 0,
-            FUNCW::MOSI0_ => 1,
-            FUNCW::CT16B0_MAT1_ => 2,
+            FUNCW::PIO0_9 => 0,
+            FUNCW::MOSI0 => 1,
+            FUNCW::CT16B0_MAT1 => 2,
         }
     }
 }
@@ -322,18 +322,18 @@ impl<'a> _FUNCW<'a> {
     }
     #[doc = "PIO0_9."]
     #[inline]
-    pub fn pio0_9_(self) -> &'a mut W {
-        self.variant(FUNCW::PIO0_9_)
+    pub fn pio0_9(self) -> &'a mut W {
+        self.variant(FUNCW::PIO0_9)
     }
     #[doc = "MOSI0."]
     #[inline]
-    pub fn mosi0_(self) -> &'a mut W {
-        self.variant(FUNCW::MOSI0_)
+    pub fn mosi0(self) -> &'a mut W {
+        self.variant(FUNCW::MOSI0)
     }
     #[doc = "CT16B0_MAT1."]
     #[inline]
-    pub fn ct16b0_mat1_(self) -> &'a mut W {
-        self.variant(FUNCW::CT16B0_MAT1_)
+    pub fn ct16b0_mat1(self) -> &'a mut W {
+        self.variant(FUNCW::CT16B0_MAT1)
     }
     #[doc = r" Writes raw bits to the field"]
     #[inline]
@@ -348,13 +348,13 @@ impl<'a> _FUNCW<'a> {
 #[doc = "Values that can be written to the field `MODE`"]
 pub enum MODEW {
     #[doc = "Inactive (no pull-down/pull-up resistor enabled)."]
-    INACTIVE_NO_PULL_DO,
+    INACTIVE,
     #[doc = "Pull-down resistor enabled."]
-    PULL_DOWN_RESISTOR_E,
+    PULL_DOWN,
     #[doc = "Pull-up resistor enabled."]
-    PULL_UP_RESISTOR_ENA,
+    PULL_UP,
     #[doc = "Repeater mode."]
-    REPEATER_MODE_,
+    REPEATER,
 }
 impl MODEW {
     #[allow(missing_docs)]
@@ -362,10 +362,10 @@ impl MODEW {
     #[inline]
     pub fn _bits(&self) -> u8 {
         match *self {
-            MODEW::INACTIVE_NO_PULL_DO => 0,
-            MODEW::PULL_DOWN_RESISTOR_E => 1,
-            MODEW::PULL_UP_RESISTOR_ENA => 2,
-            MODEW::REPEATER_MODE_ => 3,
+            MODEW::INACTIVE => 0,
+            MODEW::PULL_DOWN => 1,
+            MODEW::PULL_UP => 2,
+            MODEW::REPEATER => 3,
         }
     }
 }
@@ -383,23 +383,23 @@ impl<'a> _MODEW<'a> {
     }
     #[doc = "Inactive (no pull-down/pull-up resistor enabled)."]
     #[inline]
-    pub fn inactive_no_pull_do(self) -> &'a mut W {
-        self.variant(MODEW::INACTIVE_NO_PULL_DO)
+    pub fn inactive(self) -> &'a mut W {
+        self.variant(MODEW::INACTIVE)
     }
     #[doc = "Pull-down resistor enabled."]
     #[inline]
-    pub fn pull_down_resistor_e(self) -> &'a mut W {
-        self.variant(MODEW::PULL_DOWN_RESISTOR_E)
+    pub fn pull_down(self) -> &'a mut W {
+        self.variant(MODEW::PULL_DOWN)
     }
     #[doc = "Pull-up resistor enabled."]
     #[inline]
-    pub fn pull_up_resistor_ena(self) -> &'a mut W {
-        self.variant(MODEW::PULL_UP_RESISTOR_ENA)
+    pub fn pull_up(self) -> &'a mut W {
+        self.variant(MODEW::PULL_UP)
     }
     #[doc = "Repeater mode."]
     #[inline]
-    pub fn repeater_mode_(self) -> &'a mut W {
-        self.variant(MODEW::REPEATER_MODE_)
+    pub fn repeater(self) -> &'a mut W {
+        self.variant(MODEW::REPEATER)
     }
     #[doc = r" Writes raw bits to the field"]
     #[inline]
@@ -414,9 +414,9 @@ impl<'a> _MODEW<'a> {
 #[doc = "Values that can be written to the field `HYS`"]
 pub enum HYSW {
     #[doc = "Disable."]
-    DISABLE_,
+    DISABLED,
     #[doc = "Enable."]
-    ENABLE_,
+    ENABLED,
 }
 impl HYSW {
     #[allow(missing_docs)]
@@ -424,8 +424,8 @@ impl HYSW {
     #[inline]
     pub fn _bits(&self) -> bool {
         match *self {
-            HYSW::DISABLE_ => false,
-            HYSW::ENABLE_ => true,
+            HYSW::DISABLED => false,
+            HYSW::ENABLED => true,
         }
     }
 }
@@ -443,13 +443,13 @@ impl<'a> _HYSW<'a> {
     }
     #[doc = "Disable."]
     #[inline]
-    pub fn disable_(self) -> &'a mut W {
-        self.variant(HYSW::DISABLE_)
+    pub fn disabled(self) -> &'a mut W {
+        self.variant(HYSW::DISABLED)
     }
     #[doc = "Enable."]
     #[inline]
-    pub fn enable_(self) -> &'a mut W {
-        self.variant(HYSW::ENABLE_)
+    pub fn enabled(self) -> &'a mut W {
+        self.variant(HYSW::ENABLED)
     }
     #[doc = r" Sets the field bit"]
     pub fn set_bit(self) -> &'a mut W {
@@ -472,9 +472,9 @@ impl<'a> _HYSW<'a> {
 #[doc = "Values that can be written to the field `INV`"]
 pub enum INVW {
     #[doc = "Input not inverted (HIGH on pin reads as 1, LOW on pin reads as 0)."]
-    INPUT_NOT_INVERTED_,
+    NOT_INVERTED,
     #[doc = "Input inverted (HIGH on pin reads as 0, LOW on pin reads as 1)."]
-    INPUT_INVERTED_HIGH,
+    INVERTED,
 }
 impl INVW {
     #[allow(missing_docs)]
@@ -482,8 +482,8 @@ impl INVW {
     #[inline]
     pub fn _bits(&self) -> bool {
         match *self {
-            INVW::INPUT_NOT_INVERTED_ => false,
-            INVW::INPUT_INVERTED_HIGH => true,
+            INVW::NOT_INVERTED => false,
+            INVW::INVERTED => true,
         }
     }
 }
@@ -501,13 +501,13 @@ impl<'a> _INVW<'a> {
     }
     #[doc = "Input not inverted (HIGH on pin reads as 1, LOW on pin reads as 0)."]
     #[inline]
-    pub fn input_not_inverted_(self) -> &'a mut W {
-        self.variant(INVW::INPUT_NOT_INVERTED_)
+    pub fn not_inverted(self) -> &'a mut W {
+        self.variant(INVW::NOT_INVERTED)
     }
     #[doc = "Input inverted (HIGH on pin reads as 0, LOW on pin reads as 1)."]
     #[inline]
-    pub fn input_inverted_high(self) -> &'a mut W {
-        self.variant(INVW::INPUT_INVERTED_HIGH)
+    pub fn inverted(self) -> &'a mut W {
+        self.variant(INVW::INVERTED)
     }
     #[doc = r" Sets the field bit"]
     pub fn set_bit(self) -> &'a mut W {
@@ -530,9 +530,9 @@ impl<'a> _INVW<'a> {
 #[doc = "Values that can be written to the field `OD`"]
 pub enum ODW {
     #[doc = "Disable."]
-    DISABLE_,
+    DISABLED,
     #[doc = "Open-drain mode enabled.  This is not a true open-drain mode."]
-    OPEN_DRAIN_MODE_ENAB,
+    OPEN_DRAIN,
 }
 impl ODW {
     #[allow(missing_docs)]
@@ -540,8 +540,8 @@ impl ODW {
     #[inline]
     pub fn _bits(&self) -> bool {
         match *self {
-            ODW::DISABLE_ => false,
-            ODW::OPEN_DRAIN_MODE_ENAB => true,
+            ODW::DISABLED => false,
+            ODW::OPEN_DRAIN => true,
         }
     }
 }
@@ -559,13 +559,13 @@ impl<'a> _ODW<'a> {
     }
     #[doc = "Disable."]
     #[inline]
-    pub fn disable_(self) -> &'a mut W {
-        self.variant(ODW::DISABLE_)
+    pub fn disabled(self) -> &'a mut W {
+        self.variant(ODW::DISABLED)
     }
     #[doc = "Open-drain mode enabled. This is not a true open-drain mode."]
     #[inline]
-    pub fn open_drain_mode_enab(self) -> &'a mut W {
-        self.variant(ODW::OPEN_DRAIN_MODE_ENAB)
+    pub fn open_drain(self) -> &'a mut W {
+        self.variant(ODW::OPEN_DRAIN)
     }
     #[doc = r" Sets the field bit"]
     pub fn set_bit(self) -> &'a mut W {

--- a/lpc11uxx/src/iocon/pio1_0.rs
+++ b/lpc11uxx/src/iocon/pio1_0.rs
@@ -46,9 +46,9 @@ impl super::PIO1_0 {
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum FUNCR {
     #[doc = "PIO1_0."]
-    PIO1_0_,
+    PIO1_0,
     #[doc = "CT32B1_MAT1."]
-    CT32B1_MAT1_,
+    CT32B1_MAT1,
     #[doc = r" Reserved"]
     _Reserved(u8),
 }
@@ -57,8 +57,8 @@ impl FUNCR {
     #[inline]
     pub fn bits(&self) -> u8 {
         match *self {
-            FUNCR::PIO1_0_ => 0,
-            FUNCR::CT32B1_MAT1_ => 1,
+            FUNCR::PIO1_0 => 0,
+            FUNCR::CT32B1_MAT1 => 1,
             FUNCR::_Reserved(bits) => bits,
         }
     }
@@ -67,43 +67,43 @@ impl FUNCR {
     #[inline]
     pub fn _from(value: u8) -> FUNCR {
         match value {
-            0 => FUNCR::PIO1_0_,
-            1 => FUNCR::CT32B1_MAT1_,
+            0 => FUNCR::PIO1_0,
+            1 => FUNCR::CT32B1_MAT1,
             i => FUNCR::_Reserved(i),
         }
     }
-    #[doc = "Checks if the value of the field is `PIO1_0_`"]
+    #[doc = "Checks if the value of the field is `PIO1_0`"]
     #[inline]
-    pub fn is_pio1_0_(&self) -> bool {
-        *self == FUNCR::PIO1_0_
+    pub fn is_pio1_0(&self) -> bool {
+        *self == FUNCR::PIO1_0
     }
-    #[doc = "Checks if the value of the field is `CT32B1_MAT1_`"]
+    #[doc = "Checks if the value of the field is `CT32B1_MAT1`"]
     #[inline]
-    pub fn is_ct32b1_mat1_(&self) -> bool {
-        *self == FUNCR::CT32B1_MAT1_
+    pub fn is_ct32b1_mat1(&self) -> bool {
+        *self == FUNCR::CT32B1_MAT1
     }
 }
 #[doc = "Possible values of the field `MODE`"]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum MODER {
     #[doc = "Inactive (no pull-down/pull-up resistor enabled)."]
-    INACTIVE_NO_PULL_DO,
+    INACTIVE,
     #[doc = "Pull-down resistor enabled."]
-    PULL_DOWN_RESISTOR_E,
+    PULL_DOWN,
     #[doc = "Pull-up resistor enabled."]
-    PULL_UP_RESISTOR_ENA,
+    PULL_UP,
     #[doc = "Repeater mode."]
-    REPEATER_MODE_,
+    REPEATER,
 }
 impl MODER {
     #[doc = r" Value of the field as raw bits"]
     #[inline]
     pub fn bits(&self) -> u8 {
         match *self {
-            MODER::INACTIVE_NO_PULL_DO => 0,
-            MODER::PULL_DOWN_RESISTOR_E => 1,
-            MODER::PULL_UP_RESISTOR_ENA => 2,
-            MODER::REPEATER_MODE_ => 3,
+            MODER::INACTIVE => 0,
+            MODER::PULL_DOWN => 1,
+            MODER::PULL_UP => 2,
+            MODER::REPEATER => 3,
         }
     }
     #[allow(missing_docs)]
@@ -111,41 +111,41 @@ impl MODER {
     #[inline]
     pub fn _from(value: u8) -> MODER {
         match value {
-            0 => MODER::INACTIVE_NO_PULL_DO,
-            1 => MODER::PULL_DOWN_RESISTOR_E,
-            2 => MODER::PULL_UP_RESISTOR_ENA,
-            3 => MODER::REPEATER_MODE_,
+            0 => MODER::INACTIVE,
+            1 => MODER::PULL_DOWN,
+            2 => MODER::PULL_UP,
+            3 => MODER::REPEATER,
             _ => unreachable!(),
         }
     }
-    #[doc = "Checks if the value of the field is `INACTIVE_NO_PULL_DO`"]
+    #[doc = "Checks if the value of the field is `INACTIVE`"]
     #[inline]
-    pub fn is_inactive_no_pull_do(&self) -> bool {
-        *self == MODER::INACTIVE_NO_PULL_DO
+    pub fn is_inactive(&self) -> bool {
+        *self == MODER::INACTIVE
     }
-    #[doc = "Checks if the value of the field is `PULL_DOWN_RESISTOR_E`"]
+    #[doc = "Checks if the value of the field is `PULL_DOWN`"]
     #[inline]
-    pub fn is_pull_down_resistor_e(&self) -> bool {
-        *self == MODER::PULL_DOWN_RESISTOR_E
+    pub fn is_pull_down(&self) -> bool {
+        *self == MODER::PULL_DOWN
     }
-    #[doc = "Checks if the value of the field is `PULL_UP_RESISTOR_ENA`"]
+    #[doc = "Checks if the value of the field is `PULL_UP`"]
     #[inline]
-    pub fn is_pull_up_resistor_ena(&self) -> bool {
-        *self == MODER::PULL_UP_RESISTOR_ENA
+    pub fn is_pull_up(&self) -> bool {
+        *self == MODER::PULL_UP
     }
-    #[doc = "Checks if the value of the field is `REPEATER_MODE_`"]
+    #[doc = "Checks if the value of the field is `REPEATER`"]
     #[inline]
-    pub fn is_repeater_mode_(&self) -> bool {
-        *self == MODER::REPEATER_MODE_
+    pub fn is_repeater(&self) -> bool {
+        *self == MODER::REPEATER
     }
 }
 #[doc = "Possible values of the field `HYS`"]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum HYSR {
     #[doc = "Disable."]
-    DISABLE_,
+    DISABLED,
     #[doc = "Enable."]
-    ENABLE_,
+    ENABLED,
 }
 impl HYSR {
     #[doc = r" Returns `true` if the bit is clear (0)"]
@@ -162,8 +162,8 @@ impl HYSR {
     #[inline]
     pub fn bit(&self) -> bool {
         match *self {
-            HYSR::DISABLE_ => false,
-            HYSR::ENABLE_ => true,
+            HYSR::DISABLED => false,
+            HYSR::ENABLED => true,
         }
     }
     #[allow(missing_docs)]
@@ -171,28 +171,28 @@ impl HYSR {
     #[inline]
     pub fn _from(value: bool) -> HYSR {
         match value {
-            false => HYSR::DISABLE_,
-            true => HYSR::ENABLE_,
+            false => HYSR::DISABLED,
+            true => HYSR::ENABLED,
         }
     }
-    #[doc = "Checks if the value of the field is `DISABLE_`"]
+    #[doc = "Checks if the value of the field is `DISABLED`"]
     #[inline]
-    pub fn is_disable_(&self) -> bool {
-        *self == HYSR::DISABLE_
+    pub fn is_disabled(&self) -> bool {
+        *self == HYSR::DISABLED
     }
-    #[doc = "Checks if the value of the field is `ENABLE_`"]
+    #[doc = "Checks if the value of the field is `ENABLED`"]
     #[inline]
-    pub fn is_enable_(&self) -> bool {
-        *self == HYSR::ENABLE_
+    pub fn is_enabled(&self) -> bool {
+        *self == HYSR::ENABLED
     }
 }
 #[doc = "Possible values of the field `INV`"]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum INVR {
     #[doc = "Input not inverted (HIGH on pin reads as 1, LOW on pin reads as 0)."]
-    INPUT_NOT_INVERTED_,
+    NOT_INVERTED,
     #[doc = "Input inverted (HIGH on pin reads as 0, LOW on pin reads as 1)."]
-    INPUT_INVERTED_HIGH,
+    INVERTED,
 }
 impl INVR {
     #[doc = r" Returns `true` if the bit is clear (0)"]
@@ -209,8 +209,8 @@ impl INVR {
     #[inline]
     pub fn bit(&self) -> bool {
         match *self {
-            INVR::INPUT_NOT_INVERTED_ => false,
-            INVR::INPUT_INVERTED_HIGH => true,
+            INVR::NOT_INVERTED => false,
+            INVR::INVERTED => true,
         }
     }
     #[allow(missing_docs)]
@@ -218,28 +218,28 @@ impl INVR {
     #[inline]
     pub fn _from(value: bool) -> INVR {
         match value {
-            false => INVR::INPUT_NOT_INVERTED_,
-            true => INVR::INPUT_INVERTED_HIGH,
+            false => INVR::NOT_INVERTED,
+            true => INVR::INVERTED,
         }
     }
-    #[doc = "Checks if the value of the field is `INPUT_NOT_INVERTED_`"]
+    #[doc = "Checks if the value of the field is `NOT_INVERTED`"]
     #[inline]
-    pub fn is_input_not_inverted_(&self) -> bool {
-        *self == INVR::INPUT_NOT_INVERTED_
+    pub fn is_not_inverted(&self) -> bool {
+        *self == INVR::NOT_INVERTED
     }
-    #[doc = "Checks if the value of the field is `INPUT_INVERTED_HIGH`"]
+    #[doc = "Checks if the value of the field is `INVERTED`"]
     #[inline]
-    pub fn is_input_inverted_high(&self) -> bool {
-        *self == INVR::INPUT_INVERTED_HIGH
+    pub fn is_inverted(&self) -> bool {
+        *self == INVR::INVERTED
     }
 }
 #[doc = "Possible values of the field `OD`"]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum ODR {
     #[doc = "Disable."]
-    DISABLE_,
+    DISABLED,
     #[doc = "Open-drain mode enabled. This is not a true open-drain mode. Input cannot be pulled up above VDD."]
-    OPEN_DRAIN_MODE_ENAB,
+    OPEN_DRAIN,
 }
 impl ODR {
     #[doc = r" Returns `true` if the bit is clear (0)"]
@@ -256,8 +256,8 @@ impl ODR {
     #[inline]
     pub fn bit(&self) -> bool {
         match *self {
-            ODR::DISABLE_ => false,
-            ODR::OPEN_DRAIN_MODE_ENAB => true,
+            ODR::DISABLED => false,
+            ODR::OPEN_DRAIN => true,
         }
     }
     #[allow(missing_docs)]
@@ -265,27 +265,27 @@ impl ODR {
     #[inline]
     pub fn _from(value: bool) -> ODR {
         match value {
-            false => ODR::DISABLE_,
-            true => ODR::OPEN_DRAIN_MODE_ENAB,
+            false => ODR::DISABLED,
+            true => ODR::OPEN_DRAIN,
         }
     }
-    #[doc = "Checks if the value of the field is `DISABLE_`"]
+    #[doc = "Checks if the value of the field is `DISABLED`"]
     #[inline]
-    pub fn is_disable_(&self) -> bool {
-        *self == ODR::DISABLE_
+    pub fn is_disabled(&self) -> bool {
+        *self == ODR::DISABLED
     }
-    #[doc = "Checks if the value of the field is `OPEN_DRAIN_MODE_ENAB`"]
+    #[doc = "Checks if the value of the field is `OPEN_DRAIN`"]
     #[inline]
-    pub fn is_open_drain_mode_enab(&self) -> bool {
-        *self == ODR::OPEN_DRAIN_MODE_ENAB
+    pub fn is_open_drain(&self) -> bool {
+        *self == ODR::OPEN_DRAIN
     }
 }
 #[doc = "Values that can be written to the field `FUNC`"]
 pub enum FUNCW {
     #[doc = "PIO1_0."]
-    PIO1_0_,
+    PIO1_0,
     #[doc = "CT32B1_MAT1."]
-    CT32B1_MAT1_,
+    CT32B1_MAT1,
 }
 impl FUNCW {
     #[allow(missing_docs)]
@@ -293,8 +293,8 @@ impl FUNCW {
     #[inline]
     pub fn _bits(&self) -> u8 {
         match *self {
-            FUNCW::PIO1_0_ => 0,
-            FUNCW::CT32B1_MAT1_ => 1,
+            FUNCW::PIO1_0 => 0,
+            FUNCW::CT32B1_MAT1 => 1,
         }
     }
 }
@@ -310,13 +310,13 @@ impl<'a> _FUNCW<'a> {
     }
     #[doc = "PIO1_0."]
     #[inline]
-    pub fn pio1_0_(self) -> &'a mut W {
-        self.variant(FUNCW::PIO1_0_)
+    pub fn pio1_0(self) -> &'a mut W {
+        self.variant(FUNCW::PIO1_0)
     }
     #[doc = "CT32B1_MAT1."]
     #[inline]
-    pub fn ct32b1_mat1_(self) -> &'a mut W {
-        self.variant(FUNCW::CT32B1_MAT1_)
+    pub fn ct32b1_mat1(self) -> &'a mut W {
+        self.variant(FUNCW::CT32B1_MAT1)
     }
     #[doc = r" Writes raw bits to the field"]
     #[inline]
@@ -331,13 +331,13 @@ impl<'a> _FUNCW<'a> {
 #[doc = "Values that can be written to the field `MODE`"]
 pub enum MODEW {
     #[doc = "Inactive (no pull-down/pull-up resistor enabled)."]
-    INACTIVE_NO_PULL_DO,
+    INACTIVE,
     #[doc = "Pull-down resistor enabled."]
-    PULL_DOWN_RESISTOR_E,
+    PULL_DOWN,
     #[doc = "Pull-up resistor enabled."]
-    PULL_UP_RESISTOR_ENA,
+    PULL_UP,
     #[doc = "Repeater mode."]
-    REPEATER_MODE_,
+    REPEATER,
 }
 impl MODEW {
     #[allow(missing_docs)]
@@ -345,10 +345,10 @@ impl MODEW {
     #[inline]
     pub fn _bits(&self) -> u8 {
         match *self {
-            MODEW::INACTIVE_NO_PULL_DO => 0,
-            MODEW::PULL_DOWN_RESISTOR_E => 1,
-            MODEW::PULL_UP_RESISTOR_ENA => 2,
-            MODEW::REPEATER_MODE_ => 3,
+            MODEW::INACTIVE => 0,
+            MODEW::PULL_DOWN => 1,
+            MODEW::PULL_UP => 2,
+            MODEW::REPEATER => 3,
         }
     }
 }
@@ -366,23 +366,23 @@ impl<'a> _MODEW<'a> {
     }
     #[doc = "Inactive (no pull-down/pull-up resistor enabled)."]
     #[inline]
-    pub fn inactive_no_pull_do(self) -> &'a mut W {
-        self.variant(MODEW::INACTIVE_NO_PULL_DO)
+    pub fn inactive(self) -> &'a mut W {
+        self.variant(MODEW::INACTIVE)
     }
     #[doc = "Pull-down resistor enabled."]
     #[inline]
-    pub fn pull_down_resistor_e(self) -> &'a mut W {
-        self.variant(MODEW::PULL_DOWN_RESISTOR_E)
+    pub fn pull_down(self) -> &'a mut W {
+        self.variant(MODEW::PULL_DOWN)
     }
     #[doc = "Pull-up resistor enabled."]
     #[inline]
-    pub fn pull_up_resistor_ena(self) -> &'a mut W {
-        self.variant(MODEW::PULL_UP_RESISTOR_ENA)
+    pub fn pull_up(self) -> &'a mut W {
+        self.variant(MODEW::PULL_UP)
     }
     #[doc = "Repeater mode."]
     #[inline]
-    pub fn repeater_mode_(self) -> &'a mut W {
-        self.variant(MODEW::REPEATER_MODE_)
+    pub fn repeater(self) -> &'a mut W {
+        self.variant(MODEW::REPEATER)
     }
     #[doc = r" Writes raw bits to the field"]
     #[inline]
@@ -397,9 +397,9 @@ impl<'a> _MODEW<'a> {
 #[doc = "Values that can be written to the field `HYS`"]
 pub enum HYSW {
     #[doc = "Disable."]
-    DISABLE_,
+    DISABLED,
     #[doc = "Enable."]
-    ENABLE_,
+    ENABLED,
 }
 impl HYSW {
     #[allow(missing_docs)]
@@ -407,8 +407,8 @@ impl HYSW {
     #[inline]
     pub fn _bits(&self) -> bool {
         match *self {
-            HYSW::DISABLE_ => false,
-            HYSW::ENABLE_ => true,
+            HYSW::DISABLED => false,
+            HYSW::ENABLED => true,
         }
     }
 }
@@ -426,13 +426,13 @@ impl<'a> _HYSW<'a> {
     }
     #[doc = "Disable."]
     #[inline]
-    pub fn disable_(self) -> &'a mut W {
-        self.variant(HYSW::DISABLE_)
+    pub fn disabled(self) -> &'a mut W {
+        self.variant(HYSW::DISABLED)
     }
     #[doc = "Enable."]
     #[inline]
-    pub fn enable_(self) -> &'a mut W {
-        self.variant(HYSW::ENABLE_)
+    pub fn enabled(self) -> &'a mut W {
+        self.variant(HYSW::ENABLED)
     }
     #[doc = r" Sets the field bit"]
     pub fn set_bit(self) -> &'a mut W {
@@ -455,9 +455,9 @@ impl<'a> _HYSW<'a> {
 #[doc = "Values that can be written to the field `INV`"]
 pub enum INVW {
     #[doc = "Input not inverted (HIGH on pin reads as 1, LOW on pin reads as 0)."]
-    INPUT_NOT_INVERTED_,
+    NOT_INVERTED,
     #[doc = "Input inverted (HIGH on pin reads as 0, LOW on pin reads as 1)."]
-    INPUT_INVERTED_HIGH,
+    INVERTED,
 }
 impl INVW {
     #[allow(missing_docs)]
@@ -465,8 +465,8 @@ impl INVW {
     #[inline]
     pub fn _bits(&self) -> bool {
         match *self {
-            INVW::INPUT_NOT_INVERTED_ => false,
-            INVW::INPUT_INVERTED_HIGH => true,
+            INVW::NOT_INVERTED => false,
+            INVW::INVERTED => true,
         }
     }
 }
@@ -484,13 +484,13 @@ impl<'a> _INVW<'a> {
     }
     #[doc = "Input not inverted (HIGH on pin reads as 1, LOW on pin reads as 0)."]
     #[inline]
-    pub fn input_not_inverted_(self) -> &'a mut W {
-        self.variant(INVW::INPUT_NOT_INVERTED_)
+    pub fn not_inverted(self) -> &'a mut W {
+        self.variant(INVW::NOT_INVERTED)
     }
     #[doc = "Input inverted (HIGH on pin reads as 0, LOW on pin reads as 1)."]
     #[inline]
-    pub fn input_inverted_high(self) -> &'a mut W {
-        self.variant(INVW::INPUT_INVERTED_HIGH)
+    pub fn inverted(self) -> &'a mut W {
+        self.variant(INVW::INVERTED)
     }
     #[doc = r" Sets the field bit"]
     pub fn set_bit(self) -> &'a mut W {
@@ -513,9 +513,9 @@ impl<'a> _INVW<'a> {
 #[doc = "Values that can be written to the field `OD`"]
 pub enum ODW {
     #[doc = "Disable."]
-    DISABLE_,
+    DISABLED,
     #[doc = "Open-drain mode enabled. This is not a true open-drain mode. Input cannot be pulled up above VDD."]
-    OPEN_DRAIN_MODE_ENAB,
+    OPEN_DRAIN,
 }
 impl ODW {
     #[allow(missing_docs)]
@@ -523,8 +523,8 @@ impl ODW {
     #[inline]
     pub fn _bits(&self) -> bool {
         match *self {
-            ODW::DISABLE_ => false,
-            ODW::OPEN_DRAIN_MODE_ENAB => true,
+            ODW::DISABLED => false,
+            ODW::OPEN_DRAIN => true,
         }
     }
 }
@@ -542,13 +542,13 @@ impl<'a> _ODW<'a> {
     }
     #[doc = "Disable."]
     #[inline]
-    pub fn disable_(self) -> &'a mut W {
-        self.variant(ODW::DISABLE_)
+    pub fn disabled(self) -> &'a mut W {
+        self.variant(ODW::DISABLED)
     }
     #[doc = "Open-drain mode enabled. This is not a true open-drain mode. Input cannot be pulled up above VDD."]
     #[inline]
-    pub fn open_drain_mode_enab(self) -> &'a mut W {
-        self.variant(ODW::OPEN_DRAIN_MODE_ENAB)
+    pub fn open_drain(self) -> &'a mut W {
+        self.variant(ODW::OPEN_DRAIN)
     }
     #[doc = r" Sets the field bit"]
     pub fn set_bit(self) -> &'a mut W {

--- a/lpc11uxx/src/iocon/pio1_1.rs
+++ b/lpc11uxx/src/iocon/pio1_1.rs
@@ -46,9 +46,9 @@ impl super::PIO1_1 {
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum FUNCR {
     #[doc = "PIO1_1."]
-    PIO1_1_,
+    PIO1_1,
     #[doc = "CT32B1_MAT1."]
-    CT32B1_MAT1_,
+    CT32B1_MAT1,
     #[doc = r" Reserved"]
     _Reserved(u8),
 }
@@ -57,8 +57,8 @@ impl FUNCR {
     #[inline]
     pub fn bits(&self) -> u8 {
         match *self {
-            FUNCR::PIO1_1_ => 0,
-            FUNCR::CT32B1_MAT1_ => 1,
+            FUNCR::PIO1_1 => 0,
+            FUNCR::CT32B1_MAT1 => 1,
             FUNCR::_Reserved(bits) => bits,
         }
     }
@@ -67,43 +67,43 @@ impl FUNCR {
     #[inline]
     pub fn _from(value: u8) -> FUNCR {
         match value {
-            0 => FUNCR::PIO1_1_,
-            1 => FUNCR::CT32B1_MAT1_,
+            0 => FUNCR::PIO1_1,
+            1 => FUNCR::CT32B1_MAT1,
             i => FUNCR::_Reserved(i),
         }
     }
-    #[doc = "Checks if the value of the field is `PIO1_1_`"]
+    #[doc = "Checks if the value of the field is `PIO1_1`"]
     #[inline]
-    pub fn is_pio1_1_(&self) -> bool {
-        *self == FUNCR::PIO1_1_
+    pub fn is_pio1_1(&self) -> bool {
+        *self == FUNCR::PIO1_1
     }
-    #[doc = "Checks if the value of the field is `CT32B1_MAT1_`"]
+    #[doc = "Checks if the value of the field is `CT32B1_MAT1`"]
     #[inline]
-    pub fn is_ct32b1_mat1_(&self) -> bool {
-        *self == FUNCR::CT32B1_MAT1_
+    pub fn is_ct32b1_mat1(&self) -> bool {
+        *self == FUNCR::CT32B1_MAT1
     }
 }
 #[doc = "Possible values of the field `MODE`"]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum MODER {
     #[doc = "Inactive (no pull-down/pull-up resistor enabled)."]
-    INACTIVE_NO_PULL_DO,
+    INACTIVE,
     #[doc = "Pull-down resistor enabled."]
-    PULL_DOWN_RESISTOR_E,
+    PULL_DOWN,
     #[doc = "Pull-up resistor enabled."]
-    PULL_UP_RESISTOR_ENA,
+    PULL_UP,
     #[doc = "Repeater mode."]
-    REPEATER_MODE_,
+    REPEATER,
 }
 impl MODER {
     #[doc = r" Value of the field as raw bits"]
     #[inline]
     pub fn bits(&self) -> u8 {
         match *self {
-            MODER::INACTIVE_NO_PULL_DO => 0,
-            MODER::PULL_DOWN_RESISTOR_E => 1,
-            MODER::PULL_UP_RESISTOR_ENA => 2,
-            MODER::REPEATER_MODE_ => 3,
+            MODER::INACTIVE => 0,
+            MODER::PULL_DOWN => 1,
+            MODER::PULL_UP => 2,
+            MODER::REPEATER => 3,
         }
     }
     #[allow(missing_docs)]
@@ -111,41 +111,41 @@ impl MODER {
     #[inline]
     pub fn _from(value: u8) -> MODER {
         match value {
-            0 => MODER::INACTIVE_NO_PULL_DO,
-            1 => MODER::PULL_DOWN_RESISTOR_E,
-            2 => MODER::PULL_UP_RESISTOR_ENA,
-            3 => MODER::REPEATER_MODE_,
+            0 => MODER::INACTIVE,
+            1 => MODER::PULL_DOWN,
+            2 => MODER::PULL_UP,
+            3 => MODER::REPEATER,
             _ => unreachable!(),
         }
     }
-    #[doc = "Checks if the value of the field is `INACTIVE_NO_PULL_DO`"]
+    #[doc = "Checks if the value of the field is `INACTIVE`"]
     #[inline]
-    pub fn is_inactive_no_pull_do(&self) -> bool {
-        *self == MODER::INACTIVE_NO_PULL_DO
+    pub fn is_inactive(&self) -> bool {
+        *self == MODER::INACTIVE
     }
-    #[doc = "Checks if the value of the field is `PULL_DOWN_RESISTOR_E`"]
+    #[doc = "Checks if the value of the field is `PULL_DOWN`"]
     #[inline]
-    pub fn is_pull_down_resistor_e(&self) -> bool {
-        *self == MODER::PULL_DOWN_RESISTOR_E
+    pub fn is_pull_down(&self) -> bool {
+        *self == MODER::PULL_DOWN
     }
-    #[doc = "Checks if the value of the field is `PULL_UP_RESISTOR_ENA`"]
+    #[doc = "Checks if the value of the field is `PULL_UP`"]
     #[inline]
-    pub fn is_pull_up_resistor_ena(&self) -> bool {
-        *self == MODER::PULL_UP_RESISTOR_ENA
+    pub fn is_pull_up(&self) -> bool {
+        *self == MODER::PULL_UP
     }
-    #[doc = "Checks if the value of the field is `REPEATER_MODE_`"]
+    #[doc = "Checks if the value of the field is `REPEATER`"]
     #[inline]
-    pub fn is_repeater_mode_(&self) -> bool {
-        *self == MODER::REPEATER_MODE_
+    pub fn is_repeater(&self) -> bool {
+        *self == MODER::REPEATER
     }
 }
 #[doc = "Possible values of the field `HYS`"]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum HYSR {
     #[doc = "Disable."]
-    DISABLE_,
+    DISABLED,
     #[doc = "Enable."]
-    ENABLE_,
+    ENABLED,
 }
 impl HYSR {
     #[doc = r" Returns `true` if the bit is clear (0)"]
@@ -162,8 +162,8 @@ impl HYSR {
     #[inline]
     pub fn bit(&self) -> bool {
         match *self {
-            HYSR::DISABLE_ => false,
-            HYSR::ENABLE_ => true,
+            HYSR::DISABLED => false,
+            HYSR::ENABLED => true,
         }
     }
     #[allow(missing_docs)]
@@ -171,28 +171,28 @@ impl HYSR {
     #[inline]
     pub fn _from(value: bool) -> HYSR {
         match value {
-            false => HYSR::DISABLE_,
-            true => HYSR::ENABLE_,
+            false => HYSR::DISABLED,
+            true => HYSR::ENABLED,
         }
     }
-    #[doc = "Checks if the value of the field is `DISABLE_`"]
+    #[doc = "Checks if the value of the field is `DISABLED`"]
     #[inline]
-    pub fn is_disable_(&self) -> bool {
-        *self == HYSR::DISABLE_
+    pub fn is_disabled(&self) -> bool {
+        *self == HYSR::DISABLED
     }
-    #[doc = "Checks if the value of the field is `ENABLE_`"]
+    #[doc = "Checks if the value of the field is `ENABLED`"]
     #[inline]
-    pub fn is_enable_(&self) -> bool {
-        *self == HYSR::ENABLE_
+    pub fn is_enabled(&self) -> bool {
+        *self == HYSR::ENABLED
     }
 }
 #[doc = "Possible values of the field `INV`"]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum INVR {
     #[doc = "Input not inverted (HIGH on pin reads as 1, LOW on pin reads as 0)."]
-    INPUT_NOT_INVERTED_,
+    NOT_INVERTED,
     #[doc = "Input inverted (HIGH on pin reads as 0, LOW on pin reads as 1)."]
-    INPUT_INVERTED_HIGH,
+    INVERTED,
 }
 impl INVR {
     #[doc = r" Returns `true` if the bit is clear (0)"]
@@ -209,8 +209,8 @@ impl INVR {
     #[inline]
     pub fn bit(&self) -> bool {
         match *self {
-            INVR::INPUT_NOT_INVERTED_ => false,
-            INVR::INPUT_INVERTED_HIGH => true,
+            INVR::NOT_INVERTED => false,
+            INVR::INVERTED => true,
         }
     }
     #[allow(missing_docs)]
@@ -218,28 +218,28 @@ impl INVR {
     #[inline]
     pub fn _from(value: bool) -> INVR {
         match value {
-            false => INVR::INPUT_NOT_INVERTED_,
-            true => INVR::INPUT_INVERTED_HIGH,
+            false => INVR::NOT_INVERTED,
+            true => INVR::INVERTED,
         }
     }
-    #[doc = "Checks if the value of the field is `INPUT_NOT_INVERTED_`"]
+    #[doc = "Checks if the value of the field is `NOT_INVERTED`"]
     #[inline]
-    pub fn is_input_not_inverted_(&self) -> bool {
-        *self == INVR::INPUT_NOT_INVERTED_
+    pub fn is_not_inverted(&self) -> bool {
+        *self == INVR::NOT_INVERTED
     }
-    #[doc = "Checks if the value of the field is `INPUT_INVERTED_HIGH`"]
+    #[doc = "Checks if the value of the field is `INVERTED`"]
     #[inline]
-    pub fn is_input_inverted_high(&self) -> bool {
-        *self == INVR::INPUT_INVERTED_HIGH
+    pub fn is_inverted(&self) -> bool {
+        *self == INVR::INVERTED
     }
 }
 #[doc = "Possible values of the field `OD`"]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum ODR {
     #[doc = "Disable."]
-    DISABLE_,
+    DISABLED,
     #[doc = "Open-drain mode enabled. This is not a true open-drain mode. Input cannot be pulled up above VDD."]
-    OPEN_DRAIN_MODE_ENAB,
+    OPEN_DRAIN,
 }
 impl ODR {
     #[doc = r" Returns `true` if the bit is clear (0)"]
@@ -256,8 +256,8 @@ impl ODR {
     #[inline]
     pub fn bit(&self) -> bool {
         match *self {
-            ODR::DISABLE_ => false,
-            ODR::OPEN_DRAIN_MODE_ENAB => true,
+            ODR::DISABLED => false,
+            ODR::OPEN_DRAIN => true,
         }
     }
     #[allow(missing_docs)]
@@ -265,27 +265,27 @@ impl ODR {
     #[inline]
     pub fn _from(value: bool) -> ODR {
         match value {
-            false => ODR::DISABLE_,
-            true => ODR::OPEN_DRAIN_MODE_ENAB,
+            false => ODR::DISABLED,
+            true => ODR::OPEN_DRAIN,
         }
     }
-    #[doc = "Checks if the value of the field is `DISABLE_`"]
+    #[doc = "Checks if the value of the field is `DISABLED`"]
     #[inline]
-    pub fn is_disable_(&self) -> bool {
-        *self == ODR::DISABLE_
+    pub fn is_disabled(&self) -> bool {
+        *self == ODR::DISABLED
     }
-    #[doc = "Checks if the value of the field is `OPEN_DRAIN_MODE_ENAB`"]
+    #[doc = "Checks if the value of the field is `OPEN_DRAIN`"]
     #[inline]
-    pub fn is_open_drain_mode_enab(&self) -> bool {
-        *self == ODR::OPEN_DRAIN_MODE_ENAB
+    pub fn is_open_drain(&self) -> bool {
+        *self == ODR::OPEN_DRAIN
     }
 }
 #[doc = "Values that can be written to the field `FUNC`"]
 pub enum FUNCW {
     #[doc = "PIO1_1."]
-    PIO1_1_,
+    PIO1_1,
     #[doc = "CT32B1_MAT1."]
-    CT32B1_MAT1_,
+    CT32B1_MAT1,
 }
 impl FUNCW {
     #[allow(missing_docs)]
@@ -293,8 +293,8 @@ impl FUNCW {
     #[inline]
     pub fn _bits(&self) -> u8 {
         match *self {
-            FUNCW::PIO1_1_ => 0,
-            FUNCW::CT32B1_MAT1_ => 1,
+            FUNCW::PIO1_1 => 0,
+            FUNCW::CT32B1_MAT1 => 1,
         }
     }
 }
@@ -310,13 +310,13 @@ impl<'a> _FUNCW<'a> {
     }
     #[doc = "PIO1_1."]
     #[inline]
-    pub fn pio1_1_(self) -> &'a mut W {
-        self.variant(FUNCW::PIO1_1_)
+    pub fn pio1_1(self) -> &'a mut W {
+        self.variant(FUNCW::PIO1_1)
     }
     #[doc = "CT32B1_MAT1."]
     #[inline]
-    pub fn ct32b1_mat1_(self) -> &'a mut W {
-        self.variant(FUNCW::CT32B1_MAT1_)
+    pub fn ct32b1_mat1(self) -> &'a mut W {
+        self.variant(FUNCW::CT32B1_MAT1)
     }
     #[doc = r" Writes raw bits to the field"]
     #[inline]
@@ -331,13 +331,13 @@ impl<'a> _FUNCW<'a> {
 #[doc = "Values that can be written to the field `MODE`"]
 pub enum MODEW {
     #[doc = "Inactive (no pull-down/pull-up resistor enabled)."]
-    INACTIVE_NO_PULL_DO,
+    INACTIVE,
     #[doc = "Pull-down resistor enabled."]
-    PULL_DOWN_RESISTOR_E,
+    PULL_DOWN,
     #[doc = "Pull-up resistor enabled."]
-    PULL_UP_RESISTOR_ENA,
+    PULL_UP,
     #[doc = "Repeater mode."]
-    REPEATER_MODE_,
+    REPEATER,
 }
 impl MODEW {
     #[allow(missing_docs)]
@@ -345,10 +345,10 @@ impl MODEW {
     #[inline]
     pub fn _bits(&self) -> u8 {
         match *self {
-            MODEW::INACTIVE_NO_PULL_DO => 0,
-            MODEW::PULL_DOWN_RESISTOR_E => 1,
-            MODEW::PULL_UP_RESISTOR_ENA => 2,
-            MODEW::REPEATER_MODE_ => 3,
+            MODEW::INACTIVE => 0,
+            MODEW::PULL_DOWN => 1,
+            MODEW::PULL_UP => 2,
+            MODEW::REPEATER => 3,
         }
     }
 }
@@ -366,23 +366,23 @@ impl<'a> _MODEW<'a> {
     }
     #[doc = "Inactive (no pull-down/pull-up resistor enabled)."]
     #[inline]
-    pub fn inactive_no_pull_do(self) -> &'a mut W {
-        self.variant(MODEW::INACTIVE_NO_PULL_DO)
+    pub fn inactive(self) -> &'a mut W {
+        self.variant(MODEW::INACTIVE)
     }
     #[doc = "Pull-down resistor enabled."]
     #[inline]
-    pub fn pull_down_resistor_e(self) -> &'a mut W {
-        self.variant(MODEW::PULL_DOWN_RESISTOR_E)
+    pub fn pull_down(self) -> &'a mut W {
+        self.variant(MODEW::PULL_DOWN)
     }
     #[doc = "Pull-up resistor enabled."]
     #[inline]
-    pub fn pull_up_resistor_ena(self) -> &'a mut W {
-        self.variant(MODEW::PULL_UP_RESISTOR_ENA)
+    pub fn pull_up(self) -> &'a mut W {
+        self.variant(MODEW::PULL_UP)
     }
     #[doc = "Repeater mode."]
     #[inline]
-    pub fn repeater_mode_(self) -> &'a mut W {
-        self.variant(MODEW::REPEATER_MODE_)
+    pub fn repeater(self) -> &'a mut W {
+        self.variant(MODEW::REPEATER)
     }
     #[doc = r" Writes raw bits to the field"]
     #[inline]
@@ -397,9 +397,9 @@ impl<'a> _MODEW<'a> {
 #[doc = "Values that can be written to the field `HYS`"]
 pub enum HYSW {
     #[doc = "Disable."]
-    DISABLE_,
+    DISABLED,
     #[doc = "Enable."]
-    ENABLE_,
+    ENABLED,
 }
 impl HYSW {
     #[allow(missing_docs)]
@@ -407,8 +407,8 @@ impl HYSW {
     #[inline]
     pub fn _bits(&self) -> bool {
         match *self {
-            HYSW::DISABLE_ => false,
-            HYSW::ENABLE_ => true,
+            HYSW::DISABLED => false,
+            HYSW::ENABLED => true,
         }
     }
 }
@@ -426,13 +426,13 @@ impl<'a> _HYSW<'a> {
     }
     #[doc = "Disable."]
     #[inline]
-    pub fn disable_(self) -> &'a mut W {
-        self.variant(HYSW::DISABLE_)
+    pub fn disabled(self) -> &'a mut W {
+        self.variant(HYSW::DISABLED)
     }
     #[doc = "Enable."]
     #[inline]
-    pub fn enable_(self) -> &'a mut W {
-        self.variant(HYSW::ENABLE_)
+    pub fn enabled(self) -> &'a mut W {
+        self.variant(HYSW::ENABLED)
     }
     #[doc = r" Sets the field bit"]
     pub fn set_bit(self) -> &'a mut W {
@@ -455,9 +455,9 @@ impl<'a> _HYSW<'a> {
 #[doc = "Values that can be written to the field `INV`"]
 pub enum INVW {
     #[doc = "Input not inverted (HIGH on pin reads as 1, LOW on pin reads as 0)."]
-    INPUT_NOT_INVERTED_,
+    NOT_INVERTED,
     #[doc = "Input inverted (HIGH on pin reads as 0, LOW on pin reads as 1)."]
-    INPUT_INVERTED_HIGH,
+    INVERTED,
 }
 impl INVW {
     #[allow(missing_docs)]
@@ -465,8 +465,8 @@ impl INVW {
     #[inline]
     pub fn _bits(&self) -> bool {
         match *self {
-            INVW::INPUT_NOT_INVERTED_ => false,
-            INVW::INPUT_INVERTED_HIGH => true,
+            INVW::NOT_INVERTED => false,
+            INVW::INVERTED => true,
         }
     }
 }
@@ -484,13 +484,13 @@ impl<'a> _INVW<'a> {
     }
     #[doc = "Input not inverted (HIGH on pin reads as 1, LOW on pin reads as 0)."]
     #[inline]
-    pub fn input_not_inverted_(self) -> &'a mut W {
-        self.variant(INVW::INPUT_NOT_INVERTED_)
+    pub fn not_inverted(self) -> &'a mut W {
+        self.variant(INVW::NOT_INVERTED)
     }
     #[doc = "Input inverted (HIGH on pin reads as 0, LOW on pin reads as 1)."]
     #[inline]
-    pub fn input_inverted_high(self) -> &'a mut W {
-        self.variant(INVW::INPUT_INVERTED_HIGH)
+    pub fn inverted(self) -> &'a mut W {
+        self.variant(INVW::INVERTED)
     }
     #[doc = r" Sets the field bit"]
     pub fn set_bit(self) -> &'a mut W {
@@ -513,9 +513,9 @@ impl<'a> _INVW<'a> {
 #[doc = "Values that can be written to the field `OD`"]
 pub enum ODW {
     #[doc = "Disable."]
-    DISABLE_,
+    DISABLED,
     #[doc = "Open-drain mode enabled. This is not a true open-drain mode. Input cannot be pulled up above VDD."]
-    OPEN_DRAIN_MODE_ENAB,
+    OPEN_DRAIN,
 }
 impl ODW {
     #[allow(missing_docs)]
@@ -523,8 +523,8 @@ impl ODW {
     #[inline]
     pub fn _bits(&self) -> bool {
         match *self {
-            ODW::DISABLE_ => false,
-            ODW::OPEN_DRAIN_MODE_ENAB => true,
+            ODW::DISABLED => false,
+            ODW::OPEN_DRAIN => true,
         }
     }
 }
@@ -542,13 +542,13 @@ impl<'a> _ODW<'a> {
     }
     #[doc = "Disable."]
     #[inline]
-    pub fn disable_(self) -> &'a mut W {
-        self.variant(ODW::DISABLE_)
+    pub fn disabled(self) -> &'a mut W {
+        self.variant(ODW::DISABLED)
     }
     #[doc = "Open-drain mode enabled. This is not a true open-drain mode. Input cannot be pulled up above VDD."]
     #[inline]
-    pub fn open_drain_mode_enab(self) -> &'a mut W {
-        self.variant(ODW::OPEN_DRAIN_MODE_ENAB)
+    pub fn open_drain(self) -> &'a mut W {
+        self.variant(ODW::OPEN_DRAIN)
     }
     #[doc = r" Sets the field bit"]
     pub fn set_bit(self) -> &'a mut W {

--- a/lpc11uxx/src/iocon/pio1_10.rs
+++ b/lpc11uxx/src/iocon/pio1_10.rs
@@ -46,7 +46,7 @@ impl super::PIO1_10 {
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum FUNCR {
     #[doc = "PIO1_10."]
-    PIO1_10_,
+    PIO1_10,
     #[doc = r" Reserved"]
     _Reserved(u8),
 }
@@ -55,7 +55,7 @@ impl FUNCR {
     #[inline]
     pub fn bits(&self) -> u8 {
         match *self {
-            FUNCR::PIO1_10_ => 0,
+            FUNCR::PIO1_10 => 0,
             FUNCR::_Reserved(bits) => bits,
         }
     }
@@ -64,37 +64,37 @@ impl FUNCR {
     #[inline]
     pub fn _from(value: u8) -> FUNCR {
         match value {
-            0 => FUNCR::PIO1_10_,
+            0 => FUNCR::PIO1_10,
             i => FUNCR::_Reserved(i),
         }
     }
-    #[doc = "Checks if the value of the field is `PIO1_10_`"]
+    #[doc = "Checks if the value of the field is `PIO1_10`"]
     #[inline]
-    pub fn is_pio1_10_(&self) -> bool {
-        *self == FUNCR::PIO1_10_
+    pub fn is_pio1_10(&self) -> bool {
+        *self == FUNCR::PIO1_10
     }
 }
 #[doc = "Possible values of the field `MODE`"]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum MODER {
     #[doc = "Inactive (no pull-down/pull-up resistor enabled)."]
-    INACTIVE_NO_PULL_DO,
+    INACTIVE,
     #[doc = "Pull-down resistor enabled."]
-    PULL_DOWN_RESISTOR_E,
+    PULL_DOWN,
     #[doc = "Pull-up resistor enabled."]
-    PULL_UP_RESISTOR_ENA,
+    PULL_UP,
     #[doc = "Repeater mode."]
-    REPEATER_MODE_,
+    REPEATER,
 }
 impl MODER {
     #[doc = r" Value of the field as raw bits"]
     #[inline]
     pub fn bits(&self) -> u8 {
         match *self {
-            MODER::INACTIVE_NO_PULL_DO => 0,
-            MODER::PULL_DOWN_RESISTOR_E => 1,
-            MODER::PULL_UP_RESISTOR_ENA => 2,
-            MODER::REPEATER_MODE_ => 3,
+            MODER::INACTIVE => 0,
+            MODER::PULL_DOWN => 1,
+            MODER::PULL_UP => 2,
+            MODER::REPEATER => 3,
         }
     }
     #[allow(missing_docs)]
@@ -102,41 +102,41 @@ impl MODER {
     #[inline]
     pub fn _from(value: u8) -> MODER {
         match value {
-            0 => MODER::INACTIVE_NO_PULL_DO,
-            1 => MODER::PULL_DOWN_RESISTOR_E,
-            2 => MODER::PULL_UP_RESISTOR_ENA,
-            3 => MODER::REPEATER_MODE_,
+            0 => MODER::INACTIVE,
+            1 => MODER::PULL_DOWN,
+            2 => MODER::PULL_UP,
+            3 => MODER::REPEATER,
             _ => unreachable!(),
         }
     }
-    #[doc = "Checks if the value of the field is `INACTIVE_NO_PULL_DO`"]
+    #[doc = "Checks if the value of the field is `INACTIVE`"]
     #[inline]
-    pub fn is_inactive_no_pull_do(&self) -> bool {
-        *self == MODER::INACTIVE_NO_PULL_DO
+    pub fn is_inactive(&self) -> bool {
+        *self == MODER::INACTIVE
     }
-    #[doc = "Checks if the value of the field is `PULL_DOWN_RESISTOR_E`"]
+    #[doc = "Checks if the value of the field is `PULL_DOWN`"]
     #[inline]
-    pub fn is_pull_down_resistor_e(&self) -> bool {
-        *self == MODER::PULL_DOWN_RESISTOR_E
+    pub fn is_pull_down(&self) -> bool {
+        *self == MODER::PULL_DOWN
     }
-    #[doc = "Checks if the value of the field is `PULL_UP_RESISTOR_ENA`"]
+    #[doc = "Checks if the value of the field is `PULL_UP`"]
     #[inline]
-    pub fn is_pull_up_resistor_ena(&self) -> bool {
-        *self == MODER::PULL_UP_RESISTOR_ENA
+    pub fn is_pull_up(&self) -> bool {
+        *self == MODER::PULL_UP
     }
-    #[doc = "Checks if the value of the field is `REPEATER_MODE_`"]
+    #[doc = "Checks if the value of the field is `REPEATER`"]
     #[inline]
-    pub fn is_repeater_mode_(&self) -> bool {
-        *self == MODER::REPEATER_MODE_
+    pub fn is_repeater(&self) -> bool {
+        *self == MODER::REPEATER
     }
 }
 #[doc = "Possible values of the field `HYS`"]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum HYSR {
     #[doc = "Disable."]
-    DISABLE_,
+    DISABLED,
     #[doc = "Enable."]
-    ENABLE_,
+    ENABLED,
 }
 impl HYSR {
     #[doc = r" Returns `true` if the bit is clear (0)"]
@@ -153,8 +153,8 @@ impl HYSR {
     #[inline]
     pub fn bit(&self) -> bool {
         match *self {
-            HYSR::DISABLE_ => false,
-            HYSR::ENABLE_ => true,
+            HYSR::DISABLED => false,
+            HYSR::ENABLED => true,
         }
     }
     #[allow(missing_docs)]
@@ -162,28 +162,28 @@ impl HYSR {
     #[inline]
     pub fn _from(value: bool) -> HYSR {
         match value {
-            false => HYSR::DISABLE_,
-            true => HYSR::ENABLE_,
+            false => HYSR::DISABLED,
+            true => HYSR::ENABLED,
         }
     }
-    #[doc = "Checks if the value of the field is `DISABLE_`"]
+    #[doc = "Checks if the value of the field is `DISABLED`"]
     #[inline]
-    pub fn is_disable_(&self) -> bool {
-        *self == HYSR::DISABLE_
+    pub fn is_disabled(&self) -> bool {
+        *self == HYSR::DISABLED
     }
-    #[doc = "Checks if the value of the field is `ENABLE_`"]
+    #[doc = "Checks if the value of the field is `ENABLED`"]
     #[inline]
-    pub fn is_enable_(&self) -> bool {
-        *self == HYSR::ENABLE_
+    pub fn is_enabled(&self) -> bool {
+        *self == HYSR::ENABLED
     }
 }
 #[doc = "Possible values of the field `INV`"]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum INVR {
     #[doc = "Input not inverted (HIGH on pin reads as 1, LOW on pin reads as 0)."]
-    INPUT_NOT_INVERTED_,
+    NOT_INVERTED,
     #[doc = "Input inverted (HIGH on pin reads as 0, LOW on pin reads as 1)."]
-    INPUT_INVERTED_HIGH,
+    INVERTED,
 }
 impl INVR {
     #[doc = r" Returns `true` if the bit is clear (0)"]
@@ -200,8 +200,8 @@ impl INVR {
     #[inline]
     pub fn bit(&self) -> bool {
         match *self {
-            INVR::INPUT_NOT_INVERTED_ => false,
-            INVR::INPUT_INVERTED_HIGH => true,
+            INVR::NOT_INVERTED => false,
+            INVR::INVERTED => true,
         }
     }
     #[allow(missing_docs)]
@@ -209,28 +209,28 @@ impl INVR {
     #[inline]
     pub fn _from(value: bool) -> INVR {
         match value {
-            false => INVR::INPUT_NOT_INVERTED_,
-            true => INVR::INPUT_INVERTED_HIGH,
+            false => INVR::NOT_INVERTED,
+            true => INVR::INVERTED,
         }
     }
-    #[doc = "Checks if the value of the field is `INPUT_NOT_INVERTED_`"]
+    #[doc = "Checks if the value of the field is `NOT_INVERTED`"]
     #[inline]
-    pub fn is_input_not_inverted_(&self) -> bool {
-        *self == INVR::INPUT_NOT_INVERTED_
+    pub fn is_not_inverted(&self) -> bool {
+        *self == INVR::NOT_INVERTED
     }
-    #[doc = "Checks if the value of the field is `INPUT_INVERTED_HIGH`"]
+    #[doc = "Checks if the value of the field is `INVERTED`"]
     #[inline]
-    pub fn is_input_inverted_high(&self) -> bool {
-        *self == INVR::INPUT_INVERTED_HIGH
+    pub fn is_inverted(&self) -> bool {
+        *self == INVR::INVERTED
     }
 }
 #[doc = "Possible values of the field `OD`"]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum ODR {
     #[doc = "Disable."]
-    DISABLE_,
+    DISABLED,
     #[doc = "Open-drain mode enabled. This is not a true open-drain mode. Input cannot be pulled up above VDD."]
-    OPEN_DRAIN_MODE_ENAB,
+    OPEN_DRAIN,
 }
 impl ODR {
     #[doc = r" Returns `true` if the bit is clear (0)"]
@@ -247,8 +247,8 @@ impl ODR {
     #[inline]
     pub fn bit(&self) -> bool {
         match *self {
-            ODR::DISABLE_ => false,
-            ODR::OPEN_DRAIN_MODE_ENAB => true,
+            ODR::DISABLED => false,
+            ODR::OPEN_DRAIN => true,
         }
     }
     #[allow(missing_docs)]
@@ -256,25 +256,25 @@ impl ODR {
     #[inline]
     pub fn _from(value: bool) -> ODR {
         match value {
-            false => ODR::DISABLE_,
-            true => ODR::OPEN_DRAIN_MODE_ENAB,
+            false => ODR::DISABLED,
+            true => ODR::OPEN_DRAIN,
         }
     }
-    #[doc = "Checks if the value of the field is `DISABLE_`"]
+    #[doc = "Checks if the value of the field is `DISABLED`"]
     #[inline]
-    pub fn is_disable_(&self) -> bool {
-        *self == ODR::DISABLE_
+    pub fn is_disabled(&self) -> bool {
+        *self == ODR::DISABLED
     }
-    #[doc = "Checks if the value of the field is `OPEN_DRAIN_MODE_ENAB`"]
+    #[doc = "Checks if the value of the field is `OPEN_DRAIN`"]
     #[inline]
-    pub fn is_open_drain_mode_enab(&self) -> bool {
-        *self == ODR::OPEN_DRAIN_MODE_ENAB
+    pub fn is_open_drain(&self) -> bool {
+        *self == ODR::OPEN_DRAIN
     }
 }
 #[doc = "Values that can be written to the field `FUNC`"]
 pub enum FUNCW {
     #[doc = "PIO1_10."]
-    PIO1_10_,
+    PIO1_10,
 }
 impl FUNCW {
     #[allow(missing_docs)]
@@ -282,7 +282,7 @@ impl FUNCW {
     #[inline]
     pub fn _bits(&self) -> u8 {
         match *self {
-            FUNCW::PIO1_10_ => 0,
+            FUNCW::PIO1_10 => 0,
         }
     }
 }
@@ -298,8 +298,8 @@ impl<'a> _FUNCW<'a> {
     }
     #[doc = "PIO1_10."]
     #[inline]
-    pub fn pio1_10_(self) -> &'a mut W {
-        self.variant(FUNCW::PIO1_10_)
+    pub fn pio1_10(self) -> &'a mut W {
+        self.variant(FUNCW::PIO1_10)
     }
     #[doc = r" Writes raw bits to the field"]
     #[inline]
@@ -314,13 +314,13 @@ impl<'a> _FUNCW<'a> {
 #[doc = "Values that can be written to the field `MODE`"]
 pub enum MODEW {
     #[doc = "Inactive (no pull-down/pull-up resistor enabled)."]
-    INACTIVE_NO_PULL_DO,
+    INACTIVE,
     #[doc = "Pull-down resistor enabled."]
-    PULL_DOWN_RESISTOR_E,
+    PULL_DOWN,
     #[doc = "Pull-up resistor enabled."]
-    PULL_UP_RESISTOR_ENA,
+    PULL_UP,
     #[doc = "Repeater mode."]
-    REPEATER_MODE_,
+    REPEATER,
 }
 impl MODEW {
     #[allow(missing_docs)]
@@ -328,10 +328,10 @@ impl MODEW {
     #[inline]
     pub fn _bits(&self) -> u8 {
         match *self {
-            MODEW::INACTIVE_NO_PULL_DO => 0,
-            MODEW::PULL_DOWN_RESISTOR_E => 1,
-            MODEW::PULL_UP_RESISTOR_ENA => 2,
-            MODEW::REPEATER_MODE_ => 3,
+            MODEW::INACTIVE => 0,
+            MODEW::PULL_DOWN => 1,
+            MODEW::PULL_UP => 2,
+            MODEW::REPEATER => 3,
         }
     }
 }
@@ -349,23 +349,23 @@ impl<'a> _MODEW<'a> {
     }
     #[doc = "Inactive (no pull-down/pull-up resistor enabled)."]
     #[inline]
-    pub fn inactive_no_pull_do(self) -> &'a mut W {
-        self.variant(MODEW::INACTIVE_NO_PULL_DO)
+    pub fn inactive(self) -> &'a mut W {
+        self.variant(MODEW::INACTIVE)
     }
     #[doc = "Pull-down resistor enabled."]
     #[inline]
-    pub fn pull_down_resistor_e(self) -> &'a mut W {
-        self.variant(MODEW::PULL_DOWN_RESISTOR_E)
+    pub fn pull_down(self) -> &'a mut W {
+        self.variant(MODEW::PULL_DOWN)
     }
     #[doc = "Pull-up resistor enabled."]
     #[inline]
-    pub fn pull_up_resistor_ena(self) -> &'a mut W {
-        self.variant(MODEW::PULL_UP_RESISTOR_ENA)
+    pub fn pull_up(self) -> &'a mut W {
+        self.variant(MODEW::PULL_UP)
     }
     #[doc = "Repeater mode."]
     #[inline]
-    pub fn repeater_mode_(self) -> &'a mut W {
-        self.variant(MODEW::REPEATER_MODE_)
+    pub fn repeater(self) -> &'a mut W {
+        self.variant(MODEW::REPEATER)
     }
     #[doc = r" Writes raw bits to the field"]
     #[inline]
@@ -380,9 +380,9 @@ impl<'a> _MODEW<'a> {
 #[doc = "Values that can be written to the field `HYS`"]
 pub enum HYSW {
     #[doc = "Disable."]
-    DISABLE_,
+    DISABLED,
     #[doc = "Enable."]
-    ENABLE_,
+    ENABLED,
 }
 impl HYSW {
     #[allow(missing_docs)]
@@ -390,8 +390,8 @@ impl HYSW {
     #[inline]
     pub fn _bits(&self) -> bool {
         match *self {
-            HYSW::DISABLE_ => false,
-            HYSW::ENABLE_ => true,
+            HYSW::DISABLED => false,
+            HYSW::ENABLED => true,
         }
     }
 }
@@ -409,13 +409,13 @@ impl<'a> _HYSW<'a> {
     }
     #[doc = "Disable."]
     #[inline]
-    pub fn disable_(self) -> &'a mut W {
-        self.variant(HYSW::DISABLE_)
+    pub fn disabled(self) -> &'a mut W {
+        self.variant(HYSW::DISABLED)
     }
     #[doc = "Enable."]
     #[inline]
-    pub fn enable_(self) -> &'a mut W {
-        self.variant(HYSW::ENABLE_)
+    pub fn enabled(self) -> &'a mut W {
+        self.variant(HYSW::ENABLED)
     }
     #[doc = r" Sets the field bit"]
     pub fn set_bit(self) -> &'a mut W {
@@ -438,9 +438,9 @@ impl<'a> _HYSW<'a> {
 #[doc = "Values that can be written to the field `INV`"]
 pub enum INVW {
     #[doc = "Input not inverted (HIGH on pin reads as 1, LOW on pin reads as 0)."]
-    INPUT_NOT_INVERTED_,
+    NOT_INVERTED,
     #[doc = "Input inverted (HIGH on pin reads as 0, LOW on pin reads as 1)."]
-    INPUT_INVERTED_HIGH,
+    INVERTED,
 }
 impl INVW {
     #[allow(missing_docs)]
@@ -448,8 +448,8 @@ impl INVW {
     #[inline]
     pub fn _bits(&self) -> bool {
         match *self {
-            INVW::INPUT_NOT_INVERTED_ => false,
-            INVW::INPUT_INVERTED_HIGH => true,
+            INVW::NOT_INVERTED => false,
+            INVW::INVERTED => true,
         }
     }
 }
@@ -467,13 +467,13 @@ impl<'a> _INVW<'a> {
     }
     #[doc = "Input not inverted (HIGH on pin reads as 1, LOW on pin reads as 0)."]
     #[inline]
-    pub fn input_not_inverted_(self) -> &'a mut W {
-        self.variant(INVW::INPUT_NOT_INVERTED_)
+    pub fn not_inverted(self) -> &'a mut W {
+        self.variant(INVW::NOT_INVERTED)
     }
     #[doc = "Input inverted (HIGH on pin reads as 0, LOW on pin reads as 1)."]
     #[inline]
-    pub fn input_inverted_high(self) -> &'a mut W {
-        self.variant(INVW::INPUT_INVERTED_HIGH)
+    pub fn inverted(self) -> &'a mut W {
+        self.variant(INVW::INVERTED)
     }
     #[doc = r" Sets the field bit"]
     pub fn set_bit(self) -> &'a mut W {
@@ -496,9 +496,9 @@ impl<'a> _INVW<'a> {
 #[doc = "Values that can be written to the field `OD`"]
 pub enum ODW {
     #[doc = "Disable."]
-    DISABLE_,
+    DISABLED,
     #[doc = "Open-drain mode enabled. This is not a true open-drain mode. Input cannot be pulled up above VDD."]
-    OPEN_DRAIN_MODE_ENAB,
+    OPEN_DRAIN,
 }
 impl ODW {
     #[allow(missing_docs)]
@@ -506,8 +506,8 @@ impl ODW {
     #[inline]
     pub fn _bits(&self) -> bool {
         match *self {
-            ODW::DISABLE_ => false,
-            ODW::OPEN_DRAIN_MODE_ENAB => true,
+            ODW::DISABLED => false,
+            ODW::OPEN_DRAIN => true,
         }
     }
 }
@@ -525,13 +525,13 @@ impl<'a> _ODW<'a> {
     }
     #[doc = "Disable."]
     #[inline]
-    pub fn disable_(self) -> &'a mut W {
-        self.variant(ODW::DISABLE_)
+    pub fn disabled(self) -> &'a mut W {
+        self.variant(ODW::DISABLED)
     }
     #[doc = "Open-drain mode enabled. This is not a true open-drain mode. Input cannot be pulled up above VDD."]
     #[inline]
-    pub fn open_drain_mode_enab(self) -> &'a mut W {
-        self.variant(ODW::OPEN_DRAIN_MODE_ENAB)
+    pub fn open_drain(self) -> &'a mut W {
+        self.variant(ODW::OPEN_DRAIN)
     }
     #[doc = r" Sets the field bit"]
     pub fn set_bit(self) -> &'a mut W {

--- a/lpc11uxx/src/iocon/pio1_11.rs
+++ b/lpc11uxx/src/iocon/pio1_11.rs
@@ -46,7 +46,7 @@ impl super::PIO1_11 {
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum FUNCR {
     #[doc = "PIO1_11."]
-    PIO1_11_,
+    PIO1_11,
     #[doc = r" Reserved"]
     _Reserved(u8),
 }
@@ -55,7 +55,7 @@ impl FUNCR {
     #[inline]
     pub fn bits(&self) -> u8 {
         match *self {
-            FUNCR::PIO1_11_ => 0,
+            FUNCR::PIO1_11 => 0,
             FUNCR::_Reserved(bits) => bits,
         }
     }
@@ -64,37 +64,37 @@ impl FUNCR {
     #[inline]
     pub fn _from(value: u8) -> FUNCR {
         match value {
-            0 => FUNCR::PIO1_11_,
+            0 => FUNCR::PIO1_11,
             i => FUNCR::_Reserved(i),
         }
     }
-    #[doc = "Checks if the value of the field is `PIO1_11_`"]
+    #[doc = "Checks if the value of the field is `PIO1_11`"]
     #[inline]
-    pub fn is_pio1_11_(&self) -> bool {
-        *self == FUNCR::PIO1_11_
+    pub fn is_pio1_11(&self) -> bool {
+        *self == FUNCR::PIO1_11
     }
 }
 #[doc = "Possible values of the field `MODE`"]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum MODER {
     #[doc = "Inactive (no pull-down/pull-up resistor enabled)."]
-    INACTIVE_NO_PULL_DO,
+    INACTIVE,
     #[doc = "Pull-down resistor enabled."]
-    PULL_DOWN_RESISTOR_E,
+    PULL_DOWN,
     #[doc = "Pull-up resistor enabled."]
-    PULL_UP_RESISTOR_ENA,
+    PULL_UP,
     #[doc = "Repeater mode."]
-    REPEATER_MODE_,
+    REPEATER,
 }
 impl MODER {
     #[doc = r" Value of the field as raw bits"]
     #[inline]
     pub fn bits(&self) -> u8 {
         match *self {
-            MODER::INACTIVE_NO_PULL_DO => 0,
-            MODER::PULL_DOWN_RESISTOR_E => 1,
-            MODER::PULL_UP_RESISTOR_ENA => 2,
-            MODER::REPEATER_MODE_ => 3,
+            MODER::INACTIVE => 0,
+            MODER::PULL_DOWN => 1,
+            MODER::PULL_UP => 2,
+            MODER::REPEATER => 3,
         }
     }
     #[allow(missing_docs)]
@@ -102,41 +102,41 @@ impl MODER {
     #[inline]
     pub fn _from(value: u8) -> MODER {
         match value {
-            0 => MODER::INACTIVE_NO_PULL_DO,
-            1 => MODER::PULL_DOWN_RESISTOR_E,
-            2 => MODER::PULL_UP_RESISTOR_ENA,
-            3 => MODER::REPEATER_MODE_,
+            0 => MODER::INACTIVE,
+            1 => MODER::PULL_DOWN,
+            2 => MODER::PULL_UP,
+            3 => MODER::REPEATER,
             _ => unreachable!(),
         }
     }
-    #[doc = "Checks if the value of the field is `INACTIVE_NO_PULL_DO`"]
+    #[doc = "Checks if the value of the field is `INACTIVE`"]
     #[inline]
-    pub fn is_inactive_no_pull_do(&self) -> bool {
-        *self == MODER::INACTIVE_NO_PULL_DO
+    pub fn is_inactive(&self) -> bool {
+        *self == MODER::INACTIVE
     }
-    #[doc = "Checks if the value of the field is `PULL_DOWN_RESISTOR_E`"]
+    #[doc = "Checks if the value of the field is `PULL_DOWN`"]
     #[inline]
-    pub fn is_pull_down_resistor_e(&self) -> bool {
-        *self == MODER::PULL_DOWN_RESISTOR_E
+    pub fn is_pull_down(&self) -> bool {
+        *self == MODER::PULL_DOWN
     }
-    #[doc = "Checks if the value of the field is `PULL_UP_RESISTOR_ENA`"]
+    #[doc = "Checks if the value of the field is `PULL_UP`"]
     #[inline]
-    pub fn is_pull_up_resistor_ena(&self) -> bool {
-        *self == MODER::PULL_UP_RESISTOR_ENA
+    pub fn is_pull_up(&self) -> bool {
+        *self == MODER::PULL_UP
     }
-    #[doc = "Checks if the value of the field is `REPEATER_MODE_`"]
+    #[doc = "Checks if the value of the field is `REPEATER`"]
     #[inline]
-    pub fn is_repeater_mode_(&self) -> bool {
-        *self == MODER::REPEATER_MODE_
+    pub fn is_repeater(&self) -> bool {
+        *self == MODER::REPEATER
     }
 }
 #[doc = "Possible values of the field `HYS`"]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum HYSR {
     #[doc = "Disable."]
-    DISABLE_,
+    DISABLED,
     #[doc = "Enable."]
-    ENABLE_,
+    ENABLED,
 }
 impl HYSR {
     #[doc = r" Returns `true` if the bit is clear (0)"]
@@ -153,8 +153,8 @@ impl HYSR {
     #[inline]
     pub fn bit(&self) -> bool {
         match *self {
-            HYSR::DISABLE_ => false,
-            HYSR::ENABLE_ => true,
+            HYSR::DISABLED => false,
+            HYSR::ENABLED => true,
         }
     }
     #[allow(missing_docs)]
@@ -162,28 +162,28 @@ impl HYSR {
     #[inline]
     pub fn _from(value: bool) -> HYSR {
         match value {
-            false => HYSR::DISABLE_,
-            true => HYSR::ENABLE_,
+            false => HYSR::DISABLED,
+            true => HYSR::ENABLED,
         }
     }
-    #[doc = "Checks if the value of the field is `DISABLE_`"]
+    #[doc = "Checks if the value of the field is `DISABLED`"]
     #[inline]
-    pub fn is_disable_(&self) -> bool {
-        *self == HYSR::DISABLE_
+    pub fn is_disabled(&self) -> bool {
+        *self == HYSR::DISABLED
     }
-    #[doc = "Checks if the value of the field is `ENABLE_`"]
+    #[doc = "Checks if the value of the field is `ENABLED`"]
     #[inline]
-    pub fn is_enable_(&self) -> bool {
-        *self == HYSR::ENABLE_
+    pub fn is_enabled(&self) -> bool {
+        *self == HYSR::ENABLED
     }
 }
 #[doc = "Possible values of the field `INV`"]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum INVR {
     #[doc = "Input not inverted (HIGH on pin reads as 1, LOW on pin reads as 0)."]
-    INPUT_NOT_INVERTED_,
+    NOT_INVERTED,
     #[doc = "Input inverted (HIGH on pin reads as 0, LOW on pin reads as 1)."]
-    INPUT_INVERTED_HIGH,
+    INVERTED,
 }
 impl INVR {
     #[doc = r" Returns `true` if the bit is clear (0)"]
@@ -200,8 +200,8 @@ impl INVR {
     #[inline]
     pub fn bit(&self) -> bool {
         match *self {
-            INVR::INPUT_NOT_INVERTED_ => false,
-            INVR::INPUT_INVERTED_HIGH => true,
+            INVR::NOT_INVERTED => false,
+            INVR::INVERTED => true,
         }
     }
     #[allow(missing_docs)]
@@ -209,28 +209,28 @@ impl INVR {
     #[inline]
     pub fn _from(value: bool) -> INVR {
         match value {
-            false => INVR::INPUT_NOT_INVERTED_,
-            true => INVR::INPUT_INVERTED_HIGH,
+            false => INVR::NOT_INVERTED,
+            true => INVR::INVERTED,
         }
     }
-    #[doc = "Checks if the value of the field is `INPUT_NOT_INVERTED_`"]
+    #[doc = "Checks if the value of the field is `NOT_INVERTED`"]
     #[inline]
-    pub fn is_input_not_inverted_(&self) -> bool {
-        *self == INVR::INPUT_NOT_INVERTED_
+    pub fn is_not_inverted(&self) -> bool {
+        *self == INVR::NOT_INVERTED
     }
-    #[doc = "Checks if the value of the field is `INPUT_INVERTED_HIGH`"]
+    #[doc = "Checks if the value of the field is `INVERTED`"]
     #[inline]
-    pub fn is_input_inverted_high(&self) -> bool {
-        *self == INVR::INPUT_INVERTED_HIGH
+    pub fn is_inverted(&self) -> bool {
+        *self == INVR::INVERTED
     }
 }
 #[doc = "Possible values of the field `OD`"]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum ODR {
     #[doc = "Disable."]
-    DISABLE_,
+    DISABLED,
     #[doc = "Open-drain mode enabled. This is not a true open-drain mode. Input cannot be pulled up above VDD."]
-    OPEN_DRAIN_MODE_ENAB,
+    OPEN_DRAIN,
 }
 impl ODR {
     #[doc = r" Returns `true` if the bit is clear (0)"]
@@ -247,8 +247,8 @@ impl ODR {
     #[inline]
     pub fn bit(&self) -> bool {
         match *self {
-            ODR::DISABLE_ => false,
-            ODR::OPEN_DRAIN_MODE_ENAB => true,
+            ODR::DISABLED => false,
+            ODR::OPEN_DRAIN => true,
         }
     }
     #[allow(missing_docs)]
@@ -256,25 +256,25 @@ impl ODR {
     #[inline]
     pub fn _from(value: bool) -> ODR {
         match value {
-            false => ODR::DISABLE_,
-            true => ODR::OPEN_DRAIN_MODE_ENAB,
+            false => ODR::DISABLED,
+            true => ODR::OPEN_DRAIN,
         }
     }
-    #[doc = "Checks if the value of the field is `DISABLE_`"]
+    #[doc = "Checks if the value of the field is `DISABLED`"]
     #[inline]
-    pub fn is_disable_(&self) -> bool {
-        *self == ODR::DISABLE_
+    pub fn is_disabled(&self) -> bool {
+        *self == ODR::DISABLED
     }
-    #[doc = "Checks if the value of the field is `OPEN_DRAIN_MODE_ENAB`"]
+    #[doc = "Checks if the value of the field is `OPEN_DRAIN`"]
     #[inline]
-    pub fn is_open_drain_mode_enab(&self) -> bool {
-        *self == ODR::OPEN_DRAIN_MODE_ENAB
+    pub fn is_open_drain(&self) -> bool {
+        *self == ODR::OPEN_DRAIN
     }
 }
 #[doc = "Values that can be written to the field `FUNC`"]
 pub enum FUNCW {
     #[doc = "PIO1_11."]
-    PIO1_11_,
+    PIO1_11,
 }
 impl FUNCW {
     #[allow(missing_docs)]
@@ -282,7 +282,7 @@ impl FUNCW {
     #[inline]
     pub fn _bits(&self) -> u8 {
         match *self {
-            FUNCW::PIO1_11_ => 0,
+            FUNCW::PIO1_11 => 0,
         }
     }
 }
@@ -298,8 +298,8 @@ impl<'a> _FUNCW<'a> {
     }
     #[doc = "PIO1_11."]
     #[inline]
-    pub fn pio1_11_(self) -> &'a mut W {
-        self.variant(FUNCW::PIO1_11_)
+    pub fn pio1_11(self) -> &'a mut W {
+        self.variant(FUNCW::PIO1_11)
     }
     #[doc = r" Writes raw bits to the field"]
     #[inline]
@@ -314,13 +314,13 @@ impl<'a> _FUNCW<'a> {
 #[doc = "Values that can be written to the field `MODE`"]
 pub enum MODEW {
     #[doc = "Inactive (no pull-down/pull-up resistor enabled)."]
-    INACTIVE_NO_PULL_DO,
+    INACTIVE,
     #[doc = "Pull-down resistor enabled."]
-    PULL_DOWN_RESISTOR_E,
+    PULL_DOWN,
     #[doc = "Pull-up resistor enabled."]
-    PULL_UP_RESISTOR_ENA,
+    PULL_UP,
     #[doc = "Repeater mode."]
-    REPEATER_MODE_,
+    REPEATER,
 }
 impl MODEW {
     #[allow(missing_docs)]
@@ -328,10 +328,10 @@ impl MODEW {
     #[inline]
     pub fn _bits(&self) -> u8 {
         match *self {
-            MODEW::INACTIVE_NO_PULL_DO => 0,
-            MODEW::PULL_DOWN_RESISTOR_E => 1,
-            MODEW::PULL_UP_RESISTOR_ENA => 2,
-            MODEW::REPEATER_MODE_ => 3,
+            MODEW::INACTIVE => 0,
+            MODEW::PULL_DOWN => 1,
+            MODEW::PULL_UP => 2,
+            MODEW::REPEATER => 3,
         }
     }
 }
@@ -349,23 +349,23 @@ impl<'a> _MODEW<'a> {
     }
     #[doc = "Inactive (no pull-down/pull-up resistor enabled)."]
     #[inline]
-    pub fn inactive_no_pull_do(self) -> &'a mut W {
-        self.variant(MODEW::INACTIVE_NO_PULL_DO)
+    pub fn inactive(self) -> &'a mut W {
+        self.variant(MODEW::INACTIVE)
     }
     #[doc = "Pull-down resistor enabled."]
     #[inline]
-    pub fn pull_down_resistor_e(self) -> &'a mut W {
-        self.variant(MODEW::PULL_DOWN_RESISTOR_E)
+    pub fn pull_down(self) -> &'a mut W {
+        self.variant(MODEW::PULL_DOWN)
     }
     #[doc = "Pull-up resistor enabled."]
     #[inline]
-    pub fn pull_up_resistor_ena(self) -> &'a mut W {
-        self.variant(MODEW::PULL_UP_RESISTOR_ENA)
+    pub fn pull_up(self) -> &'a mut W {
+        self.variant(MODEW::PULL_UP)
     }
     #[doc = "Repeater mode."]
     #[inline]
-    pub fn repeater_mode_(self) -> &'a mut W {
-        self.variant(MODEW::REPEATER_MODE_)
+    pub fn repeater(self) -> &'a mut W {
+        self.variant(MODEW::REPEATER)
     }
     #[doc = r" Writes raw bits to the field"]
     #[inline]
@@ -380,9 +380,9 @@ impl<'a> _MODEW<'a> {
 #[doc = "Values that can be written to the field `HYS`"]
 pub enum HYSW {
     #[doc = "Disable."]
-    DISABLE_,
+    DISABLED,
     #[doc = "Enable."]
-    ENABLE_,
+    ENABLED,
 }
 impl HYSW {
     #[allow(missing_docs)]
@@ -390,8 +390,8 @@ impl HYSW {
     #[inline]
     pub fn _bits(&self) -> bool {
         match *self {
-            HYSW::DISABLE_ => false,
-            HYSW::ENABLE_ => true,
+            HYSW::DISABLED => false,
+            HYSW::ENABLED => true,
         }
     }
 }
@@ -409,13 +409,13 @@ impl<'a> _HYSW<'a> {
     }
     #[doc = "Disable."]
     #[inline]
-    pub fn disable_(self) -> &'a mut W {
-        self.variant(HYSW::DISABLE_)
+    pub fn disabled(self) -> &'a mut W {
+        self.variant(HYSW::DISABLED)
     }
     #[doc = "Enable."]
     #[inline]
-    pub fn enable_(self) -> &'a mut W {
-        self.variant(HYSW::ENABLE_)
+    pub fn enabled(self) -> &'a mut W {
+        self.variant(HYSW::ENABLED)
     }
     #[doc = r" Sets the field bit"]
     pub fn set_bit(self) -> &'a mut W {
@@ -438,9 +438,9 @@ impl<'a> _HYSW<'a> {
 #[doc = "Values that can be written to the field `INV`"]
 pub enum INVW {
     #[doc = "Input not inverted (HIGH on pin reads as 1, LOW on pin reads as 0)."]
-    INPUT_NOT_INVERTED_,
+    NOT_INVERTED,
     #[doc = "Input inverted (HIGH on pin reads as 0, LOW on pin reads as 1)."]
-    INPUT_INVERTED_HIGH,
+    INVERTED,
 }
 impl INVW {
     #[allow(missing_docs)]
@@ -448,8 +448,8 @@ impl INVW {
     #[inline]
     pub fn _bits(&self) -> bool {
         match *self {
-            INVW::INPUT_NOT_INVERTED_ => false,
-            INVW::INPUT_INVERTED_HIGH => true,
+            INVW::NOT_INVERTED => false,
+            INVW::INVERTED => true,
         }
     }
 }
@@ -467,13 +467,13 @@ impl<'a> _INVW<'a> {
     }
     #[doc = "Input not inverted (HIGH on pin reads as 1, LOW on pin reads as 0)."]
     #[inline]
-    pub fn input_not_inverted_(self) -> &'a mut W {
-        self.variant(INVW::INPUT_NOT_INVERTED_)
+    pub fn not_inverted(self) -> &'a mut W {
+        self.variant(INVW::NOT_INVERTED)
     }
     #[doc = "Input inverted (HIGH on pin reads as 0, LOW on pin reads as 1)."]
     #[inline]
-    pub fn input_inverted_high(self) -> &'a mut W {
-        self.variant(INVW::INPUT_INVERTED_HIGH)
+    pub fn inverted(self) -> &'a mut W {
+        self.variant(INVW::INVERTED)
     }
     #[doc = r" Sets the field bit"]
     pub fn set_bit(self) -> &'a mut W {
@@ -496,9 +496,9 @@ impl<'a> _INVW<'a> {
 #[doc = "Values that can be written to the field `OD`"]
 pub enum ODW {
     #[doc = "Disable."]
-    DISABLE_,
+    DISABLED,
     #[doc = "Open-drain mode enabled. This is not a true open-drain mode. Input cannot be pulled up above VDD."]
-    OPEN_DRAIN_MODE_ENAB,
+    OPEN_DRAIN,
 }
 impl ODW {
     #[allow(missing_docs)]
@@ -506,8 +506,8 @@ impl ODW {
     #[inline]
     pub fn _bits(&self) -> bool {
         match *self {
-            ODW::DISABLE_ => false,
-            ODW::OPEN_DRAIN_MODE_ENAB => true,
+            ODW::DISABLED => false,
+            ODW::OPEN_DRAIN => true,
         }
     }
 }
@@ -525,13 +525,13 @@ impl<'a> _ODW<'a> {
     }
     #[doc = "Disable."]
     #[inline]
-    pub fn disable_(self) -> &'a mut W {
-        self.variant(ODW::DISABLE_)
+    pub fn disabled(self) -> &'a mut W {
+        self.variant(ODW::DISABLED)
     }
     #[doc = "Open-drain mode enabled. This is not a true open-drain mode. Input cannot be pulled up above VDD."]
     #[inline]
-    pub fn open_drain_mode_enab(self) -> &'a mut W {
-        self.variant(ODW::OPEN_DRAIN_MODE_ENAB)
+    pub fn open_drain(self) -> &'a mut W {
+        self.variant(ODW::OPEN_DRAIN)
     }
     #[doc = r" Sets the field bit"]
     pub fn set_bit(self) -> &'a mut W {

--- a/lpc11uxx/src/iocon/pio1_12.rs
+++ b/lpc11uxx/src/iocon/pio1_12.rs
@@ -46,7 +46,7 @@ impl super::PIO1_12 {
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum FUNCR {
     #[doc = "PIO1_12."]
-    PIO1_12_,
+    PIO1_12,
     #[doc = r" Reserved"]
     _Reserved(u8),
 }
@@ -55,7 +55,7 @@ impl FUNCR {
     #[inline]
     pub fn bits(&self) -> u8 {
         match *self {
-            FUNCR::PIO1_12_ => 0,
+            FUNCR::PIO1_12 => 0,
             FUNCR::_Reserved(bits) => bits,
         }
     }
@@ -64,37 +64,37 @@ impl FUNCR {
     #[inline]
     pub fn _from(value: u8) -> FUNCR {
         match value {
-            0 => FUNCR::PIO1_12_,
+            0 => FUNCR::PIO1_12,
             i => FUNCR::_Reserved(i),
         }
     }
-    #[doc = "Checks if the value of the field is `PIO1_12_`"]
+    #[doc = "Checks if the value of the field is `PIO1_12`"]
     #[inline]
-    pub fn is_pio1_12_(&self) -> bool {
-        *self == FUNCR::PIO1_12_
+    pub fn is_pio1_12(&self) -> bool {
+        *self == FUNCR::PIO1_12
     }
 }
 #[doc = "Possible values of the field `MODE`"]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum MODER {
     #[doc = "Inactive (no pull-down/pull-up resistor enabled)."]
-    INACTIVE_NO_PULL_DO,
+    INACTIVE,
     #[doc = "Pull-down resistor enabled."]
-    PULL_DOWN_RESISTOR_E,
+    PULL_DOWN,
     #[doc = "Pull-up resistor enabled."]
-    PULL_UP_RESISTOR_ENA,
+    PULL_UP,
     #[doc = "Repeater mode."]
-    REPEATER_MODE_,
+    REPEATER,
 }
 impl MODER {
     #[doc = r" Value of the field as raw bits"]
     #[inline]
     pub fn bits(&self) -> u8 {
         match *self {
-            MODER::INACTIVE_NO_PULL_DO => 0,
-            MODER::PULL_DOWN_RESISTOR_E => 1,
-            MODER::PULL_UP_RESISTOR_ENA => 2,
-            MODER::REPEATER_MODE_ => 3,
+            MODER::INACTIVE => 0,
+            MODER::PULL_DOWN => 1,
+            MODER::PULL_UP => 2,
+            MODER::REPEATER => 3,
         }
     }
     #[allow(missing_docs)]
@@ -102,41 +102,41 @@ impl MODER {
     #[inline]
     pub fn _from(value: u8) -> MODER {
         match value {
-            0 => MODER::INACTIVE_NO_PULL_DO,
-            1 => MODER::PULL_DOWN_RESISTOR_E,
-            2 => MODER::PULL_UP_RESISTOR_ENA,
-            3 => MODER::REPEATER_MODE_,
+            0 => MODER::INACTIVE,
+            1 => MODER::PULL_DOWN,
+            2 => MODER::PULL_UP,
+            3 => MODER::REPEATER,
             _ => unreachable!(),
         }
     }
-    #[doc = "Checks if the value of the field is `INACTIVE_NO_PULL_DO`"]
+    #[doc = "Checks if the value of the field is `INACTIVE`"]
     #[inline]
-    pub fn is_inactive_no_pull_do(&self) -> bool {
-        *self == MODER::INACTIVE_NO_PULL_DO
+    pub fn is_inactive(&self) -> bool {
+        *self == MODER::INACTIVE
     }
-    #[doc = "Checks if the value of the field is `PULL_DOWN_RESISTOR_E`"]
+    #[doc = "Checks if the value of the field is `PULL_DOWN`"]
     #[inline]
-    pub fn is_pull_down_resistor_e(&self) -> bool {
-        *self == MODER::PULL_DOWN_RESISTOR_E
+    pub fn is_pull_down(&self) -> bool {
+        *self == MODER::PULL_DOWN
     }
-    #[doc = "Checks if the value of the field is `PULL_UP_RESISTOR_ENA`"]
+    #[doc = "Checks if the value of the field is `PULL_UP`"]
     #[inline]
-    pub fn is_pull_up_resistor_ena(&self) -> bool {
-        *self == MODER::PULL_UP_RESISTOR_ENA
+    pub fn is_pull_up(&self) -> bool {
+        *self == MODER::PULL_UP
     }
-    #[doc = "Checks if the value of the field is `REPEATER_MODE_`"]
+    #[doc = "Checks if the value of the field is `REPEATER`"]
     #[inline]
-    pub fn is_repeater_mode_(&self) -> bool {
-        *self == MODER::REPEATER_MODE_
+    pub fn is_repeater(&self) -> bool {
+        *self == MODER::REPEATER
     }
 }
 #[doc = "Possible values of the field `HYS`"]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum HYSR {
     #[doc = "Disable."]
-    DISABLE_,
+    DISABLED,
     #[doc = "Enable."]
-    ENABLE_,
+    ENABLED,
 }
 impl HYSR {
     #[doc = r" Returns `true` if the bit is clear (0)"]
@@ -153,8 +153,8 @@ impl HYSR {
     #[inline]
     pub fn bit(&self) -> bool {
         match *self {
-            HYSR::DISABLE_ => false,
-            HYSR::ENABLE_ => true,
+            HYSR::DISABLED => false,
+            HYSR::ENABLED => true,
         }
     }
     #[allow(missing_docs)]
@@ -162,28 +162,28 @@ impl HYSR {
     #[inline]
     pub fn _from(value: bool) -> HYSR {
         match value {
-            false => HYSR::DISABLE_,
-            true => HYSR::ENABLE_,
+            false => HYSR::DISABLED,
+            true => HYSR::ENABLED,
         }
     }
-    #[doc = "Checks if the value of the field is `DISABLE_`"]
+    #[doc = "Checks if the value of the field is `DISABLED`"]
     #[inline]
-    pub fn is_disable_(&self) -> bool {
-        *self == HYSR::DISABLE_
+    pub fn is_disabled(&self) -> bool {
+        *self == HYSR::DISABLED
     }
-    #[doc = "Checks if the value of the field is `ENABLE_`"]
+    #[doc = "Checks if the value of the field is `ENABLED`"]
     #[inline]
-    pub fn is_enable_(&self) -> bool {
-        *self == HYSR::ENABLE_
+    pub fn is_enabled(&self) -> bool {
+        *self == HYSR::ENABLED
     }
 }
 #[doc = "Possible values of the field `INV`"]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum INVR {
     #[doc = "Input not inverted (HIGH on pin reads as 1, LOW on pin reads as 0)."]
-    INPUT_NOT_INVERTED_,
+    NOT_INVERTED,
     #[doc = "Input inverted (HIGH on pin reads as 0, LOW on pin reads as 1)."]
-    INPUT_INVERTED_HIGH,
+    INVERTED,
 }
 impl INVR {
     #[doc = r" Returns `true` if the bit is clear (0)"]
@@ -200,8 +200,8 @@ impl INVR {
     #[inline]
     pub fn bit(&self) -> bool {
         match *self {
-            INVR::INPUT_NOT_INVERTED_ => false,
-            INVR::INPUT_INVERTED_HIGH => true,
+            INVR::NOT_INVERTED => false,
+            INVR::INVERTED => true,
         }
     }
     #[allow(missing_docs)]
@@ -209,28 +209,28 @@ impl INVR {
     #[inline]
     pub fn _from(value: bool) -> INVR {
         match value {
-            false => INVR::INPUT_NOT_INVERTED_,
-            true => INVR::INPUT_INVERTED_HIGH,
+            false => INVR::NOT_INVERTED,
+            true => INVR::INVERTED,
         }
     }
-    #[doc = "Checks if the value of the field is `INPUT_NOT_INVERTED_`"]
+    #[doc = "Checks if the value of the field is `NOT_INVERTED`"]
     #[inline]
-    pub fn is_input_not_inverted_(&self) -> bool {
-        *self == INVR::INPUT_NOT_INVERTED_
+    pub fn is_not_inverted(&self) -> bool {
+        *self == INVR::NOT_INVERTED
     }
-    #[doc = "Checks if the value of the field is `INPUT_INVERTED_HIGH`"]
+    #[doc = "Checks if the value of the field is `INVERTED`"]
     #[inline]
-    pub fn is_input_inverted_high(&self) -> bool {
-        *self == INVR::INPUT_INVERTED_HIGH
+    pub fn is_inverted(&self) -> bool {
+        *self == INVR::INVERTED
     }
 }
 #[doc = "Possible values of the field `OD`"]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum ODR {
     #[doc = "Disable."]
-    DISABLE_,
+    DISABLED,
     #[doc = "Open-drain mode enabled. This is not a true open-drain mode. Input cannot be pulled up above VDD."]
-    OPEN_DRAIN_MODE_ENAB,
+    OPEN_DRAIN,
 }
 impl ODR {
     #[doc = r" Returns `true` if the bit is clear (0)"]
@@ -247,8 +247,8 @@ impl ODR {
     #[inline]
     pub fn bit(&self) -> bool {
         match *self {
-            ODR::DISABLE_ => false,
-            ODR::OPEN_DRAIN_MODE_ENAB => true,
+            ODR::DISABLED => false,
+            ODR::OPEN_DRAIN => true,
         }
     }
     #[allow(missing_docs)]
@@ -256,25 +256,25 @@ impl ODR {
     #[inline]
     pub fn _from(value: bool) -> ODR {
         match value {
-            false => ODR::DISABLE_,
-            true => ODR::OPEN_DRAIN_MODE_ENAB,
+            false => ODR::DISABLED,
+            true => ODR::OPEN_DRAIN,
         }
     }
-    #[doc = "Checks if the value of the field is `DISABLE_`"]
+    #[doc = "Checks if the value of the field is `DISABLED`"]
     #[inline]
-    pub fn is_disable_(&self) -> bool {
-        *self == ODR::DISABLE_
+    pub fn is_disabled(&self) -> bool {
+        *self == ODR::DISABLED
     }
-    #[doc = "Checks if the value of the field is `OPEN_DRAIN_MODE_ENAB`"]
+    #[doc = "Checks if the value of the field is `OPEN_DRAIN`"]
     #[inline]
-    pub fn is_open_drain_mode_enab(&self) -> bool {
-        *self == ODR::OPEN_DRAIN_MODE_ENAB
+    pub fn is_open_drain(&self) -> bool {
+        *self == ODR::OPEN_DRAIN
     }
 }
 #[doc = "Values that can be written to the field `FUNC`"]
 pub enum FUNCW {
     #[doc = "PIO1_12."]
-    PIO1_12_,
+    PIO1_12,
 }
 impl FUNCW {
     #[allow(missing_docs)]
@@ -282,7 +282,7 @@ impl FUNCW {
     #[inline]
     pub fn _bits(&self) -> u8 {
         match *self {
-            FUNCW::PIO1_12_ => 0,
+            FUNCW::PIO1_12 => 0,
         }
     }
 }
@@ -298,8 +298,8 @@ impl<'a> _FUNCW<'a> {
     }
     #[doc = "PIO1_12."]
     #[inline]
-    pub fn pio1_12_(self) -> &'a mut W {
-        self.variant(FUNCW::PIO1_12_)
+    pub fn pio1_12(self) -> &'a mut W {
+        self.variant(FUNCW::PIO1_12)
     }
     #[doc = r" Writes raw bits to the field"]
     #[inline]
@@ -314,13 +314,13 @@ impl<'a> _FUNCW<'a> {
 #[doc = "Values that can be written to the field `MODE`"]
 pub enum MODEW {
     #[doc = "Inactive (no pull-down/pull-up resistor enabled)."]
-    INACTIVE_NO_PULL_DO,
+    INACTIVE,
     #[doc = "Pull-down resistor enabled."]
-    PULL_DOWN_RESISTOR_E,
+    PULL_DOWN,
     #[doc = "Pull-up resistor enabled."]
-    PULL_UP_RESISTOR_ENA,
+    PULL_UP,
     #[doc = "Repeater mode."]
-    REPEATER_MODE_,
+    REPEATER,
 }
 impl MODEW {
     #[allow(missing_docs)]
@@ -328,10 +328,10 @@ impl MODEW {
     #[inline]
     pub fn _bits(&self) -> u8 {
         match *self {
-            MODEW::INACTIVE_NO_PULL_DO => 0,
-            MODEW::PULL_DOWN_RESISTOR_E => 1,
-            MODEW::PULL_UP_RESISTOR_ENA => 2,
-            MODEW::REPEATER_MODE_ => 3,
+            MODEW::INACTIVE => 0,
+            MODEW::PULL_DOWN => 1,
+            MODEW::PULL_UP => 2,
+            MODEW::REPEATER => 3,
         }
     }
 }
@@ -349,23 +349,23 @@ impl<'a> _MODEW<'a> {
     }
     #[doc = "Inactive (no pull-down/pull-up resistor enabled)."]
     #[inline]
-    pub fn inactive_no_pull_do(self) -> &'a mut W {
-        self.variant(MODEW::INACTIVE_NO_PULL_DO)
+    pub fn inactive(self) -> &'a mut W {
+        self.variant(MODEW::INACTIVE)
     }
     #[doc = "Pull-down resistor enabled."]
     #[inline]
-    pub fn pull_down_resistor_e(self) -> &'a mut W {
-        self.variant(MODEW::PULL_DOWN_RESISTOR_E)
+    pub fn pull_down(self) -> &'a mut W {
+        self.variant(MODEW::PULL_DOWN)
     }
     #[doc = "Pull-up resistor enabled."]
     #[inline]
-    pub fn pull_up_resistor_ena(self) -> &'a mut W {
-        self.variant(MODEW::PULL_UP_RESISTOR_ENA)
+    pub fn pull_up(self) -> &'a mut W {
+        self.variant(MODEW::PULL_UP)
     }
     #[doc = "Repeater mode."]
     #[inline]
-    pub fn repeater_mode_(self) -> &'a mut W {
-        self.variant(MODEW::REPEATER_MODE_)
+    pub fn repeater(self) -> &'a mut W {
+        self.variant(MODEW::REPEATER)
     }
     #[doc = r" Writes raw bits to the field"]
     #[inline]
@@ -380,9 +380,9 @@ impl<'a> _MODEW<'a> {
 #[doc = "Values that can be written to the field `HYS`"]
 pub enum HYSW {
     #[doc = "Disable."]
-    DISABLE_,
+    DISABLED,
     #[doc = "Enable."]
-    ENABLE_,
+    ENABLED,
 }
 impl HYSW {
     #[allow(missing_docs)]
@@ -390,8 +390,8 @@ impl HYSW {
     #[inline]
     pub fn _bits(&self) -> bool {
         match *self {
-            HYSW::DISABLE_ => false,
-            HYSW::ENABLE_ => true,
+            HYSW::DISABLED => false,
+            HYSW::ENABLED => true,
         }
     }
 }
@@ -409,13 +409,13 @@ impl<'a> _HYSW<'a> {
     }
     #[doc = "Disable."]
     #[inline]
-    pub fn disable_(self) -> &'a mut W {
-        self.variant(HYSW::DISABLE_)
+    pub fn disabled(self) -> &'a mut W {
+        self.variant(HYSW::DISABLED)
     }
     #[doc = "Enable."]
     #[inline]
-    pub fn enable_(self) -> &'a mut W {
-        self.variant(HYSW::ENABLE_)
+    pub fn enabled(self) -> &'a mut W {
+        self.variant(HYSW::ENABLED)
     }
     #[doc = r" Sets the field bit"]
     pub fn set_bit(self) -> &'a mut W {
@@ -438,9 +438,9 @@ impl<'a> _HYSW<'a> {
 #[doc = "Values that can be written to the field `INV`"]
 pub enum INVW {
     #[doc = "Input not inverted (HIGH on pin reads as 1, LOW on pin reads as 0)."]
-    INPUT_NOT_INVERTED_,
+    NOT_INVERTED,
     #[doc = "Input inverted (HIGH on pin reads as 0, LOW on pin reads as 1)."]
-    INPUT_INVERTED_HIGH,
+    INVERTED,
 }
 impl INVW {
     #[allow(missing_docs)]
@@ -448,8 +448,8 @@ impl INVW {
     #[inline]
     pub fn _bits(&self) -> bool {
         match *self {
-            INVW::INPUT_NOT_INVERTED_ => false,
-            INVW::INPUT_INVERTED_HIGH => true,
+            INVW::NOT_INVERTED => false,
+            INVW::INVERTED => true,
         }
     }
 }
@@ -467,13 +467,13 @@ impl<'a> _INVW<'a> {
     }
     #[doc = "Input not inverted (HIGH on pin reads as 1, LOW on pin reads as 0)."]
     #[inline]
-    pub fn input_not_inverted_(self) -> &'a mut W {
-        self.variant(INVW::INPUT_NOT_INVERTED_)
+    pub fn not_inverted(self) -> &'a mut W {
+        self.variant(INVW::NOT_INVERTED)
     }
     #[doc = "Input inverted (HIGH on pin reads as 0, LOW on pin reads as 1)."]
     #[inline]
-    pub fn input_inverted_high(self) -> &'a mut W {
-        self.variant(INVW::INPUT_INVERTED_HIGH)
+    pub fn inverted(self) -> &'a mut W {
+        self.variant(INVW::INVERTED)
     }
     #[doc = r" Sets the field bit"]
     pub fn set_bit(self) -> &'a mut W {
@@ -496,9 +496,9 @@ impl<'a> _INVW<'a> {
 #[doc = "Values that can be written to the field `OD`"]
 pub enum ODW {
     #[doc = "Disable."]
-    DISABLE_,
+    DISABLED,
     #[doc = "Open-drain mode enabled. This is not a true open-drain mode. Input cannot be pulled up above VDD."]
-    OPEN_DRAIN_MODE_ENAB,
+    OPEN_DRAIN,
 }
 impl ODW {
     #[allow(missing_docs)]
@@ -506,8 +506,8 @@ impl ODW {
     #[inline]
     pub fn _bits(&self) -> bool {
         match *self {
-            ODW::DISABLE_ => false,
-            ODW::OPEN_DRAIN_MODE_ENAB => true,
+            ODW::DISABLED => false,
+            ODW::OPEN_DRAIN => true,
         }
     }
 }
@@ -525,13 +525,13 @@ impl<'a> _ODW<'a> {
     }
     #[doc = "Disable."]
     #[inline]
-    pub fn disable_(self) -> &'a mut W {
-        self.variant(ODW::DISABLE_)
+    pub fn disabled(self) -> &'a mut W {
+        self.variant(ODW::DISABLED)
     }
     #[doc = "Open-drain mode enabled. This is not a true open-drain mode. Input cannot be pulled up above VDD."]
     #[inline]
-    pub fn open_drain_mode_enab(self) -> &'a mut W {
-        self.variant(ODW::OPEN_DRAIN_MODE_ENAB)
+    pub fn open_drain(self) -> &'a mut W {
+        self.variant(ODW::OPEN_DRAIN)
     }
     #[doc = r" Sets the field bit"]
     pub fn set_bit(self) -> &'a mut W {

--- a/lpc11uxx/src/iocon/pio1_13.rs
+++ b/lpc11uxx/src/iocon/pio1_13.rs
@@ -46,13 +46,13 @@ impl super::PIO1_13 {
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum FUNCR {
     #[doc = "PIO1_13."]
-    PIO1_13_,
+    PIO1_13,
     #[doc = "DTR."]
-    DTR_,
+    DTR,
     #[doc = "CT16B0_MAT0."]
-    CT16B0_MAT0_,
+    CT16B0_MAT0,
     #[doc = "TXD."]
-    TXD_,
+    TXD,
     #[doc = r" Reserved"]
     _Reserved(u8),
 }
@@ -61,10 +61,10 @@ impl FUNCR {
     #[inline]
     pub fn bits(&self) -> u8 {
         match *self {
-            FUNCR::PIO1_13_ => 0,
-            FUNCR::DTR_ => 1,
-            FUNCR::CT16B0_MAT0_ => 2,
-            FUNCR::TXD_ => 3,
+            FUNCR::PIO1_13 => 0,
+            FUNCR::DTR => 1,
+            FUNCR::CT16B0_MAT0 => 2,
+            FUNCR::TXD => 3,
             FUNCR::_Reserved(bits) => bits,
         }
     }
@@ -73,55 +73,55 @@ impl FUNCR {
     #[inline]
     pub fn _from(value: u8) -> FUNCR {
         match value {
-            0 => FUNCR::PIO1_13_,
-            1 => FUNCR::DTR_,
-            2 => FUNCR::CT16B0_MAT0_,
-            3 => FUNCR::TXD_,
+            0 => FUNCR::PIO1_13,
+            1 => FUNCR::DTR,
+            2 => FUNCR::CT16B0_MAT0,
+            3 => FUNCR::TXD,
             i => FUNCR::_Reserved(i),
         }
     }
-    #[doc = "Checks if the value of the field is `PIO1_13_`"]
+    #[doc = "Checks if the value of the field is `PIO1_13`"]
     #[inline]
-    pub fn is_pio1_13_(&self) -> bool {
-        *self == FUNCR::PIO1_13_
+    pub fn is_pio1_13(&self) -> bool {
+        *self == FUNCR::PIO1_13
     }
-    #[doc = "Checks if the value of the field is `DTR_`"]
+    #[doc = "Checks if the value of the field is `DTR`"]
     #[inline]
-    pub fn is_dtr_(&self) -> bool {
-        *self == FUNCR::DTR_
+    pub fn is_dtr(&self) -> bool {
+        *self == FUNCR::DTR
     }
-    #[doc = "Checks if the value of the field is `CT16B0_MAT0_`"]
+    #[doc = "Checks if the value of the field is `CT16B0_MAT0`"]
     #[inline]
-    pub fn is_ct16b0_mat0_(&self) -> bool {
-        *self == FUNCR::CT16B0_MAT0_
+    pub fn is_ct16b0_mat0(&self) -> bool {
+        *self == FUNCR::CT16B0_MAT0
     }
-    #[doc = "Checks if the value of the field is `TXD_`"]
+    #[doc = "Checks if the value of the field is `TXD`"]
     #[inline]
-    pub fn is_txd_(&self) -> bool {
-        *self == FUNCR::TXD_
+    pub fn is_txd(&self) -> bool {
+        *self == FUNCR::TXD
     }
 }
 #[doc = "Possible values of the field `MODE`"]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum MODER {
     #[doc = "Inactive (no pull-down/pull-up resistor enabled)."]
-    INACTIVE_NO_PULL_DO,
+    INACTIVE,
     #[doc = "Pull-down resistor enabled."]
-    PULL_DOWN_RESISTOR_E,
+    PULL_DOWN,
     #[doc = "Pull-up resistor enabled."]
-    PULL_UP_RESISTOR_ENA,
+    PULL_UP,
     #[doc = "Repeater mode."]
-    REPEATER_MODE_,
+    REPEATER,
 }
 impl MODER {
     #[doc = r" Value of the field as raw bits"]
     #[inline]
     pub fn bits(&self) -> u8 {
         match *self {
-            MODER::INACTIVE_NO_PULL_DO => 0,
-            MODER::PULL_DOWN_RESISTOR_E => 1,
-            MODER::PULL_UP_RESISTOR_ENA => 2,
-            MODER::REPEATER_MODE_ => 3,
+            MODER::INACTIVE => 0,
+            MODER::PULL_DOWN => 1,
+            MODER::PULL_UP => 2,
+            MODER::REPEATER => 3,
         }
     }
     #[allow(missing_docs)]
@@ -129,41 +129,41 @@ impl MODER {
     #[inline]
     pub fn _from(value: u8) -> MODER {
         match value {
-            0 => MODER::INACTIVE_NO_PULL_DO,
-            1 => MODER::PULL_DOWN_RESISTOR_E,
-            2 => MODER::PULL_UP_RESISTOR_ENA,
-            3 => MODER::REPEATER_MODE_,
+            0 => MODER::INACTIVE,
+            1 => MODER::PULL_DOWN,
+            2 => MODER::PULL_UP,
+            3 => MODER::REPEATER,
             _ => unreachable!(),
         }
     }
-    #[doc = "Checks if the value of the field is `INACTIVE_NO_PULL_DO`"]
+    #[doc = "Checks if the value of the field is `INACTIVE`"]
     #[inline]
-    pub fn is_inactive_no_pull_do(&self) -> bool {
-        *self == MODER::INACTIVE_NO_PULL_DO
+    pub fn is_inactive(&self) -> bool {
+        *self == MODER::INACTIVE
     }
-    #[doc = "Checks if the value of the field is `PULL_DOWN_RESISTOR_E`"]
+    #[doc = "Checks if the value of the field is `PULL_DOWN`"]
     #[inline]
-    pub fn is_pull_down_resistor_e(&self) -> bool {
-        *self == MODER::PULL_DOWN_RESISTOR_E
+    pub fn is_pull_down(&self) -> bool {
+        *self == MODER::PULL_DOWN
     }
-    #[doc = "Checks if the value of the field is `PULL_UP_RESISTOR_ENA`"]
+    #[doc = "Checks if the value of the field is `PULL_UP`"]
     #[inline]
-    pub fn is_pull_up_resistor_ena(&self) -> bool {
-        *self == MODER::PULL_UP_RESISTOR_ENA
+    pub fn is_pull_up(&self) -> bool {
+        *self == MODER::PULL_UP
     }
-    #[doc = "Checks if the value of the field is `REPEATER_MODE_`"]
+    #[doc = "Checks if the value of the field is `REPEATER`"]
     #[inline]
-    pub fn is_repeater_mode_(&self) -> bool {
-        *self == MODER::REPEATER_MODE_
+    pub fn is_repeater(&self) -> bool {
+        *self == MODER::REPEATER
     }
 }
 #[doc = "Possible values of the field `HYS`"]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum HYSR {
     #[doc = "Disable."]
-    DISABLE_,
+    DISABLED,
     #[doc = "Enable."]
-    ENABLE_,
+    ENABLED,
 }
 impl HYSR {
     #[doc = r" Returns `true` if the bit is clear (0)"]
@@ -180,8 +180,8 @@ impl HYSR {
     #[inline]
     pub fn bit(&self) -> bool {
         match *self {
-            HYSR::DISABLE_ => false,
-            HYSR::ENABLE_ => true,
+            HYSR::DISABLED => false,
+            HYSR::ENABLED => true,
         }
     }
     #[allow(missing_docs)]
@@ -189,28 +189,28 @@ impl HYSR {
     #[inline]
     pub fn _from(value: bool) -> HYSR {
         match value {
-            false => HYSR::DISABLE_,
-            true => HYSR::ENABLE_,
+            false => HYSR::DISABLED,
+            true => HYSR::ENABLED,
         }
     }
-    #[doc = "Checks if the value of the field is `DISABLE_`"]
+    #[doc = "Checks if the value of the field is `DISABLED`"]
     #[inline]
-    pub fn is_disable_(&self) -> bool {
-        *self == HYSR::DISABLE_
+    pub fn is_disabled(&self) -> bool {
+        *self == HYSR::DISABLED
     }
-    #[doc = "Checks if the value of the field is `ENABLE_`"]
+    #[doc = "Checks if the value of the field is `ENABLED`"]
     #[inline]
-    pub fn is_enable_(&self) -> bool {
-        *self == HYSR::ENABLE_
+    pub fn is_enabled(&self) -> bool {
+        *self == HYSR::ENABLED
     }
 }
 #[doc = "Possible values of the field `INV`"]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum INVR {
     #[doc = "Input not inverted (HIGH on pin reads as 1, LOW on pin reads as 0)."]
-    INPUT_NOT_INVERTED_,
+    NOT_INVERTED,
     #[doc = "Input inverted (HIGH on pin reads as 0, LOW on pin reads as 1)."]
-    INPUT_INVERTED_HIGH,
+    INVERTED,
 }
 impl INVR {
     #[doc = r" Returns `true` if the bit is clear (0)"]
@@ -227,8 +227,8 @@ impl INVR {
     #[inline]
     pub fn bit(&self) -> bool {
         match *self {
-            INVR::INPUT_NOT_INVERTED_ => false,
-            INVR::INPUT_INVERTED_HIGH => true,
+            INVR::NOT_INVERTED => false,
+            INVR::INVERTED => true,
         }
     }
     #[allow(missing_docs)]
@@ -236,28 +236,28 @@ impl INVR {
     #[inline]
     pub fn _from(value: bool) -> INVR {
         match value {
-            false => INVR::INPUT_NOT_INVERTED_,
-            true => INVR::INPUT_INVERTED_HIGH,
+            false => INVR::NOT_INVERTED,
+            true => INVR::INVERTED,
         }
     }
-    #[doc = "Checks if the value of the field is `INPUT_NOT_INVERTED_`"]
+    #[doc = "Checks if the value of the field is `NOT_INVERTED`"]
     #[inline]
-    pub fn is_input_not_inverted_(&self) -> bool {
-        *self == INVR::INPUT_NOT_INVERTED_
+    pub fn is_not_inverted(&self) -> bool {
+        *self == INVR::NOT_INVERTED
     }
-    #[doc = "Checks if the value of the field is `INPUT_INVERTED_HIGH`"]
+    #[doc = "Checks if the value of the field is `INVERTED`"]
     #[inline]
-    pub fn is_input_inverted_high(&self) -> bool {
-        *self == INVR::INPUT_INVERTED_HIGH
+    pub fn is_inverted(&self) -> bool {
+        *self == INVR::INVERTED
     }
 }
 #[doc = "Possible values of the field `OD`"]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum ODR {
     #[doc = "Disable."]
-    DISABLE_,
+    DISABLED,
     #[doc = "Open-drain mode enabled.  This is not a true open-drain mode."]
-    OPEN_DRAIN_MODE_ENAB,
+    OPEN_DRAIN,
 }
 impl ODR {
     #[doc = r" Returns `true` if the bit is clear (0)"]
@@ -274,8 +274,8 @@ impl ODR {
     #[inline]
     pub fn bit(&self) -> bool {
         match *self {
-            ODR::DISABLE_ => false,
-            ODR::OPEN_DRAIN_MODE_ENAB => true,
+            ODR::DISABLED => false,
+            ODR::OPEN_DRAIN => true,
         }
     }
     #[allow(missing_docs)]
@@ -283,31 +283,31 @@ impl ODR {
     #[inline]
     pub fn _from(value: bool) -> ODR {
         match value {
-            false => ODR::DISABLE_,
-            true => ODR::OPEN_DRAIN_MODE_ENAB,
+            false => ODR::DISABLED,
+            true => ODR::OPEN_DRAIN,
         }
     }
-    #[doc = "Checks if the value of the field is `DISABLE_`"]
+    #[doc = "Checks if the value of the field is `DISABLED`"]
     #[inline]
-    pub fn is_disable_(&self) -> bool {
-        *self == ODR::DISABLE_
+    pub fn is_disabled(&self) -> bool {
+        *self == ODR::DISABLED
     }
-    #[doc = "Checks if the value of the field is `OPEN_DRAIN_MODE_ENAB`"]
+    #[doc = "Checks if the value of the field is `OPEN_DRAIN`"]
     #[inline]
-    pub fn is_open_drain_mode_enab(&self) -> bool {
-        *self == ODR::OPEN_DRAIN_MODE_ENAB
+    pub fn is_open_drain(&self) -> bool {
+        *self == ODR::OPEN_DRAIN
     }
 }
 #[doc = "Values that can be written to the field `FUNC`"]
 pub enum FUNCW {
     #[doc = "PIO1_13."]
-    PIO1_13_,
+    PIO1_13,
     #[doc = "DTR."]
-    DTR_,
+    DTR,
     #[doc = "CT16B0_MAT0."]
-    CT16B0_MAT0_,
+    CT16B0_MAT0,
     #[doc = "TXD."]
-    TXD_,
+    TXD,
 }
 impl FUNCW {
     #[allow(missing_docs)]
@@ -315,10 +315,10 @@ impl FUNCW {
     #[inline]
     pub fn _bits(&self) -> u8 {
         match *self {
-            FUNCW::PIO1_13_ => 0,
-            FUNCW::DTR_ => 1,
-            FUNCW::CT16B0_MAT0_ => 2,
-            FUNCW::TXD_ => 3,
+            FUNCW::PIO1_13 => 0,
+            FUNCW::DTR => 1,
+            FUNCW::CT16B0_MAT0 => 2,
+            FUNCW::TXD => 3,
         }
     }
 }
@@ -334,23 +334,23 @@ impl<'a> _FUNCW<'a> {
     }
     #[doc = "PIO1_13."]
     #[inline]
-    pub fn pio1_13_(self) -> &'a mut W {
-        self.variant(FUNCW::PIO1_13_)
+    pub fn pio1_13(self) -> &'a mut W {
+        self.variant(FUNCW::PIO1_13)
     }
     #[doc = "DTR."]
     #[inline]
-    pub fn dtr_(self) -> &'a mut W {
-        self.variant(FUNCW::DTR_)
+    pub fn dtr(self) -> &'a mut W {
+        self.variant(FUNCW::DTR)
     }
     #[doc = "CT16B0_MAT0."]
     #[inline]
-    pub fn ct16b0_mat0_(self) -> &'a mut W {
-        self.variant(FUNCW::CT16B0_MAT0_)
+    pub fn ct16b0_mat0(self) -> &'a mut W {
+        self.variant(FUNCW::CT16B0_MAT0)
     }
     #[doc = "TXD."]
     #[inline]
-    pub fn txd_(self) -> &'a mut W {
-        self.variant(FUNCW::TXD_)
+    pub fn txd(self) -> &'a mut W {
+        self.variant(FUNCW::TXD)
     }
     #[doc = r" Writes raw bits to the field"]
     #[inline]
@@ -365,13 +365,13 @@ impl<'a> _FUNCW<'a> {
 #[doc = "Values that can be written to the field `MODE`"]
 pub enum MODEW {
     #[doc = "Inactive (no pull-down/pull-up resistor enabled)."]
-    INACTIVE_NO_PULL_DO,
+    INACTIVE,
     #[doc = "Pull-down resistor enabled."]
-    PULL_DOWN_RESISTOR_E,
+    PULL_DOWN,
     #[doc = "Pull-up resistor enabled."]
-    PULL_UP_RESISTOR_ENA,
+    PULL_UP,
     #[doc = "Repeater mode."]
-    REPEATER_MODE_,
+    REPEATER,
 }
 impl MODEW {
     #[allow(missing_docs)]
@@ -379,10 +379,10 @@ impl MODEW {
     #[inline]
     pub fn _bits(&self) -> u8 {
         match *self {
-            MODEW::INACTIVE_NO_PULL_DO => 0,
-            MODEW::PULL_DOWN_RESISTOR_E => 1,
-            MODEW::PULL_UP_RESISTOR_ENA => 2,
-            MODEW::REPEATER_MODE_ => 3,
+            MODEW::INACTIVE => 0,
+            MODEW::PULL_DOWN => 1,
+            MODEW::PULL_UP => 2,
+            MODEW::REPEATER => 3,
         }
     }
 }
@@ -400,23 +400,23 @@ impl<'a> _MODEW<'a> {
     }
     #[doc = "Inactive (no pull-down/pull-up resistor enabled)."]
     #[inline]
-    pub fn inactive_no_pull_do(self) -> &'a mut W {
-        self.variant(MODEW::INACTIVE_NO_PULL_DO)
+    pub fn inactive(self) -> &'a mut W {
+        self.variant(MODEW::INACTIVE)
     }
     #[doc = "Pull-down resistor enabled."]
     #[inline]
-    pub fn pull_down_resistor_e(self) -> &'a mut W {
-        self.variant(MODEW::PULL_DOWN_RESISTOR_E)
+    pub fn pull_down(self) -> &'a mut W {
+        self.variant(MODEW::PULL_DOWN)
     }
     #[doc = "Pull-up resistor enabled."]
     #[inline]
-    pub fn pull_up_resistor_ena(self) -> &'a mut W {
-        self.variant(MODEW::PULL_UP_RESISTOR_ENA)
+    pub fn pull_up(self) -> &'a mut W {
+        self.variant(MODEW::PULL_UP)
     }
     #[doc = "Repeater mode."]
     #[inline]
-    pub fn repeater_mode_(self) -> &'a mut W {
-        self.variant(MODEW::REPEATER_MODE_)
+    pub fn repeater(self) -> &'a mut W {
+        self.variant(MODEW::REPEATER)
     }
     #[doc = r" Writes raw bits to the field"]
     #[inline]
@@ -431,9 +431,9 @@ impl<'a> _MODEW<'a> {
 #[doc = "Values that can be written to the field `HYS`"]
 pub enum HYSW {
     #[doc = "Disable."]
-    DISABLE_,
+    DISABLED,
     #[doc = "Enable."]
-    ENABLE_,
+    ENABLED,
 }
 impl HYSW {
     #[allow(missing_docs)]
@@ -441,8 +441,8 @@ impl HYSW {
     #[inline]
     pub fn _bits(&self) -> bool {
         match *self {
-            HYSW::DISABLE_ => false,
-            HYSW::ENABLE_ => true,
+            HYSW::DISABLED => false,
+            HYSW::ENABLED => true,
         }
     }
 }
@@ -460,13 +460,13 @@ impl<'a> _HYSW<'a> {
     }
     #[doc = "Disable."]
     #[inline]
-    pub fn disable_(self) -> &'a mut W {
-        self.variant(HYSW::DISABLE_)
+    pub fn disabled(self) -> &'a mut W {
+        self.variant(HYSW::DISABLED)
     }
     #[doc = "Enable."]
     #[inline]
-    pub fn enable_(self) -> &'a mut W {
-        self.variant(HYSW::ENABLE_)
+    pub fn enabled(self) -> &'a mut W {
+        self.variant(HYSW::ENABLED)
     }
     #[doc = r" Sets the field bit"]
     pub fn set_bit(self) -> &'a mut W {
@@ -489,9 +489,9 @@ impl<'a> _HYSW<'a> {
 #[doc = "Values that can be written to the field `INV`"]
 pub enum INVW {
     #[doc = "Input not inverted (HIGH on pin reads as 1, LOW on pin reads as 0)."]
-    INPUT_NOT_INVERTED_,
+    NOT_INVERTED,
     #[doc = "Input inverted (HIGH on pin reads as 0, LOW on pin reads as 1)."]
-    INPUT_INVERTED_HIGH,
+    INVERTED,
 }
 impl INVW {
     #[allow(missing_docs)]
@@ -499,8 +499,8 @@ impl INVW {
     #[inline]
     pub fn _bits(&self) -> bool {
         match *self {
-            INVW::INPUT_NOT_INVERTED_ => false,
-            INVW::INPUT_INVERTED_HIGH => true,
+            INVW::NOT_INVERTED => false,
+            INVW::INVERTED => true,
         }
     }
 }
@@ -518,13 +518,13 @@ impl<'a> _INVW<'a> {
     }
     #[doc = "Input not inverted (HIGH on pin reads as 1, LOW on pin reads as 0)."]
     #[inline]
-    pub fn input_not_inverted_(self) -> &'a mut W {
-        self.variant(INVW::INPUT_NOT_INVERTED_)
+    pub fn not_inverted(self) -> &'a mut W {
+        self.variant(INVW::NOT_INVERTED)
     }
     #[doc = "Input inverted (HIGH on pin reads as 0, LOW on pin reads as 1)."]
     #[inline]
-    pub fn input_inverted_high(self) -> &'a mut W {
-        self.variant(INVW::INPUT_INVERTED_HIGH)
+    pub fn inverted(self) -> &'a mut W {
+        self.variant(INVW::INVERTED)
     }
     #[doc = r" Sets the field bit"]
     pub fn set_bit(self) -> &'a mut W {
@@ -547,9 +547,9 @@ impl<'a> _INVW<'a> {
 #[doc = "Values that can be written to the field `OD`"]
 pub enum ODW {
     #[doc = "Disable."]
-    DISABLE_,
+    DISABLED,
     #[doc = "Open-drain mode enabled.  This is not a true open-drain mode."]
-    OPEN_DRAIN_MODE_ENAB,
+    OPEN_DRAIN,
 }
 impl ODW {
     #[allow(missing_docs)]
@@ -557,8 +557,8 @@ impl ODW {
     #[inline]
     pub fn _bits(&self) -> bool {
         match *self {
-            ODW::DISABLE_ => false,
-            ODW::OPEN_DRAIN_MODE_ENAB => true,
+            ODW::DISABLED => false,
+            ODW::OPEN_DRAIN => true,
         }
     }
 }
@@ -576,13 +576,13 @@ impl<'a> _ODW<'a> {
     }
     #[doc = "Disable."]
     #[inline]
-    pub fn disable_(self) -> &'a mut W {
-        self.variant(ODW::DISABLE_)
+    pub fn disabled(self) -> &'a mut W {
+        self.variant(ODW::DISABLED)
     }
     #[doc = "Open-drain mode enabled. This is not a true open-drain mode."]
     #[inline]
-    pub fn open_drain_mode_enab(self) -> &'a mut W {
-        self.variant(ODW::OPEN_DRAIN_MODE_ENAB)
+    pub fn open_drain(self) -> &'a mut W {
+        self.variant(ODW::OPEN_DRAIN)
     }
     #[doc = r" Sets the field bit"]
     pub fn set_bit(self) -> &'a mut W {

--- a/lpc11uxx/src/iocon/pio1_14.rs
+++ b/lpc11uxx/src/iocon/pio1_14.rs
@@ -46,13 +46,13 @@ impl super::PIO1_14 {
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum FUNCR {
     #[doc = "PIO1_14."]
-    PIO1_14_,
+    PIO1_14,
     #[doc = "DSR."]
-    DSR_,
+    DSR,
     #[doc = "CT16B0_MAT1."]
-    CT16B0_MAT1_,
+    CT16B0_MAT1,
     #[doc = "RXD."]
-    RXD_,
+    RXD,
     #[doc = r" Reserved"]
     _Reserved(u8),
 }
@@ -61,10 +61,10 @@ impl FUNCR {
     #[inline]
     pub fn bits(&self) -> u8 {
         match *self {
-            FUNCR::PIO1_14_ => 0,
-            FUNCR::DSR_ => 1,
-            FUNCR::CT16B0_MAT1_ => 2,
-            FUNCR::RXD_ => 3,
+            FUNCR::PIO1_14 => 0,
+            FUNCR::DSR => 1,
+            FUNCR::CT16B0_MAT1 => 2,
+            FUNCR::RXD => 3,
             FUNCR::_Reserved(bits) => bits,
         }
     }
@@ -73,55 +73,55 @@ impl FUNCR {
     #[inline]
     pub fn _from(value: u8) -> FUNCR {
         match value {
-            0 => FUNCR::PIO1_14_,
-            1 => FUNCR::DSR_,
-            2 => FUNCR::CT16B0_MAT1_,
-            3 => FUNCR::RXD_,
+            0 => FUNCR::PIO1_14,
+            1 => FUNCR::DSR,
+            2 => FUNCR::CT16B0_MAT1,
+            3 => FUNCR::RXD,
             i => FUNCR::_Reserved(i),
         }
     }
-    #[doc = "Checks if the value of the field is `PIO1_14_`"]
+    #[doc = "Checks if the value of the field is `PIO1_14`"]
     #[inline]
-    pub fn is_pio1_14_(&self) -> bool {
-        *self == FUNCR::PIO1_14_
+    pub fn is_pio1_14(&self) -> bool {
+        *self == FUNCR::PIO1_14
     }
-    #[doc = "Checks if the value of the field is `DSR_`"]
+    #[doc = "Checks if the value of the field is `DSR`"]
     #[inline]
-    pub fn is_dsr_(&self) -> bool {
-        *self == FUNCR::DSR_
+    pub fn is_dsr(&self) -> bool {
+        *self == FUNCR::DSR
     }
-    #[doc = "Checks if the value of the field is `CT16B0_MAT1_`"]
+    #[doc = "Checks if the value of the field is `CT16B0_MAT1`"]
     #[inline]
-    pub fn is_ct16b0_mat1_(&self) -> bool {
-        *self == FUNCR::CT16B0_MAT1_
+    pub fn is_ct16b0_mat1(&self) -> bool {
+        *self == FUNCR::CT16B0_MAT1
     }
-    #[doc = "Checks if the value of the field is `RXD_`"]
+    #[doc = "Checks if the value of the field is `RXD`"]
     #[inline]
-    pub fn is_rxd_(&self) -> bool {
-        *self == FUNCR::RXD_
+    pub fn is_rxd(&self) -> bool {
+        *self == FUNCR::RXD
     }
 }
 #[doc = "Possible values of the field `MODE`"]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum MODER {
     #[doc = "Inactive (no pull-down/pull-up resistor enabled)."]
-    INACTIVE_NO_PULL_DO,
+    INACTIVE,
     #[doc = "Pull-down resistor enabled."]
-    PULL_DOWN_RESISTOR_E,
+    PULL_DOWN,
     #[doc = "Pull-up resistor enabled."]
-    PULL_UP_RESISTOR_ENA,
+    PULL_UP,
     #[doc = "Repeater mode."]
-    REPEATER_MODE_,
+    REPEATER,
 }
 impl MODER {
     #[doc = r" Value of the field as raw bits"]
     #[inline]
     pub fn bits(&self) -> u8 {
         match *self {
-            MODER::INACTIVE_NO_PULL_DO => 0,
-            MODER::PULL_DOWN_RESISTOR_E => 1,
-            MODER::PULL_UP_RESISTOR_ENA => 2,
-            MODER::REPEATER_MODE_ => 3,
+            MODER::INACTIVE => 0,
+            MODER::PULL_DOWN => 1,
+            MODER::PULL_UP => 2,
+            MODER::REPEATER => 3,
         }
     }
     #[allow(missing_docs)]
@@ -129,41 +129,41 @@ impl MODER {
     #[inline]
     pub fn _from(value: u8) -> MODER {
         match value {
-            0 => MODER::INACTIVE_NO_PULL_DO,
-            1 => MODER::PULL_DOWN_RESISTOR_E,
-            2 => MODER::PULL_UP_RESISTOR_ENA,
-            3 => MODER::REPEATER_MODE_,
+            0 => MODER::INACTIVE,
+            1 => MODER::PULL_DOWN,
+            2 => MODER::PULL_UP,
+            3 => MODER::REPEATER,
             _ => unreachable!(),
         }
     }
-    #[doc = "Checks if the value of the field is `INACTIVE_NO_PULL_DO`"]
+    #[doc = "Checks if the value of the field is `INACTIVE`"]
     #[inline]
-    pub fn is_inactive_no_pull_do(&self) -> bool {
-        *self == MODER::INACTIVE_NO_PULL_DO
+    pub fn is_inactive(&self) -> bool {
+        *self == MODER::INACTIVE
     }
-    #[doc = "Checks if the value of the field is `PULL_DOWN_RESISTOR_E`"]
+    #[doc = "Checks if the value of the field is `PULL_DOWN`"]
     #[inline]
-    pub fn is_pull_down_resistor_e(&self) -> bool {
-        *self == MODER::PULL_DOWN_RESISTOR_E
+    pub fn is_pull_down(&self) -> bool {
+        *self == MODER::PULL_DOWN
     }
-    #[doc = "Checks if the value of the field is `PULL_UP_RESISTOR_ENA`"]
+    #[doc = "Checks if the value of the field is `PULL_UP`"]
     #[inline]
-    pub fn is_pull_up_resistor_ena(&self) -> bool {
-        *self == MODER::PULL_UP_RESISTOR_ENA
+    pub fn is_pull_up(&self) -> bool {
+        *self == MODER::PULL_UP
     }
-    #[doc = "Checks if the value of the field is `REPEATER_MODE_`"]
+    #[doc = "Checks if the value of the field is `REPEATER`"]
     #[inline]
-    pub fn is_repeater_mode_(&self) -> bool {
-        *self == MODER::REPEATER_MODE_
+    pub fn is_repeater(&self) -> bool {
+        *self == MODER::REPEATER
     }
 }
 #[doc = "Possible values of the field `HYS`"]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum HYSR {
     #[doc = "Disable."]
-    DISABLE_,
+    DISABLED,
     #[doc = "Enable."]
-    ENABLE_,
+    ENABLED,
 }
 impl HYSR {
     #[doc = r" Returns `true` if the bit is clear (0)"]
@@ -180,8 +180,8 @@ impl HYSR {
     #[inline]
     pub fn bit(&self) -> bool {
         match *self {
-            HYSR::DISABLE_ => false,
-            HYSR::ENABLE_ => true,
+            HYSR::DISABLED => false,
+            HYSR::ENABLED => true,
         }
     }
     #[allow(missing_docs)]
@@ -189,28 +189,28 @@ impl HYSR {
     #[inline]
     pub fn _from(value: bool) -> HYSR {
         match value {
-            false => HYSR::DISABLE_,
-            true => HYSR::ENABLE_,
+            false => HYSR::DISABLED,
+            true => HYSR::ENABLED,
         }
     }
-    #[doc = "Checks if the value of the field is `DISABLE_`"]
+    #[doc = "Checks if the value of the field is `DISABLED`"]
     #[inline]
-    pub fn is_disable_(&self) -> bool {
-        *self == HYSR::DISABLE_
+    pub fn is_disabled(&self) -> bool {
+        *self == HYSR::DISABLED
     }
-    #[doc = "Checks if the value of the field is `ENABLE_`"]
+    #[doc = "Checks if the value of the field is `ENABLED`"]
     #[inline]
-    pub fn is_enable_(&self) -> bool {
-        *self == HYSR::ENABLE_
+    pub fn is_enabled(&self) -> bool {
+        *self == HYSR::ENABLED
     }
 }
 #[doc = "Possible values of the field `INV`"]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum INVR {
     #[doc = "Input not inverted (HIGH on pin reads as 1, LOW on pin reads as 0)."]
-    INPUT_NOT_INVERTED_,
+    NOT_INVERTED,
     #[doc = "Input inverted (HIGH on pin reads as 0, LOW on pin reads as 1)."]
-    INPUT_INVERTED_HIGH,
+    INVERTED,
 }
 impl INVR {
     #[doc = r" Returns `true` if the bit is clear (0)"]
@@ -227,8 +227,8 @@ impl INVR {
     #[inline]
     pub fn bit(&self) -> bool {
         match *self {
-            INVR::INPUT_NOT_INVERTED_ => false,
-            INVR::INPUT_INVERTED_HIGH => true,
+            INVR::NOT_INVERTED => false,
+            INVR::INVERTED => true,
         }
     }
     #[allow(missing_docs)]
@@ -236,28 +236,28 @@ impl INVR {
     #[inline]
     pub fn _from(value: bool) -> INVR {
         match value {
-            false => INVR::INPUT_NOT_INVERTED_,
-            true => INVR::INPUT_INVERTED_HIGH,
+            false => INVR::NOT_INVERTED,
+            true => INVR::INVERTED,
         }
     }
-    #[doc = "Checks if the value of the field is `INPUT_NOT_INVERTED_`"]
+    #[doc = "Checks if the value of the field is `NOT_INVERTED`"]
     #[inline]
-    pub fn is_input_not_inverted_(&self) -> bool {
-        *self == INVR::INPUT_NOT_INVERTED_
+    pub fn is_not_inverted(&self) -> bool {
+        *self == INVR::NOT_INVERTED
     }
-    #[doc = "Checks if the value of the field is `INPUT_INVERTED_HIGH`"]
+    #[doc = "Checks if the value of the field is `INVERTED`"]
     #[inline]
-    pub fn is_input_inverted_high(&self) -> bool {
-        *self == INVR::INPUT_INVERTED_HIGH
+    pub fn is_inverted(&self) -> bool {
+        *self == INVR::INVERTED
     }
 }
 #[doc = "Possible values of the field `OD`"]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum ODR {
     #[doc = "Disable."]
-    DISABLE_,
+    DISABLED,
     #[doc = "Open-drain mode enabled.  This is not a true open-drain mode."]
-    OPEN_DRAIN_MODE_ENAB,
+    OPEN_DRAIN,
 }
 impl ODR {
     #[doc = r" Returns `true` if the bit is clear (0)"]
@@ -274,8 +274,8 @@ impl ODR {
     #[inline]
     pub fn bit(&self) -> bool {
         match *self {
-            ODR::DISABLE_ => false,
-            ODR::OPEN_DRAIN_MODE_ENAB => true,
+            ODR::DISABLED => false,
+            ODR::OPEN_DRAIN => true,
         }
     }
     #[allow(missing_docs)]
@@ -283,31 +283,31 @@ impl ODR {
     #[inline]
     pub fn _from(value: bool) -> ODR {
         match value {
-            false => ODR::DISABLE_,
-            true => ODR::OPEN_DRAIN_MODE_ENAB,
+            false => ODR::DISABLED,
+            true => ODR::OPEN_DRAIN,
         }
     }
-    #[doc = "Checks if the value of the field is `DISABLE_`"]
+    #[doc = "Checks if the value of the field is `DISABLED`"]
     #[inline]
-    pub fn is_disable_(&self) -> bool {
-        *self == ODR::DISABLE_
+    pub fn is_disabled(&self) -> bool {
+        *self == ODR::DISABLED
     }
-    #[doc = "Checks if the value of the field is `OPEN_DRAIN_MODE_ENAB`"]
+    #[doc = "Checks if the value of the field is `OPEN_DRAIN`"]
     #[inline]
-    pub fn is_open_drain_mode_enab(&self) -> bool {
-        *self == ODR::OPEN_DRAIN_MODE_ENAB
+    pub fn is_open_drain(&self) -> bool {
+        *self == ODR::OPEN_DRAIN
     }
 }
 #[doc = "Values that can be written to the field `FUNC`"]
 pub enum FUNCW {
     #[doc = "PIO1_14."]
-    PIO1_14_,
+    PIO1_14,
     #[doc = "DSR."]
-    DSR_,
+    DSR,
     #[doc = "CT16B0_MAT1."]
-    CT16B0_MAT1_,
+    CT16B0_MAT1,
     #[doc = "RXD."]
-    RXD_,
+    RXD,
 }
 impl FUNCW {
     #[allow(missing_docs)]
@@ -315,10 +315,10 @@ impl FUNCW {
     #[inline]
     pub fn _bits(&self) -> u8 {
         match *self {
-            FUNCW::PIO1_14_ => 0,
-            FUNCW::DSR_ => 1,
-            FUNCW::CT16B0_MAT1_ => 2,
-            FUNCW::RXD_ => 3,
+            FUNCW::PIO1_14 => 0,
+            FUNCW::DSR => 1,
+            FUNCW::CT16B0_MAT1 => 2,
+            FUNCW::RXD => 3,
         }
     }
 }
@@ -334,23 +334,23 @@ impl<'a> _FUNCW<'a> {
     }
     #[doc = "PIO1_14."]
     #[inline]
-    pub fn pio1_14_(self) -> &'a mut W {
-        self.variant(FUNCW::PIO1_14_)
+    pub fn pio1_14(self) -> &'a mut W {
+        self.variant(FUNCW::PIO1_14)
     }
     #[doc = "DSR."]
     #[inline]
-    pub fn dsr_(self) -> &'a mut W {
-        self.variant(FUNCW::DSR_)
+    pub fn dsr(self) -> &'a mut W {
+        self.variant(FUNCW::DSR)
     }
     #[doc = "CT16B0_MAT1."]
     #[inline]
-    pub fn ct16b0_mat1_(self) -> &'a mut W {
-        self.variant(FUNCW::CT16B0_MAT1_)
+    pub fn ct16b0_mat1(self) -> &'a mut W {
+        self.variant(FUNCW::CT16B0_MAT1)
     }
     #[doc = "RXD."]
     #[inline]
-    pub fn rxd_(self) -> &'a mut W {
-        self.variant(FUNCW::RXD_)
+    pub fn rxd(self) -> &'a mut W {
+        self.variant(FUNCW::RXD)
     }
     #[doc = r" Writes raw bits to the field"]
     #[inline]
@@ -365,13 +365,13 @@ impl<'a> _FUNCW<'a> {
 #[doc = "Values that can be written to the field `MODE`"]
 pub enum MODEW {
     #[doc = "Inactive (no pull-down/pull-up resistor enabled)."]
-    INACTIVE_NO_PULL_DO,
+    INACTIVE,
     #[doc = "Pull-down resistor enabled."]
-    PULL_DOWN_RESISTOR_E,
+    PULL_DOWN,
     #[doc = "Pull-up resistor enabled."]
-    PULL_UP_RESISTOR_ENA,
+    PULL_UP,
     #[doc = "Repeater mode."]
-    REPEATER_MODE_,
+    REPEATER,
 }
 impl MODEW {
     #[allow(missing_docs)]
@@ -379,10 +379,10 @@ impl MODEW {
     #[inline]
     pub fn _bits(&self) -> u8 {
         match *self {
-            MODEW::INACTIVE_NO_PULL_DO => 0,
-            MODEW::PULL_DOWN_RESISTOR_E => 1,
-            MODEW::PULL_UP_RESISTOR_ENA => 2,
-            MODEW::REPEATER_MODE_ => 3,
+            MODEW::INACTIVE => 0,
+            MODEW::PULL_DOWN => 1,
+            MODEW::PULL_UP => 2,
+            MODEW::REPEATER => 3,
         }
     }
 }
@@ -400,23 +400,23 @@ impl<'a> _MODEW<'a> {
     }
     #[doc = "Inactive (no pull-down/pull-up resistor enabled)."]
     #[inline]
-    pub fn inactive_no_pull_do(self) -> &'a mut W {
-        self.variant(MODEW::INACTIVE_NO_PULL_DO)
+    pub fn inactive(self) -> &'a mut W {
+        self.variant(MODEW::INACTIVE)
     }
     #[doc = "Pull-down resistor enabled."]
     #[inline]
-    pub fn pull_down_resistor_e(self) -> &'a mut W {
-        self.variant(MODEW::PULL_DOWN_RESISTOR_E)
+    pub fn pull_down(self) -> &'a mut W {
+        self.variant(MODEW::PULL_DOWN)
     }
     #[doc = "Pull-up resistor enabled."]
     #[inline]
-    pub fn pull_up_resistor_ena(self) -> &'a mut W {
-        self.variant(MODEW::PULL_UP_RESISTOR_ENA)
+    pub fn pull_up(self) -> &'a mut W {
+        self.variant(MODEW::PULL_UP)
     }
     #[doc = "Repeater mode."]
     #[inline]
-    pub fn repeater_mode_(self) -> &'a mut W {
-        self.variant(MODEW::REPEATER_MODE_)
+    pub fn repeater(self) -> &'a mut W {
+        self.variant(MODEW::REPEATER)
     }
     #[doc = r" Writes raw bits to the field"]
     #[inline]
@@ -431,9 +431,9 @@ impl<'a> _MODEW<'a> {
 #[doc = "Values that can be written to the field `HYS`"]
 pub enum HYSW {
     #[doc = "Disable."]
-    DISABLE_,
+    DISABLED,
     #[doc = "Enable."]
-    ENABLE_,
+    ENABLED,
 }
 impl HYSW {
     #[allow(missing_docs)]
@@ -441,8 +441,8 @@ impl HYSW {
     #[inline]
     pub fn _bits(&self) -> bool {
         match *self {
-            HYSW::DISABLE_ => false,
-            HYSW::ENABLE_ => true,
+            HYSW::DISABLED => false,
+            HYSW::ENABLED => true,
         }
     }
 }
@@ -460,13 +460,13 @@ impl<'a> _HYSW<'a> {
     }
     #[doc = "Disable."]
     #[inline]
-    pub fn disable_(self) -> &'a mut W {
-        self.variant(HYSW::DISABLE_)
+    pub fn disabled(self) -> &'a mut W {
+        self.variant(HYSW::DISABLED)
     }
     #[doc = "Enable."]
     #[inline]
-    pub fn enable_(self) -> &'a mut W {
-        self.variant(HYSW::ENABLE_)
+    pub fn enabled(self) -> &'a mut W {
+        self.variant(HYSW::ENABLED)
     }
     #[doc = r" Sets the field bit"]
     pub fn set_bit(self) -> &'a mut W {
@@ -489,9 +489,9 @@ impl<'a> _HYSW<'a> {
 #[doc = "Values that can be written to the field `INV`"]
 pub enum INVW {
     #[doc = "Input not inverted (HIGH on pin reads as 1, LOW on pin reads as 0)."]
-    INPUT_NOT_INVERTED_,
+    NOT_INVERTED,
     #[doc = "Input inverted (HIGH on pin reads as 0, LOW on pin reads as 1)."]
-    INPUT_INVERTED_HIGH,
+    INVERTED,
 }
 impl INVW {
     #[allow(missing_docs)]
@@ -499,8 +499,8 @@ impl INVW {
     #[inline]
     pub fn _bits(&self) -> bool {
         match *self {
-            INVW::INPUT_NOT_INVERTED_ => false,
-            INVW::INPUT_INVERTED_HIGH => true,
+            INVW::NOT_INVERTED => false,
+            INVW::INVERTED => true,
         }
     }
 }
@@ -518,13 +518,13 @@ impl<'a> _INVW<'a> {
     }
     #[doc = "Input not inverted (HIGH on pin reads as 1, LOW on pin reads as 0)."]
     #[inline]
-    pub fn input_not_inverted_(self) -> &'a mut W {
-        self.variant(INVW::INPUT_NOT_INVERTED_)
+    pub fn not_inverted(self) -> &'a mut W {
+        self.variant(INVW::NOT_INVERTED)
     }
     #[doc = "Input inverted (HIGH on pin reads as 0, LOW on pin reads as 1)."]
     #[inline]
-    pub fn input_inverted_high(self) -> &'a mut W {
-        self.variant(INVW::INPUT_INVERTED_HIGH)
+    pub fn inverted(self) -> &'a mut W {
+        self.variant(INVW::INVERTED)
     }
     #[doc = r" Sets the field bit"]
     pub fn set_bit(self) -> &'a mut W {
@@ -547,9 +547,9 @@ impl<'a> _INVW<'a> {
 #[doc = "Values that can be written to the field `OD`"]
 pub enum ODW {
     #[doc = "Disable."]
-    DISABLE_,
+    DISABLED,
     #[doc = "Open-drain mode enabled.  This is not a true open-drain mode."]
-    OPEN_DRAIN_MODE_ENAB,
+    OPEN_DRAIN,
 }
 impl ODW {
     #[allow(missing_docs)]
@@ -557,8 +557,8 @@ impl ODW {
     #[inline]
     pub fn _bits(&self) -> bool {
         match *self {
-            ODW::DISABLE_ => false,
-            ODW::OPEN_DRAIN_MODE_ENAB => true,
+            ODW::DISABLED => false,
+            ODW::OPEN_DRAIN => true,
         }
     }
 }
@@ -576,13 +576,13 @@ impl<'a> _ODW<'a> {
     }
     #[doc = "Disable."]
     #[inline]
-    pub fn disable_(self) -> &'a mut W {
-        self.variant(ODW::DISABLE_)
+    pub fn disabled(self) -> &'a mut W {
+        self.variant(ODW::DISABLED)
     }
     #[doc = "Open-drain mode enabled. This is not a true open-drain mode."]
     #[inline]
-    pub fn open_drain_mode_enab(self) -> &'a mut W {
-        self.variant(ODW::OPEN_DRAIN_MODE_ENAB)
+    pub fn open_drain(self) -> &'a mut W {
+        self.variant(ODW::OPEN_DRAIN)
     }
     #[doc = r" Sets the field bit"]
     pub fn set_bit(self) -> &'a mut W {

--- a/lpc11uxx/src/iocon/pio1_15.rs
+++ b/lpc11uxx/src/iocon/pio1_15.rs
@@ -46,13 +46,13 @@ impl super::PIO1_15 {
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum FUNCR {
     #[doc = "PIO1_15."]
-    PIO1_15_,
+    PIO1_15,
     #[doc = "DCD."]
-    DCD_,
+    DCD,
     #[doc = "CT16B0_MAT2."]
-    CT16B0_MAT2_,
+    CT16B0_MAT2,
     #[doc = "SCK1."]
-    SCK1_,
+    SCK1,
     #[doc = r" Reserved"]
     _Reserved(u8),
 }
@@ -61,10 +61,10 @@ impl FUNCR {
     #[inline]
     pub fn bits(&self) -> u8 {
         match *self {
-            FUNCR::PIO1_15_ => 0,
-            FUNCR::DCD_ => 1,
-            FUNCR::CT16B0_MAT2_ => 2,
-            FUNCR::SCK1_ => 3,
+            FUNCR::PIO1_15 => 0,
+            FUNCR::DCD => 1,
+            FUNCR::CT16B0_MAT2 => 2,
+            FUNCR::SCK1 => 3,
             FUNCR::_Reserved(bits) => bits,
         }
     }
@@ -73,55 +73,55 @@ impl FUNCR {
     #[inline]
     pub fn _from(value: u8) -> FUNCR {
         match value {
-            0 => FUNCR::PIO1_15_,
-            1 => FUNCR::DCD_,
-            2 => FUNCR::CT16B0_MAT2_,
-            3 => FUNCR::SCK1_,
+            0 => FUNCR::PIO1_15,
+            1 => FUNCR::DCD,
+            2 => FUNCR::CT16B0_MAT2,
+            3 => FUNCR::SCK1,
             i => FUNCR::_Reserved(i),
         }
     }
-    #[doc = "Checks if the value of the field is `PIO1_15_`"]
+    #[doc = "Checks if the value of the field is `PIO1_15`"]
     #[inline]
-    pub fn is_pio1_15_(&self) -> bool {
-        *self == FUNCR::PIO1_15_
+    pub fn is_pio1_15(&self) -> bool {
+        *self == FUNCR::PIO1_15
     }
-    #[doc = "Checks if the value of the field is `DCD_`"]
+    #[doc = "Checks if the value of the field is `DCD`"]
     #[inline]
-    pub fn is_dcd_(&self) -> bool {
-        *self == FUNCR::DCD_
+    pub fn is_dcd(&self) -> bool {
+        *self == FUNCR::DCD
     }
-    #[doc = "Checks if the value of the field is `CT16B0_MAT2_`"]
+    #[doc = "Checks if the value of the field is `CT16B0_MAT2`"]
     #[inline]
-    pub fn is_ct16b0_mat2_(&self) -> bool {
-        *self == FUNCR::CT16B0_MAT2_
+    pub fn is_ct16b0_mat2(&self) -> bool {
+        *self == FUNCR::CT16B0_MAT2
     }
-    #[doc = "Checks if the value of the field is `SCK1_`"]
+    #[doc = "Checks if the value of the field is `SCK1`"]
     #[inline]
-    pub fn is_sck1_(&self) -> bool {
-        *self == FUNCR::SCK1_
+    pub fn is_sck1(&self) -> bool {
+        *self == FUNCR::SCK1
     }
 }
 #[doc = "Possible values of the field `MODE`"]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum MODER {
     #[doc = "Inactive (no pull-down/pull-up resistor enabled)."]
-    INACTIVE_NO_PULL_DO,
+    INACTIVE,
     #[doc = "Pull-down resistor enabled."]
-    PULL_DOWN_RESISTOR_E,
+    PULL_DOWN,
     #[doc = "Pull-up resistor enabled."]
-    PULL_UP_RESISTOR_ENA,
+    PULL_UP,
     #[doc = "Repeater mode."]
-    REPEATER_MODE_,
+    REPEATER,
 }
 impl MODER {
     #[doc = r" Value of the field as raw bits"]
     #[inline]
     pub fn bits(&self) -> u8 {
         match *self {
-            MODER::INACTIVE_NO_PULL_DO => 0,
-            MODER::PULL_DOWN_RESISTOR_E => 1,
-            MODER::PULL_UP_RESISTOR_ENA => 2,
-            MODER::REPEATER_MODE_ => 3,
+            MODER::INACTIVE => 0,
+            MODER::PULL_DOWN => 1,
+            MODER::PULL_UP => 2,
+            MODER::REPEATER => 3,
         }
     }
     #[allow(missing_docs)]
@@ -129,41 +129,41 @@ impl MODER {
     #[inline]
     pub fn _from(value: u8) -> MODER {
         match value {
-            0 => MODER::INACTIVE_NO_PULL_DO,
-            1 => MODER::PULL_DOWN_RESISTOR_E,
-            2 => MODER::PULL_UP_RESISTOR_ENA,
-            3 => MODER::REPEATER_MODE_,
+            0 => MODER::INACTIVE,
+            1 => MODER::PULL_DOWN,
+            2 => MODER::PULL_UP,
+            3 => MODER::REPEATER,
             _ => unreachable!(),
         }
     }
-    #[doc = "Checks if the value of the field is `INACTIVE_NO_PULL_DO`"]
+    #[doc = "Checks if the value of the field is `INACTIVE`"]
     #[inline]
-    pub fn is_inactive_no_pull_do(&self) -> bool {
-        *self == MODER::INACTIVE_NO_PULL_DO
+    pub fn is_inactive(&self) -> bool {
+        *self == MODER::INACTIVE
     }
-    #[doc = "Checks if the value of the field is `PULL_DOWN_RESISTOR_E`"]
+    #[doc = "Checks if the value of the field is `PULL_DOWN`"]
     #[inline]
-    pub fn is_pull_down_resistor_e(&self) -> bool {
-        *self == MODER::PULL_DOWN_RESISTOR_E
+    pub fn is_pull_down(&self) -> bool {
+        *self == MODER::PULL_DOWN
     }
-    #[doc = "Checks if the value of the field is `PULL_UP_RESISTOR_ENA`"]
+    #[doc = "Checks if the value of the field is `PULL_UP`"]
     #[inline]
-    pub fn is_pull_up_resistor_ena(&self) -> bool {
-        *self == MODER::PULL_UP_RESISTOR_ENA
+    pub fn is_pull_up(&self) -> bool {
+        *self == MODER::PULL_UP
     }
-    #[doc = "Checks if the value of the field is `REPEATER_MODE_`"]
+    #[doc = "Checks if the value of the field is `REPEATER`"]
     #[inline]
-    pub fn is_repeater_mode_(&self) -> bool {
-        *self == MODER::REPEATER_MODE_
+    pub fn is_repeater(&self) -> bool {
+        *self == MODER::REPEATER
     }
 }
 #[doc = "Possible values of the field `HYS`"]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum HYSR {
     #[doc = "Disable."]
-    DISABLE_,
+    DISABLED,
     #[doc = "Enable."]
-    ENABLE_,
+    ENABLED,
 }
 impl HYSR {
     #[doc = r" Returns `true` if the bit is clear (0)"]
@@ -180,8 +180,8 @@ impl HYSR {
     #[inline]
     pub fn bit(&self) -> bool {
         match *self {
-            HYSR::DISABLE_ => false,
-            HYSR::ENABLE_ => true,
+            HYSR::DISABLED => false,
+            HYSR::ENABLED => true,
         }
     }
     #[allow(missing_docs)]
@@ -189,28 +189,28 @@ impl HYSR {
     #[inline]
     pub fn _from(value: bool) -> HYSR {
         match value {
-            false => HYSR::DISABLE_,
-            true => HYSR::ENABLE_,
+            false => HYSR::DISABLED,
+            true => HYSR::ENABLED,
         }
     }
-    #[doc = "Checks if the value of the field is `DISABLE_`"]
+    #[doc = "Checks if the value of the field is `DISABLED`"]
     #[inline]
-    pub fn is_disable_(&self) -> bool {
-        *self == HYSR::DISABLE_
+    pub fn is_disabled(&self) -> bool {
+        *self == HYSR::DISABLED
     }
-    #[doc = "Checks if the value of the field is `ENABLE_`"]
+    #[doc = "Checks if the value of the field is `ENABLED`"]
     #[inline]
-    pub fn is_enable_(&self) -> bool {
-        *self == HYSR::ENABLE_
+    pub fn is_enabled(&self) -> bool {
+        *self == HYSR::ENABLED
     }
 }
 #[doc = "Possible values of the field `INV`"]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum INVR {
     #[doc = "Input not inverted (HIGH on pin reads as 1, LOW on pin reads as 0)."]
-    INPUT_NOT_INVERTED_,
+    NOT_INVERTED,
     #[doc = "Input inverted (HIGH on pin reads as 0, LOW on pin reads as 1)."]
-    INPUT_INVERTED_HIGH,
+    INVERTED,
 }
 impl INVR {
     #[doc = r" Returns `true` if the bit is clear (0)"]
@@ -227,8 +227,8 @@ impl INVR {
     #[inline]
     pub fn bit(&self) -> bool {
         match *self {
-            INVR::INPUT_NOT_INVERTED_ => false,
-            INVR::INPUT_INVERTED_HIGH => true,
+            INVR::NOT_INVERTED => false,
+            INVR::INVERTED => true,
         }
     }
     #[allow(missing_docs)]
@@ -236,28 +236,28 @@ impl INVR {
     #[inline]
     pub fn _from(value: bool) -> INVR {
         match value {
-            false => INVR::INPUT_NOT_INVERTED_,
-            true => INVR::INPUT_INVERTED_HIGH,
+            false => INVR::NOT_INVERTED,
+            true => INVR::INVERTED,
         }
     }
-    #[doc = "Checks if the value of the field is `INPUT_NOT_INVERTED_`"]
+    #[doc = "Checks if the value of the field is `NOT_INVERTED`"]
     #[inline]
-    pub fn is_input_not_inverted_(&self) -> bool {
-        *self == INVR::INPUT_NOT_INVERTED_
+    pub fn is_not_inverted(&self) -> bool {
+        *self == INVR::NOT_INVERTED
     }
-    #[doc = "Checks if the value of the field is `INPUT_INVERTED_HIGH`"]
+    #[doc = "Checks if the value of the field is `INVERTED`"]
     #[inline]
-    pub fn is_input_inverted_high(&self) -> bool {
-        *self == INVR::INPUT_INVERTED_HIGH
+    pub fn is_inverted(&self) -> bool {
+        *self == INVR::INVERTED
     }
 }
 #[doc = "Possible values of the field `OD`"]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum ODR {
     #[doc = "Disable."]
-    DISABLE_,
+    DISABLED,
     #[doc = "Open-drain mode enabled.  This is not a true open-drain mode."]
-    OPEN_DRAIN_MODE_ENAB,
+    OPEN_DRAIN,
 }
 impl ODR {
     #[doc = r" Returns `true` if the bit is clear (0)"]
@@ -274,8 +274,8 @@ impl ODR {
     #[inline]
     pub fn bit(&self) -> bool {
         match *self {
-            ODR::DISABLE_ => false,
-            ODR::OPEN_DRAIN_MODE_ENAB => true,
+            ODR::DISABLED => false,
+            ODR::OPEN_DRAIN => true,
         }
     }
     #[allow(missing_docs)]
@@ -283,31 +283,31 @@ impl ODR {
     #[inline]
     pub fn _from(value: bool) -> ODR {
         match value {
-            false => ODR::DISABLE_,
-            true => ODR::OPEN_DRAIN_MODE_ENAB,
+            false => ODR::DISABLED,
+            true => ODR::OPEN_DRAIN,
         }
     }
-    #[doc = "Checks if the value of the field is `DISABLE_`"]
+    #[doc = "Checks if the value of the field is `DISABLED`"]
     #[inline]
-    pub fn is_disable_(&self) -> bool {
-        *self == ODR::DISABLE_
+    pub fn is_disabled(&self) -> bool {
+        *self == ODR::DISABLED
     }
-    #[doc = "Checks if the value of the field is `OPEN_DRAIN_MODE_ENAB`"]
+    #[doc = "Checks if the value of the field is `OPEN_DRAIN`"]
     #[inline]
-    pub fn is_open_drain_mode_enab(&self) -> bool {
-        *self == ODR::OPEN_DRAIN_MODE_ENAB
+    pub fn is_open_drain(&self) -> bool {
+        *self == ODR::OPEN_DRAIN
     }
 }
 #[doc = "Values that can be written to the field `FUNC`"]
 pub enum FUNCW {
     #[doc = "PIO1_15."]
-    PIO1_15_,
+    PIO1_15,
     #[doc = "DCD."]
-    DCD_,
+    DCD,
     #[doc = "CT16B0_MAT2."]
-    CT16B0_MAT2_,
+    CT16B0_MAT2,
     #[doc = "SCK1."]
-    SCK1_,
+    SCK1,
 }
 impl FUNCW {
     #[allow(missing_docs)]
@@ -315,10 +315,10 @@ impl FUNCW {
     #[inline]
     pub fn _bits(&self) -> u8 {
         match *self {
-            FUNCW::PIO1_15_ => 0,
-            FUNCW::DCD_ => 1,
-            FUNCW::CT16B0_MAT2_ => 2,
-            FUNCW::SCK1_ => 3,
+            FUNCW::PIO1_15 => 0,
+            FUNCW::DCD => 1,
+            FUNCW::CT16B0_MAT2 => 2,
+            FUNCW::SCK1 => 3,
         }
     }
 }
@@ -334,23 +334,23 @@ impl<'a> _FUNCW<'a> {
     }
     #[doc = "PIO1_15."]
     #[inline]
-    pub fn pio1_15_(self) -> &'a mut W {
-        self.variant(FUNCW::PIO1_15_)
+    pub fn pio1_15(self) -> &'a mut W {
+        self.variant(FUNCW::PIO1_15)
     }
     #[doc = "DCD."]
     #[inline]
-    pub fn dcd_(self) -> &'a mut W {
-        self.variant(FUNCW::DCD_)
+    pub fn dcd(self) -> &'a mut W {
+        self.variant(FUNCW::DCD)
     }
     #[doc = "CT16B0_MAT2."]
     #[inline]
-    pub fn ct16b0_mat2_(self) -> &'a mut W {
-        self.variant(FUNCW::CT16B0_MAT2_)
+    pub fn ct16b0_mat2(self) -> &'a mut W {
+        self.variant(FUNCW::CT16B0_MAT2)
     }
     #[doc = "SCK1."]
     #[inline]
-    pub fn sck1_(self) -> &'a mut W {
-        self.variant(FUNCW::SCK1_)
+    pub fn sck1(self) -> &'a mut W {
+        self.variant(FUNCW::SCK1)
     }
     #[doc = r" Writes raw bits to the field"]
     #[inline]
@@ -365,13 +365,13 @@ impl<'a> _FUNCW<'a> {
 #[doc = "Values that can be written to the field `MODE`"]
 pub enum MODEW {
     #[doc = "Inactive (no pull-down/pull-up resistor enabled)."]
-    INACTIVE_NO_PULL_DO,
+    INACTIVE,
     #[doc = "Pull-down resistor enabled."]
-    PULL_DOWN_RESISTOR_E,
+    PULL_DOWN,
     #[doc = "Pull-up resistor enabled."]
-    PULL_UP_RESISTOR_ENA,
+    PULL_UP,
     #[doc = "Repeater mode."]
-    REPEATER_MODE_,
+    REPEATER,
 }
 impl MODEW {
     #[allow(missing_docs)]
@@ -379,10 +379,10 @@ impl MODEW {
     #[inline]
     pub fn _bits(&self) -> u8 {
         match *self {
-            MODEW::INACTIVE_NO_PULL_DO => 0,
-            MODEW::PULL_DOWN_RESISTOR_E => 1,
-            MODEW::PULL_UP_RESISTOR_ENA => 2,
-            MODEW::REPEATER_MODE_ => 3,
+            MODEW::INACTIVE => 0,
+            MODEW::PULL_DOWN => 1,
+            MODEW::PULL_UP => 2,
+            MODEW::REPEATER => 3,
         }
     }
 }
@@ -400,23 +400,23 @@ impl<'a> _MODEW<'a> {
     }
     #[doc = "Inactive (no pull-down/pull-up resistor enabled)."]
     #[inline]
-    pub fn inactive_no_pull_do(self) -> &'a mut W {
-        self.variant(MODEW::INACTIVE_NO_PULL_DO)
+    pub fn inactive(self) -> &'a mut W {
+        self.variant(MODEW::INACTIVE)
     }
     #[doc = "Pull-down resistor enabled."]
     #[inline]
-    pub fn pull_down_resistor_e(self) -> &'a mut W {
-        self.variant(MODEW::PULL_DOWN_RESISTOR_E)
+    pub fn pull_down(self) -> &'a mut W {
+        self.variant(MODEW::PULL_DOWN)
     }
     #[doc = "Pull-up resistor enabled."]
     #[inline]
-    pub fn pull_up_resistor_ena(self) -> &'a mut W {
-        self.variant(MODEW::PULL_UP_RESISTOR_ENA)
+    pub fn pull_up(self) -> &'a mut W {
+        self.variant(MODEW::PULL_UP)
     }
     #[doc = "Repeater mode."]
     #[inline]
-    pub fn repeater_mode_(self) -> &'a mut W {
-        self.variant(MODEW::REPEATER_MODE_)
+    pub fn repeater(self) -> &'a mut W {
+        self.variant(MODEW::REPEATER)
     }
     #[doc = r" Writes raw bits to the field"]
     #[inline]
@@ -431,9 +431,9 @@ impl<'a> _MODEW<'a> {
 #[doc = "Values that can be written to the field `HYS`"]
 pub enum HYSW {
     #[doc = "Disable."]
-    DISABLE_,
+    DISABLED,
     #[doc = "Enable."]
-    ENABLE_,
+    ENABLED,
 }
 impl HYSW {
     #[allow(missing_docs)]
@@ -441,8 +441,8 @@ impl HYSW {
     #[inline]
     pub fn _bits(&self) -> bool {
         match *self {
-            HYSW::DISABLE_ => false,
-            HYSW::ENABLE_ => true,
+            HYSW::DISABLED => false,
+            HYSW::ENABLED => true,
         }
     }
 }
@@ -460,13 +460,13 @@ impl<'a> _HYSW<'a> {
     }
     #[doc = "Disable."]
     #[inline]
-    pub fn disable_(self) -> &'a mut W {
-        self.variant(HYSW::DISABLE_)
+    pub fn disabled(self) -> &'a mut W {
+        self.variant(HYSW::DISABLED)
     }
     #[doc = "Enable."]
     #[inline]
-    pub fn enable_(self) -> &'a mut W {
-        self.variant(HYSW::ENABLE_)
+    pub fn enabled(self) -> &'a mut W {
+        self.variant(HYSW::ENABLED)
     }
     #[doc = r" Sets the field bit"]
     pub fn set_bit(self) -> &'a mut W {
@@ -489,9 +489,9 @@ impl<'a> _HYSW<'a> {
 #[doc = "Values that can be written to the field `INV`"]
 pub enum INVW {
     #[doc = "Input not inverted (HIGH on pin reads as 1, LOW on pin reads as 0)."]
-    INPUT_NOT_INVERTED_,
+    NOT_INVERTED,
     #[doc = "Input inverted (HIGH on pin reads as 0, LOW on pin reads as 1)."]
-    INPUT_INVERTED_HIGH,
+    INVERTED,
 }
 impl INVW {
     #[allow(missing_docs)]
@@ -499,8 +499,8 @@ impl INVW {
     #[inline]
     pub fn _bits(&self) -> bool {
         match *self {
-            INVW::INPUT_NOT_INVERTED_ => false,
-            INVW::INPUT_INVERTED_HIGH => true,
+            INVW::NOT_INVERTED => false,
+            INVW::INVERTED => true,
         }
     }
 }
@@ -518,13 +518,13 @@ impl<'a> _INVW<'a> {
     }
     #[doc = "Input not inverted (HIGH on pin reads as 1, LOW on pin reads as 0)."]
     #[inline]
-    pub fn input_not_inverted_(self) -> &'a mut W {
-        self.variant(INVW::INPUT_NOT_INVERTED_)
+    pub fn not_inverted(self) -> &'a mut W {
+        self.variant(INVW::NOT_INVERTED)
     }
     #[doc = "Input inverted (HIGH on pin reads as 0, LOW on pin reads as 1)."]
     #[inline]
-    pub fn input_inverted_high(self) -> &'a mut W {
-        self.variant(INVW::INPUT_INVERTED_HIGH)
+    pub fn inverted(self) -> &'a mut W {
+        self.variant(INVW::INVERTED)
     }
     #[doc = r" Sets the field bit"]
     pub fn set_bit(self) -> &'a mut W {
@@ -547,9 +547,9 @@ impl<'a> _INVW<'a> {
 #[doc = "Values that can be written to the field `OD`"]
 pub enum ODW {
     #[doc = "Disable."]
-    DISABLE_,
+    DISABLED,
     #[doc = "Open-drain mode enabled.  This is not a true open-drain mode."]
-    OPEN_DRAIN_MODE_ENAB,
+    OPEN_DRAIN,
 }
 impl ODW {
     #[allow(missing_docs)]
@@ -557,8 +557,8 @@ impl ODW {
     #[inline]
     pub fn _bits(&self) -> bool {
         match *self {
-            ODW::DISABLE_ => false,
-            ODW::OPEN_DRAIN_MODE_ENAB => true,
+            ODW::DISABLED => false,
+            ODW::OPEN_DRAIN => true,
         }
     }
 }
@@ -576,13 +576,13 @@ impl<'a> _ODW<'a> {
     }
     #[doc = "Disable."]
     #[inline]
-    pub fn disable_(self) -> &'a mut W {
-        self.variant(ODW::DISABLE_)
+    pub fn disabled(self) -> &'a mut W {
+        self.variant(ODW::DISABLED)
     }
     #[doc = "Open-drain mode enabled. This is not a true open-drain mode."]
     #[inline]
-    pub fn open_drain_mode_enab(self) -> &'a mut W {
-        self.variant(ODW::OPEN_DRAIN_MODE_ENAB)
+    pub fn open_drain(self) -> &'a mut W {
+        self.variant(ODW::OPEN_DRAIN)
     }
     #[doc = r" Sets the field bit"]
     pub fn set_bit(self) -> &'a mut W {

--- a/lpc11uxx/src/iocon/pio1_16.rs
+++ b/lpc11uxx/src/iocon/pio1_16.rs
@@ -46,11 +46,11 @@ impl super::PIO1_16 {
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum FUNCR {
     #[doc = "PIO1_16."]
-    PIO1_16_,
+    PIO1_16,
     #[doc = "RI."]
-    RI_,
+    RI,
     #[doc = "CT16B0_CAP0."]
-    CT16B0_CAP0_,
+    CT16B0_CAP0,
     #[doc = r" Reserved"]
     _Reserved(u8),
 }
@@ -59,9 +59,9 @@ impl FUNCR {
     #[inline]
     pub fn bits(&self) -> u8 {
         match *self {
-            FUNCR::PIO1_16_ => 0,
-            FUNCR::RI_ => 1,
-            FUNCR::CT16B0_CAP0_ => 2,
+            FUNCR::PIO1_16 => 0,
+            FUNCR::RI => 1,
+            FUNCR::CT16B0_CAP0 => 2,
             FUNCR::_Reserved(bits) => bits,
         }
     }
@@ -70,49 +70,49 @@ impl FUNCR {
     #[inline]
     pub fn _from(value: u8) -> FUNCR {
         match value {
-            0 => FUNCR::PIO1_16_,
-            1 => FUNCR::RI_,
-            2 => FUNCR::CT16B0_CAP0_,
+            0 => FUNCR::PIO1_16,
+            1 => FUNCR::RI,
+            2 => FUNCR::CT16B0_CAP0,
             i => FUNCR::_Reserved(i),
         }
     }
-    #[doc = "Checks if the value of the field is `PIO1_16_`"]
+    #[doc = "Checks if the value of the field is `PIO1_16`"]
     #[inline]
-    pub fn is_pio1_16_(&self) -> bool {
-        *self == FUNCR::PIO1_16_
+    pub fn is_pio1_16(&self) -> bool {
+        *self == FUNCR::PIO1_16
     }
-    #[doc = "Checks if the value of the field is `RI_`"]
+    #[doc = "Checks if the value of the field is `RI`"]
     #[inline]
-    pub fn is_ri_(&self) -> bool {
-        *self == FUNCR::RI_
+    pub fn is_ri(&self) -> bool {
+        *self == FUNCR::RI
     }
-    #[doc = "Checks if the value of the field is `CT16B0_CAP0_`"]
+    #[doc = "Checks if the value of the field is `CT16B0_CAP0`"]
     #[inline]
-    pub fn is_ct16b0_cap0_(&self) -> bool {
-        *self == FUNCR::CT16B0_CAP0_
+    pub fn is_ct16b0_cap0(&self) -> bool {
+        *self == FUNCR::CT16B0_CAP0
     }
 }
 #[doc = "Possible values of the field `MODE`"]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum MODER {
     #[doc = "Inactive (no pull-down/pull-up resistor enabled)."]
-    INACTIVE_NO_PULL_DO,
+    INACTIVE,
     #[doc = "Pull-down resistor enabled."]
-    PULL_DOWN_RESISTOR_E,
+    PULL_DOWN,
     #[doc = "Pull-up resistor enabled."]
-    PULL_UP_RESISTOR_ENA,
+    PULL_UP,
     #[doc = "Repeater mode."]
-    REPEATER_MODE_,
+    REPEATER,
 }
 impl MODER {
     #[doc = r" Value of the field as raw bits"]
     #[inline]
     pub fn bits(&self) -> u8 {
         match *self {
-            MODER::INACTIVE_NO_PULL_DO => 0,
-            MODER::PULL_DOWN_RESISTOR_E => 1,
-            MODER::PULL_UP_RESISTOR_ENA => 2,
-            MODER::REPEATER_MODE_ => 3,
+            MODER::INACTIVE => 0,
+            MODER::PULL_DOWN => 1,
+            MODER::PULL_UP => 2,
+            MODER::REPEATER => 3,
         }
     }
     #[allow(missing_docs)]
@@ -120,41 +120,41 @@ impl MODER {
     #[inline]
     pub fn _from(value: u8) -> MODER {
         match value {
-            0 => MODER::INACTIVE_NO_PULL_DO,
-            1 => MODER::PULL_DOWN_RESISTOR_E,
-            2 => MODER::PULL_UP_RESISTOR_ENA,
-            3 => MODER::REPEATER_MODE_,
+            0 => MODER::INACTIVE,
+            1 => MODER::PULL_DOWN,
+            2 => MODER::PULL_UP,
+            3 => MODER::REPEATER,
             _ => unreachable!(),
         }
     }
-    #[doc = "Checks if the value of the field is `INACTIVE_NO_PULL_DO`"]
+    #[doc = "Checks if the value of the field is `INACTIVE`"]
     #[inline]
-    pub fn is_inactive_no_pull_do(&self) -> bool {
-        *self == MODER::INACTIVE_NO_PULL_DO
+    pub fn is_inactive(&self) -> bool {
+        *self == MODER::INACTIVE
     }
-    #[doc = "Checks if the value of the field is `PULL_DOWN_RESISTOR_E`"]
+    #[doc = "Checks if the value of the field is `PULL_DOWN`"]
     #[inline]
-    pub fn is_pull_down_resistor_e(&self) -> bool {
-        *self == MODER::PULL_DOWN_RESISTOR_E
+    pub fn is_pull_down(&self) -> bool {
+        *self == MODER::PULL_DOWN
     }
-    #[doc = "Checks if the value of the field is `PULL_UP_RESISTOR_ENA`"]
+    #[doc = "Checks if the value of the field is `PULL_UP`"]
     #[inline]
-    pub fn is_pull_up_resistor_ena(&self) -> bool {
-        *self == MODER::PULL_UP_RESISTOR_ENA
+    pub fn is_pull_up(&self) -> bool {
+        *self == MODER::PULL_UP
     }
-    #[doc = "Checks if the value of the field is `REPEATER_MODE_`"]
+    #[doc = "Checks if the value of the field is `REPEATER`"]
     #[inline]
-    pub fn is_repeater_mode_(&self) -> bool {
-        *self == MODER::REPEATER_MODE_
+    pub fn is_repeater(&self) -> bool {
+        *self == MODER::REPEATER
     }
 }
 #[doc = "Possible values of the field `HYS`"]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum HYSR {
     #[doc = "Disable."]
-    DISABLE_,
+    DISABLED,
     #[doc = "Enable."]
-    ENABLE_,
+    ENABLED,
 }
 impl HYSR {
     #[doc = r" Returns `true` if the bit is clear (0)"]
@@ -171,8 +171,8 @@ impl HYSR {
     #[inline]
     pub fn bit(&self) -> bool {
         match *self {
-            HYSR::DISABLE_ => false,
-            HYSR::ENABLE_ => true,
+            HYSR::DISABLED => false,
+            HYSR::ENABLED => true,
         }
     }
     #[allow(missing_docs)]
@@ -180,28 +180,28 @@ impl HYSR {
     #[inline]
     pub fn _from(value: bool) -> HYSR {
         match value {
-            false => HYSR::DISABLE_,
-            true => HYSR::ENABLE_,
+            false => HYSR::DISABLED,
+            true => HYSR::ENABLED,
         }
     }
-    #[doc = "Checks if the value of the field is `DISABLE_`"]
+    #[doc = "Checks if the value of the field is `DISABLED`"]
     #[inline]
-    pub fn is_disable_(&self) -> bool {
-        *self == HYSR::DISABLE_
+    pub fn is_disabled(&self) -> bool {
+        *self == HYSR::DISABLED
     }
-    #[doc = "Checks if the value of the field is `ENABLE_`"]
+    #[doc = "Checks if the value of the field is `ENABLED`"]
     #[inline]
-    pub fn is_enable_(&self) -> bool {
-        *self == HYSR::ENABLE_
+    pub fn is_enabled(&self) -> bool {
+        *self == HYSR::ENABLED
     }
 }
 #[doc = "Possible values of the field `INV`"]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum INVR {
     #[doc = "Input not inverted (HIGH on pin reads as 1, LOW on pin reads as 0)."]
-    INPUT_NOT_INVERTED_,
+    NOT_INVERTED,
     #[doc = "Input inverted (HIGH on pin reads as 0, LOW on pin reads as 1)."]
-    INPUT_INVERTED_HIGH,
+    INVERTED,
 }
 impl INVR {
     #[doc = r" Returns `true` if the bit is clear (0)"]
@@ -218,8 +218,8 @@ impl INVR {
     #[inline]
     pub fn bit(&self) -> bool {
         match *self {
-            INVR::INPUT_NOT_INVERTED_ => false,
-            INVR::INPUT_INVERTED_HIGH => true,
+            INVR::NOT_INVERTED => false,
+            INVR::INVERTED => true,
         }
     }
     #[allow(missing_docs)]
@@ -227,28 +227,28 @@ impl INVR {
     #[inline]
     pub fn _from(value: bool) -> INVR {
         match value {
-            false => INVR::INPUT_NOT_INVERTED_,
-            true => INVR::INPUT_INVERTED_HIGH,
+            false => INVR::NOT_INVERTED,
+            true => INVR::INVERTED,
         }
     }
-    #[doc = "Checks if the value of the field is `INPUT_NOT_INVERTED_`"]
+    #[doc = "Checks if the value of the field is `NOT_INVERTED`"]
     #[inline]
-    pub fn is_input_not_inverted_(&self) -> bool {
-        *self == INVR::INPUT_NOT_INVERTED_
+    pub fn is_not_inverted(&self) -> bool {
+        *self == INVR::NOT_INVERTED
     }
-    #[doc = "Checks if the value of the field is `INPUT_INVERTED_HIGH`"]
+    #[doc = "Checks if the value of the field is `INVERTED`"]
     #[inline]
-    pub fn is_input_inverted_high(&self) -> bool {
-        *self == INVR::INPUT_INVERTED_HIGH
+    pub fn is_inverted(&self) -> bool {
+        *self == INVR::INVERTED
     }
 }
 #[doc = "Possible values of the field `OD`"]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum ODR {
     #[doc = "Disable."]
-    DISABLE_,
+    DISABLED,
     #[doc = "Open-drain mode enabled.  This is not a true open-drain mode."]
-    OPEN_DRAIN_MODE_ENAB,
+    OPEN_DRAIN,
 }
 impl ODR {
     #[doc = r" Returns `true` if the bit is clear (0)"]
@@ -265,8 +265,8 @@ impl ODR {
     #[inline]
     pub fn bit(&self) -> bool {
         match *self {
-            ODR::DISABLE_ => false,
-            ODR::OPEN_DRAIN_MODE_ENAB => true,
+            ODR::DISABLED => false,
+            ODR::OPEN_DRAIN => true,
         }
     }
     #[allow(missing_docs)]
@@ -274,29 +274,29 @@ impl ODR {
     #[inline]
     pub fn _from(value: bool) -> ODR {
         match value {
-            false => ODR::DISABLE_,
-            true => ODR::OPEN_DRAIN_MODE_ENAB,
+            false => ODR::DISABLED,
+            true => ODR::OPEN_DRAIN,
         }
     }
-    #[doc = "Checks if the value of the field is `DISABLE_`"]
+    #[doc = "Checks if the value of the field is `DISABLED`"]
     #[inline]
-    pub fn is_disable_(&self) -> bool {
-        *self == ODR::DISABLE_
+    pub fn is_disabled(&self) -> bool {
+        *self == ODR::DISABLED
     }
-    #[doc = "Checks if the value of the field is `OPEN_DRAIN_MODE_ENAB`"]
+    #[doc = "Checks if the value of the field is `OPEN_DRAIN`"]
     #[inline]
-    pub fn is_open_drain_mode_enab(&self) -> bool {
-        *self == ODR::OPEN_DRAIN_MODE_ENAB
+    pub fn is_open_drain(&self) -> bool {
+        *self == ODR::OPEN_DRAIN
     }
 }
 #[doc = "Values that can be written to the field `FUNC`"]
 pub enum FUNCW {
     #[doc = "PIO1_16."]
-    PIO1_16_,
+    PIO1_16,
     #[doc = "RI."]
-    RI_,
+    RI,
     #[doc = "CT16B0_CAP0."]
-    CT16B0_CAP0_,
+    CT16B0_CAP0,
 }
 impl FUNCW {
     #[allow(missing_docs)]
@@ -304,9 +304,9 @@ impl FUNCW {
     #[inline]
     pub fn _bits(&self) -> u8 {
         match *self {
-            FUNCW::PIO1_16_ => 0,
-            FUNCW::RI_ => 1,
-            FUNCW::CT16B0_CAP0_ => 2,
+            FUNCW::PIO1_16 => 0,
+            FUNCW::RI => 1,
+            FUNCW::CT16B0_CAP0 => 2,
         }
     }
 }
@@ -322,18 +322,18 @@ impl<'a> _FUNCW<'a> {
     }
     #[doc = "PIO1_16."]
     #[inline]
-    pub fn pio1_16_(self) -> &'a mut W {
-        self.variant(FUNCW::PIO1_16_)
+    pub fn pio1_16(self) -> &'a mut W {
+        self.variant(FUNCW::PIO1_16)
     }
     #[doc = "RI."]
     #[inline]
-    pub fn ri_(self) -> &'a mut W {
-        self.variant(FUNCW::RI_)
+    pub fn ri(self) -> &'a mut W {
+        self.variant(FUNCW::RI)
     }
     #[doc = "CT16B0_CAP0."]
     #[inline]
-    pub fn ct16b0_cap0_(self) -> &'a mut W {
-        self.variant(FUNCW::CT16B0_CAP0_)
+    pub fn ct16b0_cap0(self) -> &'a mut W {
+        self.variant(FUNCW::CT16B0_CAP0)
     }
     #[doc = r" Writes raw bits to the field"]
     #[inline]
@@ -348,13 +348,13 @@ impl<'a> _FUNCW<'a> {
 #[doc = "Values that can be written to the field `MODE`"]
 pub enum MODEW {
     #[doc = "Inactive (no pull-down/pull-up resistor enabled)."]
-    INACTIVE_NO_PULL_DO,
+    INACTIVE,
     #[doc = "Pull-down resistor enabled."]
-    PULL_DOWN_RESISTOR_E,
+    PULL_DOWN,
     #[doc = "Pull-up resistor enabled."]
-    PULL_UP_RESISTOR_ENA,
+    PULL_UP,
     #[doc = "Repeater mode."]
-    REPEATER_MODE_,
+    REPEATER,
 }
 impl MODEW {
     #[allow(missing_docs)]
@@ -362,10 +362,10 @@ impl MODEW {
     #[inline]
     pub fn _bits(&self) -> u8 {
         match *self {
-            MODEW::INACTIVE_NO_PULL_DO => 0,
-            MODEW::PULL_DOWN_RESISTOR_E => 1,
-            MODEW::PULL_UP_RESISTOR_ENA => 2,
-            MODEW::REPEATER_MODE_ => 3,
+            MODEW::INACTIVE => 0,
+            MODEW::PULL_DOWN => 1,
+            MODEW::PULL_UP => 2,
+            MODEW::REPEATER => 3,
         }
     }
 }
@@ -383,23 +383,23 @@ impl<'a> _MODEW<'a> {
     }
     #[doc = "Inactive (no pull-down/pull-up resistor enabled)."]
     #[inline]
-    pub fn inactive_no_pull_do(self) -> &'a mut W {
-        self.variant(MODEW::INACTIVE_NO_PULL_DO)
+    pub fn inactive(self) -> &'a mut W {
+        self.variant(MODEW::INACTIVE)
     }
     #[doc = "Pull-down resistor enabled."]
     #[inline]
-    pub fn pull_down_resistor_e(self) -> &'a mut W {
-        self.variant(MODEW::PULL_DOWN_RESISTOR_E)
+    pub fn pull_down(self) -> &'a mut W {
+        self.variant(MODEW::PULL_DOWN)
     }
     #[doc = "Pull-up resistor enabled."]
     #[inline]
-    pub fn pull_up_resistor_ena(self) -> &'a mut W {
-        self.variant(MODEW::PULL_UP_RESISTOR_ENA)
+    pub fn pull_up(self) -> &'a mut W {
+        self.variant(MODEW::PULL_UP)
     }
     #[doc = "Repeater mode."]
     #[inline]
-    pub fn repeater_mode_(self) -> &'a mut W {
-        self.variant(MODEW::REPEATER_MODE_)
+    pub fn repeater(self) -> &'a mut W {
+        self.variant(MODEW::REPEATER)
     }
     #[doc = r" Writes raw bits to the field"]
     #[inline]
@@ -414,9 +414,9 @@ impl<'a> _MODEW<'a> {
 #[doc = "Values that can be written to the field `HYS`"]
 pub enum HYSW {
     #[doc = "Disable."]
-    DISABLE_,
+    DISABLED,
     #[doc = "Enable."]
-    ENABLE_,
+    ENABLED,
 }
 impl HYSW {
     #[allow(missing_docs)]
@@ -424,8 +424,8 @@ impl HYSW {
     #[inline]
     pub fn _bits(&self) -> bool {
         match *self {
-            HYSW::DISABLE_ => false,
-            HYSW::ENABLE_ => true,
+            HYSW::DISABLED => false,
+            HYSW::ENABLED => true,
         }
     }
 }
@@ -443,13 +443,13 @@ impl<'a> _HYSW<'a> {
     }
     #[doc = "Disable."]
     #[inline]
-    pub fn disable_(self) -> &'a mut W {
-        self.variant(HYSW::DISABLE_)
+    pub fn disabled(self) -> &'a mut W {
+        self.variant(HYSW::DISABLED)
     }
     #[doc = "Enable."]
     #[inline]
-    pub fn enable_(self) -> &'a mut W {
-        self.variant(HYSW::ENABLE_)
+    pub fn enabled(self) -> &'a mut W {
+        self.variant(HYSW::ENABLED)
     }
     #[doc = r" Sets the field bit"]
     pub fn set_bit(self) -> &'a mut W {
@@ -472,9 +472,9 @@ impl<'a> _HYSW<'a> {
 #[doc = "Values that can be written to the field `INV`"]
 pub enum INVW {
     #[doc = "Input not inverted (HIGH on pin reads as 1, LOW on pin reads as 0)."]
-    INPUT_NOT_INVERTED_,
+    NOT_INVERTED,
     #[doc = "Input inverted (HIGH on pin reads as 0, LOW on pin reads as 1)."]
-    INPUT_INVERTED_HIGH,
+    INVERTED,
 }
 impl INVW {
     #[allow(missing_docs)]
@@ -482,8 +482,8 @@ impl INVW {
     #[inline]
     pub fn _bits(&self) -> bool {
         match *self {
-            INVW::INPUT_NOT_INVERTED_ => false,
-            INVW::INPUT_INVERTED_HIGH => true,
+            INVW::NOT_INVERTED => false,
+            INVW::INVERTED => true,
         }
     }
 }
@@ -501,13 +501,13 @@ impl<'a> _INVW<'a> {
     }
     #[doc = "Input not inverted (HIGH on pin reads as 1, LOW on pin reads as 0)."]
     #[inline]
-    pub fn input_not_inverted_(self) -> &'a mut W {
-        self.variant(INVW::INPUT_NOT_INVERTED_)
+    pub fn not_inverted(self) -> &'a mut W {
+        self.variant(INVW::NOT_INVERTED)
     }
     #[doc = "Input inverted (HIGH on pin reads as 0, LOW on pin reads as 1)."]
     #[inline]
-    pub fn input_inverted_high(self) -> &'a mut W {
-        self.variant(INVW::INPUT_INVERTED_HIGH)
+    pub fn inverted(self) -> &'a mut W {
+        self.variant(INVW::INVERTED)
     }
     #[doc = r" Sets the field bit"]
     pub fn set_bit(self) -> &'a mut W {
@@ -530,9 +530,9 @@ impl<'a> _INVW<'a> {
 #[doc = "Values that can be written to the field `OD`"]
 pub enum ODW {
     #[doc = "Disable."]
-    DISABLE_,
+    DISABLED,
     #[doc = "Open-drain mode enabled.  This is not a true open-drain mode."]
-    OPEN_DRAIN_MODE_ENAB,
+    OPEN_DRAIN,
 }
 impl ODW {
     #[allow(missing_docs)]
@@ -540,8 +540,8 @@ impl ODW {
     #[inline]
     pub fn _bits(&self) -> bool {
         match *self {
-            ODW::DISABLE_ => false,
-            ODW::OPEN_DRAIN_MODE_ENAB => true,
+            ODW::DISABLED => false,
+            ODW::OPEN_DRAIN => true,
         }
     }
 }
@@ -559,13 +559,13 @@ impl<'a> _ODW<'a> {
     }
     #[doc = "Disable."]
     #[inline]
-    pub fn disable_(self) -> &'a mut W {
-        self.variant(ODW::DISABLE_)
+    pub fn disabled(self) -> &'a mut W {
+        self.variant(ODW::DISABLED)
     }
     #[doc = "Open-drain mode enabled. This is not a true open-drain mode."]
     #[inline]
-    pub fn open_drain_mode_enab(self) -> &'a mut W {
-        self.variant(ODW::OPEN_DRAIN_MODE_ENAB)
+    pub fn open_drain(self) -> &'a mut W {
+        self.variant(ODW::OPEN_DRAIN)
     }
     #[doc = r" Sets the field bit"]
     pub fn set_bit(self) -> &'a mut W {

--- a/lpc11uxx/src/iocon/pio1_17.rs
+++ b/lpc11uxx/src/iocon/pio1_17.rs
@@ -46,7 +46,7 @@ impl super::PIO1_17 {
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum FUNCR {
     #[doc = "PIO1_17."]
-    PIO1_17_,
+    PIO1_17,
     #[doc = "CT16B0_CAP1"]
     CT16B0_CAP1,
     #[doc = "RXD"]
@@ -59,7 +59,7 @@ impl FUNCR {
     #[inline]
     pub fn bits(&self) -> u8 {
         match *self {
-            FUNCR::PIO1_17_ => 0,
+            FUNCR::PIO1_17 => 0,
             FUNCR::CT16B0_CAP1 => 1,
             FUNCR::RXD => 2,
             FUNCR::_Reserved(bits) => bits,
@@ -70,16 +70,16 @@ impl FUNCR {
     #[inline]
     pub fn _from(value: u8) -> FUNCR {
         match value {
-            0 => FUNCR::PIO1_17_,
+            0 => FUNCR::PIO1_17,
             1 => FUNCR::CT16B0_CAP1,
             2 => FUNCR::RXD,
             i => FUNCR::_Reserved(i),
         }
     }
-    #[doc = "Checks if the value of the field is `PIO1_17_`"]
+    #[doc = "Checks if the value of the field is `PIO1_17`"]
     #[inline]
-    pub fn is_pio1_17_(&self) -> bool {
-        *self == FUNCR::PIO1_17_
+    pub fn is_pio1_17(&self) -> bool {
+        *self == FUNCR::PIO1_17
     }
     #[doc = "Checks if the value of the field is `CT16B0_CAP1`"]
     #[inline]
@@ -96,23 +96,23 @@ impl FUNCR {
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum MODER {
     #[doc = "Inactive (no pull-down/pull-up resistor enabled)."]
-    INACTIVE_NO_PULL_DO,
+    INACTIVE,
     #[doc = "Pull-down resistor enabled."]
-    PULL_DOWN_RESISTOR_E,
+    PULL_DOWN,
     #[doc = "Pull-up resistor enabled."]
-    PULL_UP_RESISTOR_ENA,
+    PULL_UP,
     #[doc = "Repeater mode."]
-    REPEATER_MODE_,
+    REPEATER,
 }
 impl MODER {
     #[doc = r" Value of the field as raw bits"]
     #[inline]
     pub fn bits(&self) -> u8 {
         match *self {
-            MODER::INACTIVE_NO_PULL_DO => 0,
-            MODER::PULL_DOWN_RESISTOR_E => 1,
-            MODER::PULL_UP_RESISTOR_ENA => 2,
-            MODER::REPEATER_MODE_ => 3,
+            MODER::INACTIVE => 0,
+            MODER::PULL_DOWN => 1,
+            MODER::PULL_UP => 2,
+            MODER::REPEATER => 3,
         }
     }
     #[allow(missing_docs)]
@@ -120,41 +120,41 @@ impl MODER {
     #[inline]
     pub fn _from(value: u8) -> MODER {
         match value {
-            0 => MODER::INACTIVE_NO_PULL_DO,
-            1 => MODER::PULL_DOWN_RESISTOR_E,
-            2 => MODER::PULL_UP_RESISTOR_ENA,
-            3 => MODER::REPEATER_MODE_,
+            0 => MODER::INACTIVE,
+            1 => MODER::PULL_DOWN,
+            2 => MODER::PULL_UP,
+            3 => MODER::REPEATER,
             _ => unreachable!(),
         }
     }
-    #[doc = "Checks if the value of the field is `INACTIVE_NO_PULL_DO`"]
+    #[doc = "Checks if the value of the field is `INACTIVE`"]
     #[inline]
-    pub fn is_inactive_no_pull_do(&self) -> bool {
-        *self == MODER::INACTIVE_NO_PULL_DO
+    pub fn is_inactive(&self) -> bool {
+        *self == MODER::INACTIVE
     }
-    #[doc = "Checks if the value of the field is `PULL_DOWN_RESISTOR_E`"]
+    #[doc = "Checks if the value of the field is `PULL_DOWN`"]
     #[inline]
-    pub fn is_pull_down_resistor_e(&self) -> bool {
-        *self == MODER::PULL_DOWN_RESISTOR_E
+    pub fn is_pull_down(&self) -> bool {
+        *self == MODER::PULL_DOWN
     }
-    #[doc = "Checks if the value of the field is `PULL_UP_RESISTOR_ENA`"]
+    #[doc = "Checks if the value of the field is `PULL_UP`"]
     #[inline]
-    pub fn is_pull_up_resistor_ena(&self) -> bool {
-        *self == MODER::PULL_UP_RESISTOR_ENA
+    pub fn is_pull_up(&self) -> bool {
+        *self == MODER::PULL_UP
     }
-    #[doc = "Checks if the value of the field is `REPEATER_MODE_`"]
+    #[doc = "Checks if the value of the field is `REPEATER`"]
     #[inline]
-    pub fn is_repeater_mode_(&self) -> bool {
-        *self == MODER::REPEATER_MODE_
+    pub fn is_repeater(&self) -> bool {
+        *self == MODER::REPEATER
     }
 }
 #[doc = "Possible values of the field `HYS`"]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum HYSR {
     #[doc = "Disable."]
-    DISABLE_,
+    DISABLED,
     #[doc = "Enable."]
-    ENABLE_,
+    ENABLED,
 }
 impl HYSR {
     #[doc = r" Returns `true` if the bit is clear (0)"]
@@ -171,8 +171,8 @@ impl HYSR {
     #[inline]
     pub fn bit(&self) -> bool {
         match *self {
-            HYSR::DISABLE_ => false,
-            HYSR::ENABLE_ => true,
+            HYSR::DISABLED => false,
+            HYSR::ENABLED => true,
         }
     }
     #[allow(missing_docs)]
@@ -180,28 +180,28 @@ impl HYSR {
     #[inline]
     pub fn _from(value: bool) -> HYSR {
         match value {
-            false => HYSR::DISABLE_,
-            true => HYSR::ENABLE_,
+            false => HYSR::DISABLED,
+            true => HYSR::ENABLED,
         }
     }
-    #[doc = "Checks if the value of the field is `DISABLE_`"]
+    #[doc = "Checks if the value of the field is `DISABLED`"]
     #[inline]
-    pub fn is_disable_(&self) -> bool {
-        *self == HYSR::DISABLE_
+    pub fn is_disabled(&self) -> bool {
+        *self == HYSR::DISABLED
     }
-    #[doc = "Checks if the value of the field is `ENABLE_`"]
+    #[doc = "Checks if the value of the field is `ENABLED`"]
     #[inline]
-    pub fn is_enable_(&self) -> bool {
-        *self == HYSR::ENABLE_
+    pub fn is_enabled(&self) -> bool {
+        *self == HYSR::ENABLED
     }
 }
 #[doc = "Possible values of the field `INV`"]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum INVR {
     #[doc = "Input not inverted (HIGH on pin reads as 1, LOW on pin reads as 0)."]
-    INPUT_NOT_INVERTED_,
+    NOT_INVERTED,
     #[doc = "Input inverted (HIGH on pin reads as 0, LOW on pin reads as 1)."]
-    INPUT_INVERTED_HIGH,
+    INVERTED,
 }
 impl INVR {
     #[doc = r" Returns `true` if the bit is clear (0)"]
@@ -218,8 +218,8 @@ impl INVR {
     #[inline]
     pub fn bit(&self) -> bool {
         match *self {
-            INVR::INPUT_NOT_INVERTED_ => false,
-            INVR::INPUT_INVERTED_HIGH => true,
+            INVR::NOT_INVERTED => false,
+            INVR::INVERTED => true,
         }
     }
     #[allow(missing_docs)]
@@ -227,28 +227,28 @@ impl INVR {
     #[inline]
     pub fn _from(value: bool) -> INVR {
         match value {
-            false => INVR::INPUT_NOT_INVERTED_,
-            true => INVR::INPUT_INVERTED_HIGH,
+            false => INVR::NOT_INVERTED,
+            true => INVR::INVERTED,
         }
     }
-    #[doc = "Checks if the value of the field is `INPUT_NOT_INVERTED_`"]
+    #[doc = "Checks if the value of the field is `NOT_INVERTED`"]
     #[inline]
-    pub fn is_input_not_inverted_(&self) -> bool {
-        *self == INVR::INPUT_NOT_INVERTED_
+    pub fn is_not_inverted(&self) -> bool {
+        *self == INVR::NOT_INVERTED
     }
-    #[doc = "Checks if the value of the field is `INPUT_INVERTED_HIGH`"]
+    #[doc = "Checks if the value of the field is `INVERTED`"]
     #[inline]
-    pub fn is_input_inverted_high(&self) -> bool {
-        *self == INVR::INPUT_INVERTED_HIGH
+    pub fn is_inverted(&self) -> bool {
+        *self == INVR::INVERTED
     }
 }
 #[doc = "Possible values of the field `OD`"]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum ODR {
     #[doc = "Disable."]
-    DISABLE_,
+    DISABLED,
     #[doc = "Open-drain mode enabled. This is not a true open-drain mode. Input cannot be pulled up above VDD."]
-    OPEN_DRAIN_MODE_ENAB,
+    OPEN_DRAIN,
 }
 impl ODR {
     #[doc = r" Returns `true` if the bit is clear (0)"]
@@ -265,8 +265,8 @@ impl ODR {
     #[inline]
     pub fn bit(&self) -> bool {
         match *self {
-            ODR::DISABLE_ => false,
-            ODR::OPEN_DRAIN_MODE_ENAB => true,
+            ODR::DISABLED => false,
+            ODR::OPEN_DRAIN => true,
         }
     }
     #[allow(missing_docs)]
@@ -274,25 +274,25 @@ impl ODR {
     #[inline]
     pub fn _from(value: bool) -> ODR {
         match value {
-            false => ODR::DISABLE_,
-            true => ODR::OPEN_DRAIN_MODE_ENAB,
+            false => ODR::DISABLED,
+            true => ODR::OPEN_DRAIN,
         }
     }
-    #[doc = "Checks if the value of the field is `DISABLE_`"]
+    #[doc = "Checks if the value of the field is `DISABLED`"]
     #[inline]
-    pub fn is_disable_(&self) -> bool {
-        *self == ODR::DISABLE_
+    pub fn is_disabled(&self) -> bool {
+        *self == ODR::DISABLED
     }
-    #[doc = "Checks if the value of the field is `OPEN_DRAIN_MODE_ENAB`"]
+    #[doc = "Checks if the value of the field is `OPEN_DRAIN`"]
     #[inline]
-    pub fn is_open_drain_mode_enab(&self) -> bool {
-        *self == ODR::OPEN_DRAIN_MODE_ENAB
+    pub fn is_open_drain(&self) -> bool {
+        *self == ODR::OPEN_DRAIN
     }
 }
 #[doc = "Values that can be written to the field `FUNC`"]
 pub enum FUNCW {
     #[doc = "PIO1_17."]
-    PIO1_17_,
+    PIO1_17,
     #[doc = "CT16B0_CAP1"]
     CT16B0_CAP1,
     #[doc = "RXD"]
@@ -304,7 +304,7 @@ impl FUNCW {
     #[inline]
     pub fn _bits(&self) -> u8 {
         match *self {
-            FUNCW::PIO1_17_ => 0,
+            FUNCW::PIO1_17 => 0,
             FUNCW::CT16B0_CAP1 => 1,
             FUNCW::RXD => 2,
         }
@@ -322,8 +322,8 @@ impl<'a> _FUNCW<'a> {
     }
     #[doc = "PIO1_17."]
     #[inline]
-    pub fn pio1_17_(self) -> &'a mut W {
-        self.variant(FUNCW::PIO1_17_)
+    pub fn pio1_17(self) -> &'a mut W {
+        self.variant(FUNCW::PIO1_17)
     }
     #[doc = "CT16B0_CAP1"]
     #[inline]
@@ -348,13 +348,13 @@ impl<'a> _FUNCW<'a> {
 #[doc = "Values that can be written to the field `MODE`"]
 pub enum MODEW {
     #[doc = "Inactive (no pull-down/pull-up resistor enabled)."]
-    INACTIVE_NO_PULL_DO,
+    INACTIVE,
     #[doc = "Pull-down resistor enabled."]
-    PULL_DOWN_RESISTOR_E,
+    PULL_DOWN,
     #[doc = "Pull-up resistor enabled."]
-    PULL_UP_RESISTOR_ENA,
+    PULL_UP,
     #[doc = "Repeater mode."]
-    REPEATER_MODE_,
+    REPEATER,
 }
 impl MODEW {
     #[allow(missing_docs)]
@@ -362,10 +362,10 @@ impl MODEW {
     #[inline]
     pub fn _bits(&self) -> u8 {
         match *self {
-            MODEW::INACTIVE_NO_PULL_DO => 0,
-            MODEW::PULL_DOWN_RESISTOR_E => 1,
-            MODEW::PULL_UP_RESISTOR_ENA => 2,
-            MODEW::REPEATER_MODE_ => 3,
+            MODEW::INACTIVE => 0,
+            MODEW::PULL_DOWN => 1,
+            MODEW::PULL_UP => 2,
+            MODEW::REPEATER => 3,
         }
     }
 }
@@ -383,23 +383,23 @@ impl<'a> _MODEW<'a> {
     }
     #[doc = "Inactive (no pull-down/pull-up resistor enabled)."]
     #[inline]
-    pub fn inactive_no_pull_do(self) -> &'a mut W {
-        self.variant(MODEW::INACTIVE_NO_PULL_DO)
+    pub fn inactive(self) -> &'a mut W {
+        self.variant(MODEW::INACTIVE)
     }
     #[doc = "Pull-down resistor enabled."]
     #[inline]
-    pub fn pull_down_resistor_e(self) -> &'a mut W {
-        self.variant(MODEW::PULL_DOWN_RESISTOR_E)
+    pub fn pull_down(self) -> &'a mut W {
+        self.variant(MODEW::PULL_DOWN)
     }
     #[doc = "Pull-up resistor enabled."]
     #[inline]
-    pub fn pull_up_resistor_ena(self) -> &'a mut W {
-        self.variant(MODEW::PULL_UP_RESISTOR_ENA)
+    pub fn pull_up(self) -> &'a mut W {
+        self.variant(MODEW::PULL_UP)
     }
     #[doc = "Repeater mode."]
     #[inline]
-    pub fn repeater_mode_(self) -> &'a mut W {
-        self.variant(MODEW::REPEATER_MODE_)
+    pub fn repeater(self) -> &'a mut W {
+        self.variant(MODEW::REPEATER)
     }
     #[doc = r" Writes raw bits to the field"]
     #[inline]
@@ -414,9 +414,9 @@ impl<'a> _MODEW<'a> {
 #[doc = "Values that can be written to the field `HYS`"]
 pub enum HYSW {
     #[doc = "Disable."]
-    DISABLE_,
+    DISABLED,
     #[doc = "Enable."]
-    ENABLE_,
+    ENABLED,
 }
 impl HYSW {
     #[allow(missing_docs)]
@@ -424,8 +424,8 @@ impl HYSW {
     #[inline]
     pub fn _bits(&self) -> bool {
         match *self {
-            HYSW::DISABLE_ => false,
-            HYSW::ENABLE_ => true,
+            HYSW::DISABLED => false,
+            HYSW::ENABLED => true,
         }
     }
 }
@@ -443,13 +443,13 @@ impl<'a> _HYSW<'a> {
     }
     #[doc = "Disable."]
     #[inline]
-    pub fn disable_(self) -> &'a mut W {
-        self.variant(HYSW::DISABLE_)
+    pub fn disabled(self) -> &'a mut W {
+        self.variant(HYSW::DISABLED)
     }
     #[doc = "Enable."]
     #[inline]
-    pub fn enable_(self) -> &'a mut W {
-        self.variant(HYSW::ENABLE_)
+    pub fn enabled(self) -> &'a mut W {
+        self.variant(HYSW::ENABLED)
     }
     #[doc = r" Sets the field bit"]
     pub fn set_bit(self) -> &'a mut W {
@@ -472,9 +472,9 @@ impl<'a> _HYSW<'a> {
 #[doc = "Values that can be written to the field `INV`"]
 pub enum INVW {
     #[doc = "Input not inverted (HIGH on pin reads as 1, LOW on pin reads as 0)."]
-    INPUT_NOT_INVERTED_,
+    NOT_INVERTED,
     #[doc = "Input inverted (HIGH on pin reads as 0, LOW on pin reads as 1)."]
-    INPUT_INVERTED_HIGH,
+    INVERTED,
 }
 impl INVW {
     #[allow(missing_docs)]
@@ -482,8 +482,8 @@ impl INVW {
     #[inline]
     pub fn _bits(&self) -> bool {
         match *self {
-            INVW::INPUT_NOT_INVERTED_ => false,
-            INVW::INPUT_INVERTED_HIGH => true,
+            INVW::NOT_INVERTED => false,
+            INVW::INVERTED => true,
         }
     }
 }
@@ -501,13 +501,13 @@ impl<'a> _INVW<'a> {
     }
     #[doc = "Input not inverted (HIGH on pin reads as 1, LOW on pin reads as 0)."]
     #[inline]
-    pub fn input_not_inverted_(self) -> &'a mut W {
-        self.variant(INVW::INPUT_NOT_INVERTED_)
+    pub fn not_inverted(self) -> &'a mut W {
+        self.variant(INVW::NOT_INVERTED)
     }
     #[doc = "Input inverted (HIGH on pin reads as 0, LOW on pin reads as 1)."]
     #[inline]
-    pub fn input_inverted_high(self) -> &'a mut W {
-        self.variant(INVW::INPUT_INVERTED_HIGH)
+    pub fn inverted(self) -> &'a mut W {
+        self.variant(INVW::INVERTED)
     }
     #[doc = r" Sets the field bit"]
     pub fn set_bit(self) -> &'a mut W {
@@ -530,9 +530,9 @@ impl<'a> _INVW<'a> {
 #[doc = "Values that can be written to the field `OD`"]
 pub enum ODW {
     #[doc = "Disable."]
-    DISABLE_,
+    DISABLED,
     #[doc = "Open-drain mode enabled. This is not a true open-drain mode. Input cannot be pulled up above VDD."]
-    OPEN_DRAIN_MODE_ENAB,
+    OPEN_DRAIN,
 }
 impl ODW {
     #[allow(missing_docs)]
@@ -540,8 +540,8 @@ impl ODW {
     #[inline]
     pub fn _bits(&self) -> bool {
         match *self {
-            ODW::DISABLE_ => false,
-            ODW::OPEN_DRAIN_MODE_ENAB => true,
+            ODW::DISABLED => false,
+            ODW::OPEN_DRAIN => true,
         }
     }
 }
@@ -559,13 +559,13 @@ impl<'a> _ODW<'a> {
     }
     #[doc = "Disable."]
     #[inline]
-    pub fn disable_(self) -> &'a mut W {
-        self.variant(ODW::DISABLE_)
+    pub fn disabled(self) -> &'a mut W {
+        self.variant(ODW::DISABLED)
     }
     #[doc = "Open-drain mode enabled. This is not a true open-drain mode. Input cannot be pulled up above VDD."]
     #[inline]
-    pub fn open_drain_mode_enab(self) -> &'a mut W {
-        self.variant(ODW::OPEN_DRAIN_MODE_ENAB)
+    pub fn open_drain(self) -> &'a mut W {
+        self.variant(ODW::OPEN_DRAIN)
     }
     #[doc = r" Sets the field bit"]
     pub fn set_bit(self) -> &'a mut W {

--- a/lpc11uxx/src/iocon/pio1_18.rs
+++ b/lpc11uxx/src/iocon/pio1_18.rs
@@ -96,23 +96,23 @@ impl FUNCR {
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum MODER {
     #[doc = "Inactive (no pull-down/pull-up resistor enabled)."]
-    INACTIVE_NO_PULL_DO,
+    INACTIVE,
     #[doc = "Pull-down resistor enabled."]
-    PULL_DOWN_RESISTOR_E,
+    PULL_DOWN,
     #[doc = "Pull-up resistor enabled."]
-    PULL_UP_RESISTOR_ENA,
+    PULL_UP,
     #[doc = "Repeater mode."]
-    REPEATER_MODE_,
+    REPEATER,
 }
 impl MODER {
     #[doc = r" Value of the field as raw bits"]
     #[inline]
     pub fn bits(&self) -> u8 {
         match *self {
-            MODER::INACTIVE_NO_PULL_DO => 0,
-            MODER::PULL_DOWN_RESISTOR_E => 1,
-            MODER::PULL_UP_RESISTOR_ENA => 2,
-            MODER::REPEATER_MODE_ => 3,
+            MODER::INACTIVE => 0,
+            MODER::PULL_DOWN => 1,
+            MODER::PULL_UP => 2,
+            MODER::REPEATER => 3,
         }
     }
     #[allow(missing_docs)]
@@ -120,41 +120,41 @@ impl MODER {
     #[inline]
     pub fn _from(value: u8) -> MODER {
         match value {
-            0 => MODER::INACTIVE_NO_PULL_DO,
-            1 => MODER::PULL_DOWN_RESISTOR_E,
-            2 => MODER::PULL_UP_RESISTOR_ENA,
-            3 => MODER::REPEATER_MODE_,
+            0 => MODER::INACTIVE,
+            1 => MODER::PULL_DOWN,
+            2 => MODER::PULL_UP,
+            3 => MODER::REPEATER,
             _ => unreachable!(),
         }
     }
-    #[doc = "Checks if the value of the field is `INACTIVE_NO_PULL_DO`"]
+    #[doc = "Checks if the value of the field is `INACTIVE`"]
     #[inline]
-    pub fn is_inactive_no_pull_do(&self) -> bool {
-        *self == MODER::INACTIVE_NO_PULL_DO
+    pub fn is_inactive(&self) -> bool {
+        *self == MODER::INACTIVE
     }
-    #[doc = "Checks if the value of the field is `PULL_DOWN_RESISTOR_E`"]
+    #[doc = "Checks if the value of the field is `PULL_DOWN`"]
     #[inline]
-    pub fn is_pull_down_resistor_e(&self) -> bool {
-        *self == MODER::PULL_DOWN_RESISTOR_E
+    pub fn is_pull_down(&self) -> bool {
+        *self == MODER::PULL_DOWN
     }
-    #[doc = "Checks if the value of the field is `PULL_UP_RESISTOR_ENA`"]
+    #[doc = "Checks if the value of the field is `PULL_UP`"]
     #[inline]
-    pub fn is_pull_up_resistor_ena(&self) -> bool {
-        *self == MODER::PULL_UP_RESISTOR_ENA
+    pub fn is_pull_up(&self) -> bool {
+        *self == MODER::PULL_UP
     }
-    #[doc = "Checks if the value of the field is `REPEATER_MODE_`"]
+    #[doc = "Checks if the value of the field is `REPEATER`"]
     #[inline]
-    pub fn is_repeater_mode_(&self) -> bool {
-        *self == MODER::REPEATER_MODE_
+    pub fn is_repeater(&self) -> bool {
+        *self == MODER::REPEATER
     }
 }
 #[doc = "Possible values of the field `HYS`"]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum HYSR {
     #[doc = "Disable."]
-    DISABLE_,
+    DISABLED,
     #[doc = "Enable."]
-    ENABLE_,
+    ENABLED,
 }
 impl HYSR {
     #[doc = r" Returns `true` if the bit is clear (0)"]
@@ -171,8 +171,8 @@ impl HYSR {
     #[inline]
     pub fn bit(&self) -> bool {
         match *self {
-            HYSR::DISABLE_ => false,
-            HYSR::ENABLE_ => true,
+            HYSR::DISABLED => false,
+            HYSR::ENABLED => true,
         }
     }
     #[allow(missing_docs)]
@@ -180,28 +180,28 @@ impl HYSR {
     #[inline]
     pub fn _from(value: bool) -> HYSR {
         match value {
-            false => HYSR::DISABLE_,
-            true => HYSR::ENABLE_,
+            false => HYSR::DISABLED,
+            true => HYSR::ENABLED,
         }
     }
-    #[doc = "Checks if the value of the field is `DISABLE_`"]
+    #[doc = "Checks if the value of the field is `DISABLED`"]
     #[inline]
-    pub fn is_disable_(&self) -> bool {
-        *self == HYSR::DISABLE_
+    pub fn is_disabled(&self) -> bool {
+        *self == HYSR::DISABLED
     }
-    #[doc = "Checks if the value of the field is `ENABLE_`"]
+    #[doc = "Checks if the value of the field is `ENABLED`"]
     #[inline]
-    pub fn is_enable_(&self) -> bool {
-        *self == HYSR::ENABLE_
+    pub fn is_enabled(&self) -> bool {
+        *self == HYSR::ENABLED
     }
 }
 #[doc = "Possible values of the field `INV`"]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum INVR {
     #[doc = "Input not inverted (HIGH on pin reads as 1, LOW on pin reads as 0)."]
-    INPUT_NOT_INVERTED_,
+    NOT_INVERTED,
     #[doc = "Input inverted (HIGH on pin reads as 0, LOW on pin reads as 1)."]
-    INPUT_INVERTED_HIGH,
+    INVERTED,
 }
 impl INVR {
     #[doc = r" Returns `true` if the bit is clear (0)"]
@@ -218,8 +218,8 @@ impl INVR {
     #[inline]
     pub fn bit(&self) -> bool {
         match *self {
-            INVR::INPUT_NOT_INVERTED_ => false,
-            INVR::INPUT_INVERTED_HIGH => true,
+            INVR::NOT_INVERTED => false,
+            INVR::INVERTED => true,
         }
     }
     #[allow(missing_docs)]
@@ -227,28 +227,28 @@ impl INVR {
     #[inline]
     pub fn _from(value: bool) -> INVR {
         match value {
-            false => INVR::INPUT_NOT_INVERTED_,
-            true => INVR::INPUT_INVERTED_HIGH,
+            false => INVR::NOT_INVERTED,
+            true => INVR::INVERTED,
         }
     }
-    #[doc = "Checks if the value of the field is `INPUT_NOT_INVERTED_`"]
+    #[doc = "Checks if the value of the field is `NOT_INVERTED`"]
     #[inline]
-    pub fn is_input_not_inverted_(&self) -> bool {
-        *self == INVR::INPUT_NOT_INVERTED_
+    pub fn is_not_inverted(&self) -> bool {
+        *self == INVR::NOT_INVERTED
     }
-    #[doc = "Checks if the value of the field is `INPUT_INVERTED_HIGH`"]
+    #[doc = "Checks if the value of the field is `INVERTED`"]
     #[inline]
-    pub fn is_input_inverted_high(&self) -> bool {
-        *self == INVR::INPUT_INVERTED_HIGH
+    pub fn is_inverted(&self) -> bool {
+        *self == INVR::INVERTED
     }
 }
 #[doc = "Possible values of the field `OD`"]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum ODR {
     #[doc = "Disable."]
-    DISABLE_,
+    DISABLED,
     #[doc = "Open-drain mode enabled. This is not a true open-drain mode. Input cannot be pulled up above VDD."]
-    OPEN_DRAIN_MODE_ENAB,
+    OPEN_DRAIN,
 }
 impl ODR {
     #[doc = r" Returns `true` if the bit is clear (0)"]
@@ -265,8 +265,8 @@ impl ODR {
     #[inline]
     pub fn bit(&self) -> bool {
         match *self {
-            ODR::DISABLE_ => false,
-            ODR::OPEN_DRAIN_MODE_ENAB => true,
+            ODR::DISABLED => false,
+            ODR::OPEN_DRAIN => true,
         }
     }
     #[allow(missing_docs)]
@@ -274,19 +274,19 @@ impl ODR {
     #[inline]
     pub fn _from(value: bool) -> ODR {
         match value {
-            false => ODR::DISABLE_,
-            true => ODR::OPEN_DRAIN_MODE_ENAB,
+            false => ODR::DISABLED,
+            true => ODR::OPEN_DRAIN,
         }
     }
-    #[doc = "Checks if the value of the field is `DISABLE_`"]
+    #[doc = "Checks if the value of the field is `DISABLED`"]
     #[inline]
-    pub fn is_disable_(&self) -> bool {
-        *self == ODR::DISABLE_
+    pub fn is_disabled(&self) -> bool {
+        *self == ODR::DISABLED
     }
-    #[doc = "Checks if the value of the field is `OPEN_DRAIN_MODE_ENAB`"]
+    #[doc = "Checks if the value of the field is `OPEN_DRAIN`"]
     #[inline]
-    pub fn is_open_drain_mode_enab(&self) -> bool {
-        *self == ODR::OPEN_DRAIN_MODE_ENAB
+    pub fn is_open_drain(&self) -> bool {
+        *self == ODR::OPEN_DRAIN
     }
 }
 #[doc = "Values that can be written to the field `FUNC`"]
@@ -348,13 +348,13 @@ impl<'a> _FUNCW<'a> {
 #[doc = "Values that can be written to the field `MODE`"]
 pub enum MODEW {
     #[doc = "Inactive (no pull-down/pull-up resistor enabled)."]
-    INACTIVE_NO_PULL_DO,
+    INACTIVE,
     #[doc = "Pull-down resistor enabled."]
-    PULL_DOWN_RESISTOR_E,
+    PULL_DOWN,
     #[doc = "Pull-up resistor enabled."]
-    PULL_UP_RESISTOR_ENA,
+    PULL_UP,
     #[doc = "Repeater mode."]
-    REPEATER_MODE_,
+    REPEATER,
 }
 impl MODEW {
     #[allow(missing_docs)]
@@ -362,10 +362,10 @@ impl MODEW {
     #[inline]
     pub fn _bits(&self) -> u8 {
         match *self {
-            MODEW::INACTIVE_NO_PULL_DO => 0,
-            MODEW::PULL_DOWN_RESISTOR_E => 1,
-            MODEW::PULL_UP_RESISTOR_ENA => 2,
-            MODEW::REPEATER_MODE_ => 3,
+            MODEW::INACTIVE => 0,
+            MODEW::PULL_DOWN => 1,
+            MODEW::PULL_UP => 2,
+            MODEW::REPEATER => 3,
         }
     }
 }
@@ -383,23 +383,23 @@ impl<'a> _MODEW<'a> {
     }
     #[doc = "Inactive (no pull-down/pull-up resistor enabled)."]
     #[inline]
-    pub fn inactive_no_pull_do(self) -> &'a mut W {
-        self.variant(MODEW::INACTIVE_NO_PULL_DO)
+    pub fn inactive(self) -> &'a mut W {
+        self.variant(MODEW::INACTIVE)
     }
     #[doc = "Pull-down resistor enabled."]
     #[inline]
-    pub fn pull_down_resistor_e(self) -> &'a mut W {
-        self.variant(MODEW::PULL_DOWN_RESISTOR_E)
+    pub fn pull_down(self) -> &'a mut W {
+        self.variant(MODEW::PULL_DOWN)
     }
     #[doc = "Pull-up resistor enabled."]
     #[inline]
-    pub fn pull_up_resistor_ena(self) -> &'a mut W {
-        self.variant(MODEW::PULL_UP_RESISTOR_ENA)
+    pub fn pull_up(self) -> &'a mut W {
+        self.variant(MODEW::PULL_UP)
     }
     #[doc = "Repeater mode."]
     #[inline]
-    pub fn repeater_mode_(self) -> &'a mut W {
-        self.variant(MODEW::REPEATER_MODE_)
+    pub fn repeater(self) -> &'a mut W {
+        self.variant(MODEW::REPEATER)
     }
     #[doc = r" Writes raw bits to the field"]
     #[inline]
@@ -414,9 +414,9 @@ impl<'a> _MODEW<'a> {
 #[doc = "Values that can be written to the field `HYS`"]
 pub enum HYSW {
     #[doc = "Disable."]
-    DISABLE_,
+    DISABLED,
     #[doc = "Enable."]
-    ENABLE_,
+    ENABLED,
 }
 impl HYSW {
     #[allow(missing_docs)]
@@ -424,8 +424,8 @@ impl HYSW {
     #[inline]
     pub fn _bits(&self) -> bool {
         match *self {
-            HYSW::DISABLE_ => false,
-            HYSW::ENABLE_ => true,
+            HYSW::DISABLED => false,
+            HYSW::ENABLED => true,
         }
     }
 }
@@ -443,13 +443,13 @@ impl<'a> _HYSW<'a> {
     }
     #[doc = "Disable."]
     #[inline]
-    pub fn disable_(self) -> &'a mut W {
-        self.variant(HYSW::DISABLE_)
+    pub fn disabled(self) -> &'a mut W {
+        self.variant(HYSW::DISABLED)
     }
     #[doc = "Enable."]
     #[inline]
-    pub fn enable_(self) -> &'a mut W {
-        self.variant(HYSW::ENABLE_)
+    pub fn enabled(self) -> &'a mut W {
+        self.variant(HYSW::ENABLED)
     }
     #[doc = r" Sets the field bit"]
     pub fn set_bit(self) -> &'a mut W {
@@ -472,9 +472,9 @@ impl<'a> _HYSW<'a> {
 #[doc = "Values that can be written to the field `INV`"]
 pub enum INVW {
     #[doc = "Input not inverted (HIGH on pin reads as 1, LOW on pin reads as 0)."]
-    INPUT_NOT_INVERTED_,
+    NOT_INVERTED,
     #[doc = "Input inverted (HIGH on pin reads as 0, LOW on pin reads as 1)."]
-    INPUT_INVERTED_HIGH,
+    INVERTED,
 }
 impl INVW {
     #[allow(missing_docs)]
@@ -482,8 +482,8 @@ impl INVW {
     #[inline]
     pub fn _bits(&self) -> bool {
         match *self {
-            INVW::INPUT_NOT_INVERTED_ => false,
-            INVW::INPUT_INVERTED_HIGH => true,
+            INVW::NOT_INVERTED => false,
+            INVW::INVERTED => true,
         }
     }
 }
@@ -501,13 +501,13 @@ impl<'a> _INVW<'a> {
     }
     #[doc = "Input not inverted (HIGH on pin reads as 1, LOW on pin reads as 0)."]
     #[inline]
-    pub fn input_not_inverted_(self) -> &'a mut W {
-        self.variant(INVW::INPUT_NOT_INVERTED_)
+    pub fn not_inverted(self) -> &'a mut W {
+        self.variant(INVW::NOT_INVERTED)
     }
     #[doc = "Input inverted (HIGH on pin reads as 0, LOW on pin reads as 1)."]
     #[inline]
-    pub fn input_inverted_high(self) -> &'a mut W {
-        self.variant(INVW::INPUT_INVERTED_HIGH)
+    pub fn inverted(self) -> &'a mut W {
+        self.variant(INVW::INVERTED)
     }
     #[doc = r" Sets the field bit"]
     pub fn set_bit(self) -> &'a mut W {
@@ -530,9 +530,9 @@ impl<'a> _INVW<'a> {
 #[doc = "Values that can be written to the field `OD`"]
 pub enum ODW {
     #[doc = "Disable."]
-    DISABLE_,
+    DISABLED,
     #[doc = "Open-drain mode enabled. This is not a true open-drain mode. Input cannot be pulled up above VDD."]
-    OPEN_DRAIN_MODE_ENAB,
+    OPEN_DRAIN,
 }
 impl ODW {
     #[allow(missing_docs)]
@@ -540,8 +540,8 @@ impl ODW {
     #[inline]
     pub fn _bits(&self) -> bool {
         match *self {
-            ODW::DISABLE_ => false,
-            ODW::OPEN_DRAIN_MODE_ENAB => true,
+            ODW::DISABLED => false,
+            ODW::OPEN_DRAIN => true,
         }
     }
 }
@@ -559,13 +559,13 @@ impl<'a> _ODW<'a> {
     }
     #[doc = "Disable."]
     #[inline]
-    pub fn disable_(self) -> &'a mut W {
-        self.variant(ODW::DISABLE_)
+    pub fn disabled(self) -> &'a mut W {
+        self.variant(ODW::DISABLED)
     }
     #[doc = "Open-drain mode enabled. This is not a true open-drain mode. Input cannot be pulled up above VDD."]
     #[inline]
-    pub fn open_drain_mode_enab(self) -> &'a mut W {
-        self.variant(ODW::OPEN_DRAIN_MODE_ENAB)
+    pub fn open_drain(self) -> &'a mut W {
+        self.variant(ODW::OPEN_DRAIN)
     }
     #[doc = r" Sets the field bit"]
     pub fn set_bit(self) -> &'a mut W {

--- a/lpc11uxx/src/iocon/pio1_19.rs
+++ b/lpc11uxx/src/iocon/pio1_19.rs
@@ -46,11 +46,11 @@ impl super::PIO1_19 {
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum FUNCR {
     #[doc = "PIO1_19."]
-    PIO1_19_,
+    PIO1_19,
     #[doc = "DTR."]
-    DTR_,
+    DTR,
     #[doc = "SSEL1."]
-    SSEL1_,
+    SSEL1,
     #[doc = r" Reserved"]
     _Reserved(u8),
 }
@@ -59,9 +59,9 @@ impl FUNCR {
     #[inline]
     pub fn bits(&self) -> u8 {
         match *self {
-            FUNCR::PIO1_19_ => 0,
-            FUNCR::DTR_ => 1,
-            FUNCR::SSEL1_ => 2,
+            FUNCR::PIO1_19 => 0,
+            FUNCR::DTR => 1,
+            FUNCR::SSEL1 => 2,
             FUNCR::_Reserved(bits) => bits,
         }
     }
@@ -70,49 +70,49 @@ impl FUNCR {
     #[inline]
     pub fn _from(value: u8) -> FUNCR {
         match value {
-            0 => FUNCR::PIO1_19_,
-            1 => FUNCR::DTR_,
-            2 => FUNCR::SSEL1_,
+            0 => FUNCR::PIO1_19,
+            1 => FUNCR::DTR,
+            2 => FUNCR::SSEL1,
             i => FUNCR::_Reserved(i),
         }
     }
-    #[doc = "Checks if the value of the field is `PIO1_19_`"]
+    #[doc = "Checks if the value of the field is `PIO1_19`"]
     #[inline]
-    pub fn is_pio1_19_(&self) -> bool {
-        *self == FUNCR::PIO1_19_
+    pub fn is_pio1_19(&self) -> bool {
+        *self == FUNCR::PIO1_19
     }
-    #[doc = "Checks if the value of the field is `DTR_`"]
+    #[doc = "Checks if the value of the field is `DTR`"]
     #[inline]
-    pub fn is_dtr_(&self) -> bool {
-        *self == FUNCR::DTR_
+    pub fn is_dtr(&self) -> bool {
+        *self == FUNCR::DTR
     }
-    #[doc = "Checks if the value of the field is `SSEL1_`"]
+    #[doc = "Checks if the value of the field is `SSEL1`"]
     #[inline]
-    pub fn is_ssel1_(&self) -> bool {
-        *self == FUNCR::SSEL1_
+    pub fn is_ssel1(&self) -> bool {
+        *self == FUNCR::SSEL1
     }
 }
 #[doc = "Possible values of the field `MODE`"]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum MODER {
     #[doc = "Inactive (no pull-down/pull-up resistor enabled)."]
-    INACTIVE_NO_PULL_DO,
+    INACTIVE,
     #[doc = "Pull-down resistor enabled."]
-    PULL_DOWN_RESISTOR_E,
+    PULL_DOWN,
     #[doc = "Pull-up resistor enabled."]
-    PULL_UP_RESISTOR_ENA,
+    PULL_UP,
     #[doc = "Repeater mode."]
-    REPEATER_MODE_,
+    REPEATER,
 }
 impl MODER {
     #[doc = r" Value of the field as raw bits"]
     #[inline]
     pub fn bits(&self) -> u8 {
         match *self {
-            MODER::INACTIVE_NO_PULL_DO => 0,
-            MODER::PULL_DOWN_RESISTOR_E => 1,
-            MODER::PULL_UP_RESISTOR_ENA => 2,
-            MODER::REPEATER_MODE_ => 3,
+            MODER::INACTIVE => 0,
+            MODER::PULL_DOWN => 1,
+            MODER::PULL_UP => 2,
+            MODER::REPEATER => 3,
         }
     }
     #[allow(missing_docs)]
@@ -120,41 +120,41 @@ impl MODER {
     #[inline]
     pub fn _from(value: u8) -> MODER {
         match value {
-            0 => MODER::INACTIVE_NO_PULL_DO,
-            1 => MODER::PULL_DOWN_RESISTOR_E,
-            2 => MODER::PULL_UP_RESISTOR_ENA,
-            3 => MODER::REPEATER_MODE_,
+            0 => MODER::INACTIVE,
+            1 => MODER::PULL_DOWN,
+            2 => MODER::PULL_UP,
+            3 => MODER::REPEATER,
             _ => unreachable!(),
         }
     }
-    #[doc = "Checks if the value of the field is `INACTIVE_NO_PULL_DO`"]
+    #[doc = "Checks if the value of the field is `INACTIVE`"]
     #[inline]
-    pub fn is_inactive_no_pull_do(&self) -> bool {
-        *self == MODER::INACTIVE_NO_PULL_DO
+    pub fn is_inactive(&self) -> bool {
+        *self == MODER::INACTIVE
     }
-    #[doc = "Checks if the value of the field is `PULL_DOWN_RESISTOR_E`"]
+    #[doc = "Checks if the value of the field is `PULL_DOWN`"]
     #[inline]
-    pub fn is_pull_down_resistor_e(&self) -> bool {
-        *self == MODER::PULL_DOWN_RESISTOR_E
+    pub fn is_pull_down(&self) -> bool {
+        *self == MODER::PULL_DOWN
     }
-    #[doc = "Checks if the value of the field is `PULL_UP_RESISTOR_ENA`"]
+    #[doc = "Checks if the value of the field is `PULL_UP`"]
     #[inline]
-    pub fn is_pull_up_resistor_ena(&self) -> bool {
-        *self == MODER::PULL_UP_RESISTOR_ENA
+    pub fn is_pull_up(&self) -> bool {
+        *self == MODER::PULL_UP
     }
-    #[doc = "Checks if the value of the field is `REPEATER_MODE_`"]
+    #[doc = "Checks if the value of the field is `REPEATER`"]
     #[inline]
-    pub fn is_repeater_mode_(&self) -> bool {
-        *self == MODER::REPEATER_MODE_
+    pub fn is_repeater(&self) -> bool {
+        *self == MODER::REPEATER
     }
 }
 #[doc = "Possible values of the field `HYS`"]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum HYSR {
     #[doc = "Disable."]
-    DISABLE_,
+    DISABLED,
     #[doc = "Enable."]
-    ENABLE_,
+    ENABLED,
 }
 impl HYSR {
     #[doc = r" Returns `true` if the bit is clear (0)"]
@@ -171,8 +171,8 @@ impl HYSR {
     #[inline]
     pub fn bit(&self) -> bool {
         match *self {
-            HYSR::DISABLE_ => false,
-            HYSR::ENABLE_ => true,
+            HYSR::DISABLED => false,
+            HYSR::ENABLED => true,
         }
     }
     #[allow(missing_docs)]
@@ -180,28 +180,28 @@ impl HYSR {
     #[inline]
     pub fn _from(value: bool) -> HYSR {
         match value {
-            false => HYSR::DISABLE_,
-            true => HYSR::ENABLE_,
+            false => HYSR::DISABLED,
+            true => HYSR::ENABLED,
         }
     }
-    #[doc = "Checks if the value of the field is `DISABLE_`"]
+    #[doc = "Checks if the value of the field is `DISABLED`"]
     #[inline]
-    pub fn is_disable_(&self) -> bool {
-        *self == HYSR::DISABLE_
+    pub fn is_disabled(&self) -> bool {
+        *self == HYSR::DISABLED
     }
-    #[doc = "Checks if the value of the field is `ENABLE_`"]
+    #[doc = "Checks if the value of the field is `ENABLED`"]
     #[inline]
-    pub fn is_enable_(&self) -> bool {
-        *self == HYSR::ENABLE_
+    pub fn is_enabled(&self) -> bool {
+        *self == HYSR::ENABLED
     }
 }
 #[doc = "Possible values of the field `INV`"]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum INVR {
     #[doc = "Input not inverted (HIGH on pin reads as 1, LOW on pin reads as 0)."]
-    INPUT_NOT_INVERTED_,
+    NOT_INVERTED,
     #[doc = "Input inverted (HIGH on pin reads as 0, LOW on pin reads as 1)."]
-    INPUT_INVERTED_HIGH,
+    INVERTED,
 }
 impl INVR {
     #[doc = r" Returns `true` if the bit is clear (0)"]
@@ -218,8 +218,8 @@ impl INVR {
     #[inline]
     pub fn bit(&self) -> bool {
         match *self {
-            INVR::INPUT_NOT_INVERTED_ => false,
-            INVR::INPUT_INVERTED_HIGH => true,
+            INVR::NOT_INVERTED => false,
+            INVR::INVERTED => true,
         }
     }
     #[allow(missing_docs)]
@@ -227,28 +227,28 @@ impl INVR {
     #[inline]
     pub fn _from(value: bool) -> INVR {
         match value {
-            false => INVR::INPUT_NOT_INVERTED_,
-            true => INVR::INPUT_INVERTED_HIGH,
+            false => INVR::NOT_INVERTED,
+            true => INVR::INVERTED,
         }
     }
-    #[doc = "Checks if the value of the field is `INPUT_NOT_INVERTED_`"]
+    #[doc = "Checks if the value of the field is `NOT_INVERTED`"]
     #[inline]
-    pub fn is_input_not_inverted_(&self) -> bool {
-        *self == INVR::INPUT_NOT_INVERTED_
+    pub fn is_not_inverted(&self) -> bool {
+        *self == INVR::NOT_INVERTED
     }
-    #[doc = "Checks if the value of the field is `INPUT_INVERTED_HIGH`"]
+    #[doc = "Checks if the value of the field is `INVERTED`"]
     #[inline]
-    pub fn is_input_inverted_high(&self) -> bool {
-        *self == INVR::INPUT_INVERTED_HIGH
+    pub fn is_inverted(&self) -> bool {
+        *self == INVR::INVERTED
     }
 }
 #[doc = "Possible values of the field `OD`"]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum ODR {
     #[doc = "Disable."]
-    DISABLE_,
+    DISABLED,
     #[doc = "Open-drain mode enabled.  This is not a true open-drain mode."]
-    OPEN_DRAIN_MODE_ENAB,
+    OPEN_DRAIN,
 }
 impl ODR {
     #[doc = r" Returns `true` if the bit is clear (0)"]
@@ -265,8 +265,8 @@ impl ODR {
     #[inline]
     pub fn bit(&self) -> bool {
         match *self {
-            ODR::DISABLE_ => false,
-            ODR::OPEN_DRAIN_MODE_ENAB => true,
+            ODR::DISABLED => false,
+            ODR::OPEN_DRAIN => true,
         }
     }
     #[allow(missing_docs)]
@@ -274,29 +274,29 @@ impl ODR {
     #[inline]
     pub fn _from(value: bool) -> ODR {
         match value {
-            false => ODR::DISABLE_,
-            true => ODR::OPEN_DRAIN_MODE_ENAB,
+            false => ODR::DISABLED,
+            true => ODR::OPEN_DRAIN,
         }
     }
-    #[doc = "Checks if the value of the field is `DISABLE_`"]
+    #[doc = "Checks if the value of the field is `DISABLED`"]
     #[inline]
-    pub fn is_disable_(&self) -> bool {
-        *self == ODR::DISABLE_
+    pub fn is_disabled(&self) -> bool {
+        *self == ODR::DISABLED
     }
-    #[doc = "Checks if the value of the field is `OPEN_DRAIN_MODE_ENAB`"]
+    #[doc = "Checks if the value of the field is `OPEN_DRAIN`"]
     #[inline]
-    pub fn is_open_drain_mode_enab(&self) -> bool {
-        *self == ODR::OPEN_DRAIN_MODE_ENAB
+    pub fn is_open_drain(&self) -> bool {
+        *self == ODR::OPEN_DRAIN
     }
 }
 #[doc = "Values that can be written to the field `FUNC`"]
 pub enum FUNCW {
     #[doc = "PIO1_19."]
-    PIO1_19_,
+    PIO1_19,
     #[doc = "DTR."]
-    DTR_,
+    DTR,
     #[doc = "SSEL1."]
-    SSEL1_,
+    SSEL1,
 }
 impl FUNCW {
     #[allow(missing_docs)]
@@ -304,9 +304,9 @@ impl FUNCW {
     #[inline]
     pub fn _bits(&self) -> u8 {
         match *self {
-            FUNCW::PIO1_19_ => 0,
-            FUNCW::DTR_ => 1,
-            FUNCW::SSEL1_ => 2,
+            FUNCW::PIO1_19 => 0,
+            FUNCW::DTR => 1,
+            FUNCW::SSEL1 => 2,
         }
     }
 }
@@ -322,18 +322,18 @@ impl<'a> _FUNCW<'a> {
     }
     #[doc = "PIO1_19."]
     #[inline]
-    pub fn pio1_19_(self) -> &'a mut W {
-        self.variant(FUNCW::PIO1_19_)
+    pub fn pio1_19(self) -> &'a mut W {
+        self.variant(FUNCW::PIO1_19)
     }
     #[doc = "DTR."]
     #[inline]
-    pub fn dtr_(self) -> &'a mut W {
-        self.variant(FUNCW::DTR_)
+    pub fn dtr(self) -> &'a mut W {
+        self.variant(FUNCW::DTR)
     }
     #[doc = "SSEL1."]
     #[inline]
-    pub fn ssel1_(self) -> &'a mut W {
-        self.variant(FUNCW::SSEL1_)
+    pub fn ssel1(self) -> &'a mut W {
+        self.variant(FUNCW::SSEL1)
     }
     #[doc = r" Writes raw bits to the field"]
     #[inline]
@@ -348,13 +348,13 @@ impl<'a> _FUNCW<'a> {
 #[doc = "Values that can be written to the field `MODE`"]
 pub enum MODEW {
     #[doc = "Inactive (no pull-down/pull-up resistor enabled)."]
-    INACTIVE_NO_PULL_DO,
+    INACTIVE,
     #[doc = "Pull-down resistor enabled."]
-    PULL_DOWN_RESISTOR_E,
+    PULL_DOWN,
     #[doc = "Pull-up resistor enabled."]
-    PULL_UP_RESISTOR_ENA,
+    PULL_UP,
     #[doc = "Repeater mode."]
-    REPEATER_MODE_,
+    REPEATER,
 }
 impl MODEW {
     #[allow(missing_docs)]
@@ -362,10 +362,10 @@ impl MODEW {
     #[inline]
     pub fn _bits(&self) -> u8 {
         match *self {
-            MODEW::INACTIVE_NO_PULL_DO => 0,
-            MODEW::PULL_DOWN_RESISTOR_E => 1,
-            MODEW::PULL_UP_RESISTOR_ENA => 2,
-            MODEW::REPEATER_MODE_ => 3,
+            MODEW::INACTIVE => 0,
+            MODEW::PULL_DOWN => 1,
+            MODEW::PULL_UP => 2,
+            MODEW::REPEATER => 3,
         }
     }
 }
@@ -383,23 +383,23 @@ impl<'a> _MODEW<'a> {
     }
     #[doc = "Inactive (no pull-down/pull-up resistor enabled)."]
     #[inline]
-    pub fn inactive_no_pull_do(self) -> &'a mut W {
-        self.variant(MODEW::INACTIVE_NO_PULL_DO)
+    pub fn inactive(self) -> &'a mut W {
+        self.variant(MODEW::INACTIVE)
     }
     #[doc = "Pull-down resistor enabled."]
     #[inline]
-    pub fn pull_down_resistor_e(self) -> &'a mut W {
-        self.variant(MODEW::PULL_DOWN_RESISTOR_E)
+    pub fn pull_down(self) -> &'a mut W {
+        self.variant(MODEW::PULL_DOWN)
     }
     #[doc = "Pull-up resistor enabled."]
     #[inline]
-    pub fn pull_up_resistor_ena(self) -> &'a mut W {
-        self.variant(MODEW::PULL_UP_RESISTOR_ENA)
+    pub fn pull_up(self) -> &'a mut W {
+        self.variant(MODEW::PULL_UP)
     }
     #[doc = "Repeater mode."]
     #[inline]
-    pub fn repeater_mode_(self) -> &'a mut W {
-        self.variant(MODEW::REPEATER_MODE_)
+    pub fn repeater(self) -> &'a mut W {
+        self.variant(MODEW::REPEATER)
     }
     #[doc = r" Writes raw bits to the field"]
     #[inline]
@@ -414,9 +414,9 @@ impl<'a> _MODEW<'a> {
 #[doc = "Values that can be written to the field `HYS`"]
 pub enum HYSW {
     #[doc = "Disable."]
-    DISABLE_,
+    DISABLED,
     #[doc = "Enable."]
-    ENABLE_,
+    ENABLED,
 }
 impl HYSW {
     #[allow(missing_docs)]
@@ -424,8 +424,8 @@ impl HYSW {
     #[inline]
     pub fn _bits(&self) -> bool {
         match *self {
-            HYSW::DISABLE_ => false,
-            HYSW::ENABLE_ => true,
+            HYSW::DISABLED => false,
+            HYSW::ENABLED => true,
         }
     }
 }
@@ -443,13 +443,13 @@ impl<'a> _HYSW<'a> {
     }
     #[doc = "Disable."]
     #[inline]
-    pub fn disable_(self) -> &'a mut W {
-        self.variant(HYSW::DISABLE_)
+    pub fn disabled(self) -> &'a mut W {
+        self.variant(HYSW::DISABLED)
     }
     #[doc = "Enable."]
     #[inline]
-    pub fn enable_(self) -> &'a mut W {
-        self.variant(HYSW::ENABLE_)
+    pub fn enabled(self) -> &'a mut W {
+        self.variant(HYSW::ENABLED)
     }
     #[doc = r" Sets the field bit"]
     pub fn set_bit(self) -> &'a mut W {
@@ -472,9 +472,9 @@ impl<'a> _HYSW<'a> {
 #[doc = "Values that can be written to the field `INV`"]
 pub enum INVW {
     #[doc = "Input not inverted (HIGH on pin reads as 1, LOW on pin reads as 0)."]
-    INPUT_NOT_INVERTED_,
+    NOT_INVERTED,
     #[doc = "Input inverted (HIGH on pin reads as 0, LOW on pin reads as 1)."]
-    INPUT_INVERTED_HIGH,
+    INVERTED,
 }
 impl INVW {
     #[allow(missing_docs)]
@@ -482,8 +482,8 @@ impl INVW {
     #[inline]
     pub fn _bits(&self) -> bool {
         match *self {
-            INVW::INPUT_NOT_INVERTED_ => false,
-            INVW::INPUT_INVERTED_HIGH => true,
+            INVW::NOT_INVERTED => false,
+            INVW::INVERTED => true,
         }
     }
 }
@@ -501,13 +501,13 @@ impl<'a> _INVW<'a> {
     }
     #[doc = "Input not inverted (HIGH on pin reads as 1, LOW on pin reads as 0)."]
     #[inline]
-    pub fn input_not_inverted_(self) -> &'a mut W {
-        self.variant(INVW::INPUT_NOT_INVERTED_)
+    pub fn not_inverted(self) -> &'a mut W {
+        self.variant(INVW::NOT_INVERTED)
     }
     #[doc = "Input inverted (HIGH on pin reads as 0, LOW on pin reads as 1)."]
     #[inline]
-    pub fn input_inverted_high(self) -> &'a mut W {
-        self.variant(INVW::INPUT_INVERTED_HIGH)
+    pub fn inverted(self) -> &'a mut W {
+        self.variant(INVW::INVERTED)
     }
     #[doc = r" Sets the field bit"]
     pub fn set_bit(self) -> &'a mut W {
@@ -530,9 +530,9 @@ impl<'a> _INVW<'a> {
 #[doc = "Values that can be written to the field `OD`"]
 pub enum ODW {
     #[doc = "Disable."]
-    DISABLE_,
+    DISABLED,
     #[doc = "Open-drain mode enabled.  This is not a true open-drain mode."]
-    OPEN_DRAIN_MODE_ENAB,
+    OPEN_DRAIN,
 }
 impl ODW {
     #[allow(missing_docs)]
@@ -540,8 +540,8 @@ impl ODW {
     #[inline]
     pub fn _bits(&self) -> bool {
         match *self {
-            ODW::DISABLE_ => false,
-            ODW::OPEN_DRAIN_MODE_ENAB => true,
+            ODW::DISABLED => false,
+            ODW::OPEN_DRAIN => true,
         }
     }
 }
@@ -559,13 +559,13 @@ impl<'a> _ODW<'a> {
     }
     #[doc = "Disable."]
     #[inline]
-    pub fn disable_(self) -> &'a mut W {
-        self.variant(ODW::DISABLE_)
+    pub fn disabled(self) -> &'a mut W {
+        self.variant(ODW::DISABLED)
     }
     #[doc = "Open-drain mode enabled. This is not a true open-drain mode."]
     #[inline]
-    pub fn open_drain_mode_enab(self) -> &'a mut W {
-        self.variant(ODW::OPEN_DRAIN_MODE_ENAB)
+    pub fn open_drain(self) -> &'a mut W {
+        self.variant(ODW::OPEN_DRAIN)
     }
     #[doc = r" Sets the field bit"]
     pub fn set_bit(self) -> &'a mut W {

--- a/lpc11uxx/src/iocon/pio1_2.rs
+++ b/lpc11uxx/src/iocon/pio1_2.rs
@@ -46,9 +46,9 @@ impl super::PIO1_2 {
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum FUNCR {
     #[doc = "PIO1_2."]
-    PIO1_2_,
+    PIO1_2,
     #[doc = "CT32B1_MAT2."]
-    CT32B1_MAT2_,
+    CT32B1_MAT2,
     #[doc = r" Reserved"]
     _Reserved(u8),
 }
@@ -57,8 +57,8 @@ impl FUNCR {
     #[inline]
     pub fn bits(&self) -> u8 {
         match *self {
-            FUNCR::PIO1_2_ => 0,
-            FUNCR::CT32B1_MAT2_ => 1,
+            FUNCR::PIO1_2 => 0,
+            FUNCR::CT32B1_MAT2 => 1,
             FUNCR::_Reserved(bits) => bits,
         }
     }
@@ -67,43 +67,43 @@ impl FUNCR {
     #[inline]
     pub fn _from(value: u8) -> FUNCR {
         match value {
-            0 => FUNCR::PIO1_2_,
-            1 => FUNCR::CT32B1_MAT2_,
+            0 => FUNCR::PIO1_2,
+            1 => FUNCR::CT32B1_MAT2,
             i => FUNCR::_Reserved(i),
         }
     }
-    #[doc = "Checks if the value of the field is `PIO1_2_`"]
+    #[doc = "Checks if the value of the field is `PIO1_2`"]
     #[inline]
-    pub fn is_pio1_2_(&self) -> bool {
-        *self == FUNCR::PIO1_2_
+    pub fn is_pio1_2(&self) -> bool {
+        *self == FUNCR::PIO1_2
     }
-    #[doc = "Checks if the value of the field is `CT32B1_MAT2_`"]
+    #[doc = "Checks if the value of the field is `CT32B1_MAT2`"]
     #[inline]
-    pub fn is_ct32b1_mat2_(&self) -> bool {
-        *self == FUNCR::CT32B1_MAT2_
+    pub fn is_ct32b1_mat2(&self) -> bool {
+        *self == FUNCR::CT32B1_MAT2
     }
 }
 #[doc = "Possible values of the field `MODE`"]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum MODER {
     #[doc = "Inactive (no pull-down/pull-up resistor enabled)."]
-    INACTIVE_NO_PULL_DO,
+    INACTIVE,
     #[doc = "Pull-down resistor enabled."]
-    PULL_DOWN_RESISTOR_E,
+    PULL_DOWN,
     #[doc = "Pull-up resistor enabled."]
-    PULL_UP_RESISTOR_ENA,
+    PULL_UP,
     #[doc = "Repeater mode."]
-    REPEATER_MODE_,
+    REPEATER,
 }
 impl MODER {
     #[doc = r" Value of the field as raw bits"]
     #[inline]
     pub fn bits(&self) -> u8 {
         match *self {
-            MODER::INACTIVE_NO_PULL_DO => 0,
-            MODER::PULL_DOWN_RESISTOR_E => 1,
-            MODER::PULL_UP_RESISTOR_ENA => 2,
-            MODER::REPEATER_MODE_ => 3,
+            MODER::INACTIVE => 0,
+            MODER::PULL_DOWN => 1,
+            MODER::PULL_UP => 2,
+            MODER::REPEATER => 3,
         }
     }
     #[allow(missing_docs)]
@@ -111,41 +111,41 @@ impl MODER {
     #[inline]
     pub fn _from(value: u8) -> MODER {
         match value {
-            0 => MODER::INACTIVE_NO_PULL_DO,
-            1 => MODER::PULL_DOWN_RESISTOR_E,
-            2 => MODER::PULL_UP_RESISTOR_ENA,
-            3 => MODER::REPEATER_MODE_,
+            0 => MODER::INACTIVE,
+            1 => MODER::PULL_DOWN,
+            2 => MODER::PULL_UP,
+            3 => MODER::REPEATER,
             _ => unreachable!(),
         }
     }
-    #[doc = "Checks if the value of the field is `INACTIVE_NO_PULL_DO`"]
+    #[doc = "Checks if the value of the field is `INACTIVE`"]
     #[inline]
-    pub fn is_inactive_no_pull_do(&self) -> bool {
-        *self == MODER::INACTIVE_NO_PULL_DO
+    pub fn is_inactive(&self) -> bool {
+        *self == MODER::INACTIVE
     }
-    #[doc = "Checks if the value of the field is `PULL_DOWN_RESISTOR_E`"]
+    #[doc = "Checks if the value of the field is `PULL_DOWN`"]
     #[inline]
-    pub fn is_pull_down_resistor_e(&self) -> bool {
-        *self == MODER::PULL_DOWN_RESISTOR_E
+    pub fn is_pull_down(&self) -> bool {
+        *self == MODER::PULL_DOWN
     }
-    #[doc = "Checks if the value of the field is `PULL_UP_RESISTOR_ENA`"]
+    #[doc = "Checks if the value of the field is `PULL_UP`"]
     #[inline]
-    pub fn is_pull_up_resistor_ena(&self) -> bool {
-        *self == MODER::PULL_UP_RESISTOR_ENA
+    pub fn is_pull_up(&self) -> bool {
+        *self == MODER::PULL_UP
     }
-    #[doc = "Checks if the value of the field is `REPEATER_MODE_`"]
+    #[doc = "Checks if the value of the field is `REPEATER`"]
     #[inline]
-    pub fn is_repeater_mode_(&self) -> bool {
-        *self == MODER::REPEATER_MODE_
+    pub fn is_repeater(&self) -> bool {
+        *self == MODER::REPEATER
     }
 }
 #[doc = "Possible values of the field `HYS`"]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum HYSR {
     #[doc = "Disable."]
-    DISABLE_,
+    DISABLED,
     #[doc = "Enable."]
-    ENABLE_,
+    ENABLED,
 }
 impl HYSR {
     #[doc = r" Returns `true` if the bit is clear (0)"]
@@ -162,8 +162,8 @@ impl HYSR {
     #[inline]
     pub fn bit(&self) -> bool {
         match *self {
-            HYSR::DISABLE_ => false,
-            HYSR::ENABLE_ => true,
+            HYSR::DISABLED => false,
+            HYSR::ENABLED => true,
         }
     }
     #[allow(missing_docs)]
@@ -171,28 +171,28 @@ impl HYSR {
     #[inline]
     pub fn _from(value: bool) -> HYSR {
         match value {
-            false => HYSR::DISABLE_,
-            true => HYSR::ENABLE_,
+            false => HYSR::DISABLED,
+            true => HYSR::ENABLED,
         }
     }
-    #[doc = "Checks if the value of the field is `DISABLE_`"]
+    #[doc = "Checks if the value of the field is `DISABLED`"]
     #[inline]
-    pub fn is_disable_(&self) -> bool {
-        *self == HYSR::DISABLE_
+    pub fn is_disabled(&self) -> bool {
+        *self == HYSR::DISABLED
     }
-    #[doc = "Checks if the value of the field is `ENABLE_`"]
+    #[doc = "Checks if the value of the field is `ENABLED`"]
     #[inline]
-    pub fn is_enable_(&self) -> bool {
-        *self == HYSR::ENABLE_
+    pub fn is_enabled(&self) -> bool {
+        *self == HYSR::ENABLED
     }
 }
 #[doc = "Possible values of the field `INV`"]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum INVR {
     #[doc = "Input not inverted (HIGH on pin reads as 1, LOW on pin reads as 0)."]
-    INPUT_NOT_INVERTED_,
+    NOT_INVERTED,
     #[doc = "Input inverted (HIGH on pin reads as 0, LOW on pin reads as 1)."]
-    INPUT_INVERTED_HIGH,
+    INVERTED,
 }
 impl INVR {
     #[doc = r" Returns `true` if the bit is clear (0)"]
@@ -209,8 +209,8 @@ impl INVR {
     #[inline]
     pub fn bit(&self) -> bool {
         match *self {
-            INVR::INPUT_NOT_INVERTED_ => false,
-            INVR::INPUT_INVERTED_HIGH => true,
+            INVR::NOT_INVERTED => false,
+            INVR::INVERTED => true,
         }
     }
     #[allow(missing_docs)]
@@ -218,28 +218,28 @@ impl INVR {
     #[inline]
     pub fn _from(value: bool) -> INVR {
         match value {
-            false => INVR::INPUT_NOT_INVERTED_,
-            true => INVR::INPUT_INVERTED_HIGH,
+            false => INVR::NOT_INVERTED,
+            true => INVR::INVERTED,
         }
     }
-    #[doc = "Checks if the value of the field is `INPUT_NOT_INVERTED_`"]
+    #[doc = "Checks if the value of the field is `NOT_INVERTED`"]
     #[inline]
-    pub fn is_input_not_inverted_(&self) -> bool {
-        *self == INVR::INPUT_NOT_INVERTED_
+    pub fn is_not_inverted(&self) -> bool {
+        *self == INVR::NOT_INVERTED
     }
-    #[doc = "Checks if the value of the field is `INPUT_INVERTED_HIGH`"]
+    #[doc = "Checks if the value of the field is `INVERTED`"]
     #[inline]
-    pub fn is_input_inverted_high(&self) -> bool {
-        *self == INVR::INPUT_INVERTED_HIGH
+    pub fn is_inverted(&self) -> bool {
+        *self == INVR::INVERTED
     }
 }
 #[doc = "Possible values of the field `OD`"]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum ODR {
     #[doc = "Disable."]
-    DISABLE_,
+    DISABLED,
     #[doc = "Open-drain mode enabled. This is not a true open-drain mode. Input cannot be pulled up above VDD."]
-    OPEN_DRAIN_MODE_ENAB,
+    OPEN_DRAIN,
 }
 impl ODR {
     #[doc = r" Returns `true` if the bit is clear (0)"]
@@ -256,8 +256,8 @@ impl ODR {
     #[inline]
     pub fn bit(&self) -> bool {
         match *self {
-            ODR::DISABLE_ => false,
-            ODR::OPEN_DRAIN_MODE_ENAB => true,
+            ODR::DISABLED => false,
+            ODR::OPEN_DRAIN => true,
         }
     }
     #[allow(missing_docs)]
@@ -265,27 +265,27 @@ impl ODR {
     #[inline]
     pub fn _from(value: bool) -> ODR {
         match value {
-            false => ODR::DISABLE_,
-            true => ODR::OPEN_DRAIN_MODE_ENAB,
+            false => ODR::DISABLED,
+            true => ODR::OPEN_DRAIN,
         }
     }
-    #[doc = "Checks if the value of the field is `DISABLE_`"]
+    #[doc = "Checks if the value of the field is `DISABLED`"]
     #[inline]
-    pub fn is_disable_(&self) -> bool {
-        *self == ODR::DISABLE_
+    pub fn is_disabled(&self) -> bool {
+        *self == ODR::DISABLED
     }
-    #[doc = "Checks if the value of the field is `OPEN_DRAIN_MODE_ENAB`"]
+    #[doc = "Checks if the value of the field is `OPEN_DRAIN`"]
     #[inline]
-    pub fn is_open_drain_mode_enab(&self) -> bool {
-        *self == ODR::OPEN_DRAIN_MODE_ENAB
+    pub fn is_open_drain(&self) -> bool {
+        *self == ODR::OPEN_DRAIN
     }
 }
 #[doc = "Values that can be written to the field `FUNC`"]
 pub enum FUNCW {
     #[doc = "PIO1_2."]
-    PIO1_2_,
+    PIO1_2,
     #[doc = "CT32B1_MAT2."]
-    CT32B1_MAT2_,
+    CT32B1_MAT2,
 }
 impl FUNCW {
     #[allow(missing_docs)]
@@ -293,8 +293,8 @@ impl FUNCW {
     #[inline]
     pub fn _bits(&self) -> u8 {
         match *self {
-            FUNCW::PIO1_2_ => 0,
-            FUNCW::CT32B1_MAT2_ => 1,
+            FUNCW::PIO1_2 => 0,
+            FUNCW::CT32B1_MAT2 => 1,
         }
     }
 }
@@ -310,13 +310,13 @@ impl<'a> _FUNCW<'a> {
     }
     #[doc = "PIO1_2."]
     #[inline]
-    pub fn pio1_2_(self) -> &'a mut W {
-        self.variant(FUNCW::PIO1_2_)
+    pub fn pio1_2(self) -> &'a mut W {
+        self.variant(FUNCW::PIO1_2)
     }
     #[doc = "CT32B1_MAT2."]
     #[inline]
-    pub fn ct32b1_mat2_(self) -> &'a mut W {
-        self.variant(FUNCW::CT32B1_MAT2_)
+    pub fn ct32b1_mat2(self) -> &'a mut W {
+        self.variant(FUNCW::CT32B1_MAT2)
     }
     #[doc = r" Writes raw bits to the field"]
     #[inline]
@@ -331,13 +331,13 @@ impl<'a> _FUNCW<'a> {
 #[doc = "Values that can be written to the field `MODE`"]
 pub enum MODEW {
     #[doc = "Inactive (no pull-down/pull-up resistor enabled)."]
-    INACTIVE_NO_PULL_DO,
+    INACTIVE,
     #[doc = "Pull-down resistor enabled."]
-    PULL_DOWN_RESISTOR_E,
+    PULL_DOWN,
     #[doc = "Pull-up resistor enabled."]
-    PULL_UP_RESISTOR_ENA,
+    PULL_UP,
     #[doc = "Repeater mode."]
-    REPEATER_MODE_,
+    REPEATER,
 }
 impl MODEW {
     #[allow(missing_docs)]
@@ -345,10 +345,10 @@ impl MODEW {
     #[inline]
     pub fn _bits(&self) -> u8 {
         match *self {
-            MODEW::INACTIVE_NO_PULL_DO => 0,
-            MODEW::PULL_DOWN_RESISTOR_E => 1,
-            MODEW::PULL_UP_RESISTOR_ENA => 2,
-            MODEW::REPEATER_MODE_ => 3,
+            MODEW::INACTIVE => 0,
+            MODEW::PULL_DOWN => 1,
+            MODEW::PULL_UP => 2,
+            MODEW::REPEATER => 3,
         }
     }
 }
@@ -366,23 +366,23 @@ impl<'a> _MODEW<'a> {
     }
     #[doc = "Inactive (no pull-down/pull-up resistor enabled)."]
     #[inline]
-    pub fn inactive_no_pull_do(self) -> &'a mut W {
-        self.variant(MODEW::INACTIVE_NO_PULL_DO)
+    pub fn inactive(self) -> &'a mut W {
+        self.variant(MODEW::INACTIVE)
     }
     #[doc = "Pull-down resistor enabled."]
     #[inline]
-    pub fn pull_down_resistor_e(self) -> &'a mut W {
-        self.variant(MODEW::PULL_DOWN_RESISTOR_E)
+    pub fn pull_down(self) -> &'a mut W {
+        self.variant(MODEW::PULL_DOWN)
     }
     #[doc = "Pull-up resistor enabled."]
     #[inline]
-    pub fn pull_up_resistor_ena(self) -> &'a mut W {
-        self.variant(MODEW::PULL_UP_RESISTOR_ENA)
+    pub fn pull_up(self) -> &'a mut W {
+        self.variant(MODEW::PULL_UP)
     }
     #[doc = "Repeater mode."]
     #[inline]
-    pub fn repeater_mode_(self) -> &'a mut W {
-        self.variant(MODEW::REPEATER_MODE_)
+    pub fn repeater(self) -> &'a mut W {
+        self.variant(MODEW::REPEATER)
     }
     #[doc = r" Writes raw bits to the field"]
     #[inline]
@@ -397,9 +397,9 @@ impl<'a> _MODEW<'a> {
 #[doc = "Values that can be written to the field `HYS`"]
 pub enum HYSW {
     #[doc = "Disable."]
-    DISABLE_,
+    DISABLED,
     #[doc = "Enable."]
-    ENABLE_,
+    ENABLED,
 }
 impl HYSW {
     #[allow(missing_docs)]
@@ -407,8 +407,8 @@ impl HYSW {
     #[inline]
     pub fn _bits(&self) -> bool {
         match *self {
-            HYSW::DISABLE_ => false,
-            HYSW::ENABLE_ => true,
+            HYSW::DISABLED => false,
+            HYSW::ENABLED => true,
         }
     }
 }
@@ -426,13 +426,13 @@ impl<'a> _HYSW<'a> {
     }
     #[doc = "Disable."]
     #[inline]
-    pub fn disable_(self) -> &'a mut W {
-        self.variant(HYSW::DISABLE_)
+    pub fn disabled(self) -> &'a mut W {
+        self.variant(HYSW::DISABLED)
     }
     #[doc = "Enable."]
     #[inline]
-    pub fn enable_(self) -> &'a mut W {
-        self.variant(HYSW::ENABLE_)
+    pub fn enabled(self) -> &'a mut W {
+        self.variant(HYSW::ENABLED)
     }
     #[doc = r" Sets the field bit"]
     pub fn set_bit(self) -> &'a mut W {
@@ -455,9 +455,9 @@ impl<'a> _HYSW<'a> {
 #[doc = "Values that can be written to the field `INV`"]
 pub enum INVW {
     #[doc = "Input not inverted (HIGH on pin reads as 1, LOW on pin reads as 0)."]
-    INPUT_NOT_INVERTED_,
+    NOT_INVERTED,
     #[doc = "Input inverted (HIGH on pin reads as 0, LOW on pin reads as 1)."]
-    INPUT_INVERTED_HIGH,
+    INVERTED,
 }
 impl INVW {
     #[allow(missing_docs)]
@@ -465,8 +465,8 @@ impl INVW {
     #[inline]
     pub fn _bits(&self) -> bool {
         match *self {
-            INVW::INPUT_NOT_INVERTED_ => false,
-            INVW::INPUT_INVERTED_HIGH => true,
+            INVW::NOT_INVERTED => false,
+            INVW::INVERTED => true,
         }
     }
 }
@@ -484,13 +484,13 @@ impl<'a> _INVW<'a> {
     }
     #[doc = "Input not inverted (HIGH on pin reads as 1, LOW on pin reads as 0)."]
     #[inline]
-    pub fn input_not_inverted_(self) -> &'a mut W {
-        self.variant(INVW::INPUT_NOT_INVERTED_)
+    pub fn not_inverted(self) -> &'a mut W {
+        self.variant(INVW::NOT_INVERTED)
     }
     #[doc = "Input inverted (HIGH on pin reads as 0, LOW on pin reads as 1)."]
     #[inline]
-    pub fn input_inverted_high(self) -> &'a mut W {
-        self.variant(INVW::INPUT_INVERTED_HIGH)
+    pub fn inverted(self) -> &'a mut W {
+        self.variant(INVW::INVERTED)
     }
     #[doc = r" Sets the field bit"]
     pub fn set_bit(self) -> &'a mut W {
@@ -513,9 +513,9 @@ impl<'a> _INVW<'a> {
 #[doc = "Values that can be written to the field `OD`"]
 pub enum ODW {
     #[doc = "Disable."]
-    DISABLE_,
+    DISABLED,
     #[doc = "Open-drain mode enabled. This is not a true open-drain mode. Input cannot be pulled up above VDD."]
-    OPEN_DRAIN_MODE_ENAB,
+    OPEN_DRAIN,
 }
 impl ODW {
     #[allow(missing_docs)]
@@ -523,8 +523,8 @@ impl ODW {
     #[inline]
     pub fn _bits(&self) -> bool {
         match *self {
-            ODW::DISABLE_ => false,
-            ODW::OPEN_DRAIN_MODE_ENAB => true,
+            ODW::DISABLED => false,
+            ODW::OPEN_DRAIN => true,
         }
     }
 }
@@ -542,13 +542,13 @@ impl<'a> _ODW<'a> {
     }
     #[doc = "Disable."]
     #[inline]
-    pub fn disable_(self) -> &'a mut W {
-        self.variant(ODW::DISABLE_)
+    pub fn disabled(self) -> &'a mut W {
+        self.variant(ODW::DISABLED)
     }
     #[doc = "Open-drain mode enabled. This is not a true open-drain mode. Input cannot be pulled up above VDD."]
     #[inline]
-    pub fn open_drain_mode_enab(self) -> &'a mut W {
-        self.variant(ODW::OPEN_DRAIN_MODE_ENAB)
+    pub fn open_drain(self) -> &'a mut W {
+        self.variant(ODW::OPEN_DRAIN)
     }
     #[doc = r" Sets the field bit"]
     pub fn set_bit(self) -> &'a mut W {

--- a/lpc11uxx/src/iocon/pio1_20.rs
+++ b/lpc11uxx/src/iocon/pio1_20.rs
@@ -46,11 +46,11 @@ impl super::PIO1_20 {
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum FUNCR {
     #[doc = "PIO1_20."]
-    PIO1_20_,
+    PIO1_20,
     #[doc = "DSR."]
-    DSR_,
+    DSR,
     #[doc = "SCK1."]
-    SCK1_,
+    SCK1,
     #[doc = r" Reserved"]
     _Reserved(u8),
 }
@@ -59,9 +59,9 @@ impl FUNCR {
     #[inline]
     pub fn bits(&self) -> u8 {
         match *self {
-            FUNCR::PIO1_20_ => 0,
-            FUNCR::DSR_ => 1,
-            FUNCR::SCK1_ => 2,
+            FUNCR::PIO1_20 => 0,
+            FUNCR::DSR => 1,
+            FUNCR::SCK1 => 2,
             FUNCR::_Reserved(bits) => bits,
         }
     }
@@ -70,49 +70,49 @@ impl FUNCR {
     #[inline]
     pub fn _from(value: u8) -> FUNCR {
         match value {
-            0 => FUNCR::PIO1_20_,
-            1 => FUNCR::DSR_,
-            2 => FUNCR::SCK1_,
+            0 => FUNCR::PIO1_20,
+            1 => FUNCR::DSR,
+            2 => FUNCR::SCK1,
             i => FUNCR::_Reserved(i),
         }
     }
-    #[doc = "Checks if the value of the field is `PIO1_20_`"]
+    #[doc = "Checks if the value of the field is `PIO1_20`"]
     #[inline]
-    pub fn is_pio1_20_(&self) -> bool {
-        *self == FUNCR::PIO1_20_
+    pub fn is_pio1_20(&self) -> bool {
+        *self == FUNCR::PIO1_20
     }
-    #[doc = "Checks if the value of the field is `DSR_`"]
+    #[doc = "Checks if the value of the field is `DSR`"]
     #[inline]
-    pub fn is_dsr_(&self) -> bool {
-        *self == FUNCR::DSR_
+    pub fn is_dsr(&self) -> bool {
+        *self == FUNCR::DSR
     }
-    #[doc = "Checks if the value of the field is `SCK1_`"]
+    #[doc = "Checks if the value of the field is `SCK1`"]
     #[inline]
-    pub fn is_sck1_(&self) -> bool {
-        *self == FUNCR::SCK1_
+    pub fn is_sck1(&self) -> bool {
+        *self == FUNCR::SCK1
     }
 }
 #[doc = "Possible values of the field `MODE`"]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum MODER {
     #[doc = "Inactive (no pull-down/pull-up resistor enabled)."]
-    INACTIVE_NO_PULL_DO,
+    INACTIVE,
     #[doc = "Pull-down resistor enabled."]
-    PULL_DOWN_RESISTOR_E,
+    PULL_DOWN,
     #[doc = "Pull-up resistor enabled."]
-    PULL_UP_RESISTOR_ENA,
+    PULL_UP,
     #[doc = "Repeater mode."]
-    REPEATER_MODE_,
+    REPEATER,
 }
 impl MODER {
     #[doc = r" Value of the field as raw bits"]
     #[inline]
     pub fn bits(&self) -> u8 {
         match *self {
-            MODER::INACTIVE_NO_PULL_DO => 0,
-            MODER::PULL_DOWN_RESISTOR_E => 1,
-            MODER::PULL_UP_RESISTOR_ENA => 2,
-            MODER::REPEATER_MODE_ => 3,
+            MODER::INACTIVE => 0,
+            MODER::PULL_DOWN => 1,
+            MODER::PULL_UP => 2,
+            MODER::REPEATER => 3,
         }
     }
     #[allow(missing_docs)]
@@ -120,41 +120,41 @@ impl MODER {
     #[inline]
     pub fn _from(value: u8) -> MODER {
         match value {
-            0 => MODER::INACTIVE_NO_PULL_DO,
-            1 => MODER::PULL_DOWN_RESISTOR_E,
-            2 => MODER::PULL_UP_RESISTOR_ENA,
-            3 => MODER::REPEATER_MODE_,
+            0 => MODER::INACTIVE,
+            1 => MODER::PULL_DOWN,
+            2 => MODER::PULL_UP,
+            3 => MODER::REPEATER,
             _ => unreachable!(),
         }
     }
-    #[doc = "Checks if the value of the field is `INACTIVE_NO_PULL_DO`"]
+    #[doc = "Checks if the value of the field is `INACTIVE`"]
     #[inline]
-    pub fn is_inactive_no_pull_do(&self) -> bool {
-        *self == MODER::INACTIVE_NO_PULL_DO
+    pub fn is_inactive(&self) -> bool {
+        *self == MODER::INACTIVE
     }
-    #[doc = "Checks if the value of the field is `PULL_DOWN_RESISTOR_E`"]
+    #[doc = "Checks if the value of the field is `PULL_DOWN`"]
     #[inline]
-    pub fn is_pull_down_resistor_e(&self) -> bool {
-        *self == MODER::PULL_DOWN_RESISTOR_E
+    pub fn is_pull_down(&self) -> bool {
+        *self == MODER::PULL_DOWN
     }
-    #[doc = "Checks if the value of the field is `PULL_UP_RESISTOR_ENA`"]
+    #[doc = "Checks if the value of the field is `PULL_UP`"]
     #[inline]
-    pub fn is_pull_up_resistor_ena(&self) -> bool {
-        *self == MODER::PULL_UP_RESISTOR_ENA
+    pub fn is_pull_up(&self) -> bool {
+        *self == MODER::PULL_UP
     }
-    #[doc = "Checks if the value of the field is `REPEATER_MODE_`"]
+    #[doc = "Checks if the value of the field is `REPEATER`"]
     #[inline]
-    pub fn is_repeater_mode_(&self) -> bool {
-        *self == MODER::REPEATER_MODE_
+    pub fn is_repeater(&self) -> bool {
+        *self == MODER::REPEATER
     }
 }
 #[doc = "Possible values of the field `HYS`"]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum HYSR {
     #[doc = "Disable."]
-    DISABLE_,
+    DISABLED,
     #[doc = "Enable."]
-    ENABLE_,
+    ENABLED,
 }
 impl HYSR {
     #[doc = r" Returns `true` if the bit is clear (0)"]
@@ -171,8 +171,8 @@ impl HYSR {
     #[inline]
     pub fn bit(&self) -> bool {
         match *self {
-            HYSR::DISABLE_ => false,
-            HYSR::ENABLE_ => true,
+            HYSR::DISABLED => false,
+            HYSR::ENABLED => true,
         }
     }
     #[allow(missing_docs)]
@@ -180,28 +180,28 @@ impl HYSR {
     #[inline]
     pub fn _from(value: bool) -> HYSR {
         match value {
-            false => HYSR::DISABLE_,
-            true => HYSR::ENABLE_,
+            false => HYSR::DISABLED,
+            true => HYSR::ENABLED,
         }
     }
-    #[doc = "Checks if the value of the field is `DISABLE_`"]
+    #[doc = "Checks if the value of the field is `DISABLED`"]
     #[inline]
-    pub fn is_disable_(&self) -> bool {
-        *self == HYSR::DISABLE_
+    pub fn is_disabled(&self) -> bool {
+        *self == HYSR::DISABLED
     }
-    #[doc = "Checks if the value of the field is `ENABLE_`"]
+    #[doc = "Checks if the value of the field is `ENABLED`"]
     #[inline]
-    pub fn is_enable_(&self) -> bool {
-        *self == HYSR::ENABLE_
+    pub fn is_enabled(&self) -> bool {
+        *self == HYSR::ENABLED
     }
 }
 #[doc = "Possible values of the field `INV`"]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum INVR {
     #[doc = "Input not inverted (HIGH on pin reads as 1, LOW on pin reads as 0)."]
-    INPUT_NOT_INVERTED_,
+    NOT_INVERTED,
     #[doc = "Input inverted (HIGH on pin reads as 0, LOW on pin reads as 1)."]
-    INPUT_INVERTED_HIGH,
+    INVERTED,
 }
 impl INVR {
     #[doc = r" Returns `true` if the bit is clear (0)"]
@@ -218,8 +218,8 @@ impl INVR {
     #[inline]
     pub fn bit(&self) -> bool {
         match *self {
-            INVR::INPUT_NOT_INVERTED_ => false,
-            INVR::INPUT_INVERTED_HIGH => true,
+            INVR::NOT_INVERTED => false,
+            INVR::INVERTED => true,
         }
     }
     #[allow(missing_docs)]
@@ -227,28 +227,28 @@ impl INVR {
     #[inline]
     pub fn _from(value: bool) -> INVR {
         match value {
-            false => INVR::INPUT_NOT_INVERTED_,
-            true => INVR::INPUT_INVERTED_HIGH,
+            false => INVR::NOT_INVERTED,
+            true => INVR::INVERTED,
         }
     }
-    #[doc = "Checks if the value of the field is `INPUT_NOT_INVERTED_`"]
+    #[doc = "Checks if the value of the field is `NOT_INVERTED`"]
     #[inline]
-    pub fn is_input_not_inverted_(&self) -> bool {
-        *self == INVR::INPUT_NOT_INVERTED_
+    pub fn is_not_inverted(&self) -> bool {
+        *self == INVR::NOT_INVERTED
     }
-    #[doc = "Checks if the value of the field is `INPUT_INVERTED_HIGH`"]
+    #[doc = "Checks if the value of the field is `INVERTED`"]
     #[inline]
-    pub fn is_input_inverted_high(&self) -> bool {
-        *self == INVR::INPUT_INVERTED_HIGH
+    pub fn is_inverted(&self) -> bool {
+        *self == INVR::INVERTED
     }
 }
 #[doc = "Possible values of the field `OD`"]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum ODR {
     #[doc = "Disable."]
-    DISABLE_,
+    DISABLED,
     #[doc = "Open-drain mode enabled.  This is not a true open-drain mode."]
-    OPEN_DRAIN_MODE_ENAB,
+    OPEN_DRAIN,
 }
 impl ODR {
     #[doc = r" Returns `true` if the bit is clear (0)"]
@@ -265,8 +265,8 @@ impl ODR {
     #[inline]
     pub fn bit(&self) -> bool {
         match *self {
-            ODR::DISABLE_ => false,
-            ODR::OPEN_DRAIN_MODE_ENAB => true,
+            ODR::DISABLED => false,
+            ODR::OPEN_DRAIN => true,
         }
     }
     #[allow(missing_docs)]
@@ -274,29 +274,29 @@ impl ODR {
     #[inline]
     pub fn _from(value: bool) -> ODR {
         match value {
-            false => ODR::DISABLE_,
-            true => ODR::OPEN_DRAIN_MODE_ENAB,
+            false => ODR::DISABLED,
+            true => ODR::OPEN_DRAIN,
         }
     }
-    #[doc = "Checks if the value of the field is `DISABLE_`"]
+    #[doc = "Checks if the value of the field is `DISABLED`"]
     #[inline]
-    pub fn is_disable_(&self) -> bool {
-        *self == ODR::DISABLE_
+    pub fn is_disabled(&self) -> bool {
+        *self == ODR::DISABLED
     }
-    #[doc = "Checks if the value of the field is `OPEN_DRAIN_MODE_ENAB`"]
+    #[doc = "Checks if the value of the field is `OPEN_DRAIN`"]
     #[inline]
-    pub fn is_open_drain_mode_enab(&self) -> bool {
-        *self == ODR::OPEN_DRAIN_MODE_ENAB
+    pub fn is_open_drain(&self) -> bool {
+        *self == ODR::OPEN_DRAIN
     }
 }
 #[doc = "Values that can be written to the field `FUNC`"]
 pub enum FUNCW {
     #[doc = "PIO1_20."]
-    PIO1_20_,
+    PIO1_20,
     #[doc = "DSR."]
-    DSR_,
+    DSR,
     #[doc = "SCK1."]
-    SCK1_,
+    SCK1,
 }
 impl FUNCW {
     #[allow(missing_docs)]
@@ -304,9 +304,9 @@ impl FUNCW {
     #[inline]
     pub fn _bits(&self) -> u8 {
         match *self {
-            FUNCW::PIO1_20_ => 0,
-            FUNCW::DSR_ => 1,
-            FUNCW::SCK1_ => 2,
+            FUNCW::PIO1_20 => 0,
+            FUNCW::DSR => 1,
+            FUNCW::SCK1 => 2,
         }
     }
 }
@@ -322,18 +322,18 @@ impl<'a> _FUNCW<'a> {
     }
     #[doc = "PIO1_20."]
     #[inline]
-    pub fn pio1_20_(self) -> &'a mut W {
-        self.variant(FUNCW::PIO1_20_)
+    pub fn pio1_20(self) -> &'a mut W {
+        self.variant(FUNCW::PIO1_20)
     }
     #[doc = "DSR."]
     #[inline]
-    pub fn dsr_(self) -> &'a mut W {
-        self.variant(FUNCW::DSR_)
+    pub fn dsr(self) -> &'a mut W {
+        self.variant(FUNCW::DSR)
     }
     #[doc = "SCK1."]
     #[inline]
-    pub fn sck1_(self) -> &'a mut W {
-        self.variant(FUNCW::SCK1_)
+    pub fn sck1(self) -> &'a mut W {
+        self.variant(FUNCW::SCK1)
     }
     #[doc = r" Writes raw bits to the field"]
     #[inline]
@@ -348,13 +348,13 @@ impl<'a> _FUNCW<'a> {
 #[doc = "Values that can be written to the field `MODE`"]
 pub enum MODEW {
     #[doc = "Inactive (no pull-down/pull-up resistor enabled)."]
-    INACTIVE_NO_PULL_DO,
+    INACTIVE,
     #[doc = "Pull-down resistor enabled."]
-    PULL_DOWN_RESISTOR_E,
+    PULL_DOWN,
     #[doc = "Pull-up resistor enabled."]
-    PULL_UP_RESISTOR_ENA,
+    PULL_UP,
     #[doc = "Repeater mode."]
-    REPEATER_MODE_,
+    REPEATER,
 }
 impl MODEW {
     #[allow(missing_docs)]
@@ -362,10 +362,10 @@ impl MODEW {
     #[inline]
     pub fn _bits(&self) -> u8 {
         match *self {
-            MODEW::INACTIVE_NO_PULL_DO => 0,
-            MODEW::PULL_DOWN_RESISTOR_E => 1,
-            MODEW::PULL_UP_RESISTOR_ENA => 2,
-            MODEW::REPEATER_MODE_ => 3,
+            MODEW::INACTIVE => 0,
+            MODEW::PULL_DOWN => 1,
+            MODEW::PULL_UP => 2,
+            MODEW::REPEATER => 3,
         }
     }
 }
@@ -383,23 +383,23 @@ impl<'a> _MODEW<'a> {
     }
     #[doc = "Inactive (no pull-down/pull-up resistor enabled)."]
     #[inline]
-    pub fn inactive_no_pull_do(self) -> &'a mut W {
-        self.variant(MODEW::INACTIVE_NO_PULL_DO)
+    pub fn inactive(self) -> &'a mut W {
+        self.variant(MODEW::INACTIVE)
     }
     #[doc = "Pull-down resistor enabled."]
     #[inline]
-    pub fn pull_down_resistor_e(self) -> &'a mut W {
-        self.variant(MODEW::PULL_DOWN_RESISTOR_E)
+    pub fn pull_down(self) -> &'a mut W {
+        self.variant(MODEW::PULL_DOWN)
     }
     #[doc = "Pull-up resistor enabled."]
     #[inline]
-    pub fn pull_up_resistor_ena(self) -> &'a mut W {
-        self.variant(MODEW::PULL_UP_RESISTOR_ENA)
+    pub fn pull_up(self) -> &'a mut W {
+        self.variant(MODEW::PULL_UP)
     }
     #[doc = "Repeater mode."]
     #[inline]
-    pub fn repeater_mode_(self) -> &'a mut W {
-        self.variant(MODEW::REPEATER_MODE_)
+    pub fn repeater(self) -> &'a mut W {
+        self.variant(MODEW::REPEATER)
     }
     #[doc = r" Writes raw bits to the field"]
     #[inline]
@@ -414,9 +414,9 @@ impl<'a> _MODEW<'a> {
 #[doc = "Values that can be written to the field `HYS`"]
 pub enum HYSW {
     #[doc = "Disable."]
-    DISABLE_,
+    DISABLED,
     #[doc = "Enable."]
-    ENABLE_,
+    ENABLED,
 }
 impl HYSW {
     #[allow(missing_docs)]
@@ -424,8 +424,8 @@ impl HYSW {
     #[inline]
     pub fn _bits(&self) -> bool {
         match *self {
-            HYSW::DISABLE_ => false,
-            HYSW::ENABLE_ => true,
+            HYSW::DISABLED => false,
+            HYSW::ENABLED => true,
         }
     }
 }
@@ -443,13 +443,13 @@ impl<'a> _HYSW<'a> {
     }
     #[doc = "Disable."]
     #[inline]
-    pub fn disable_(self) -> &'a mut W {
-        self.variant(HYSW::DISABLE_)
+    pub fn disabled(self) -> &'a mut W {
+        self.variant(HYSW::DISABLED)
     }
     #[doc = "Enable."]
     #[inline]
-    pub fn enable_(self) -> &'a mut W {
-        self.variant(HYSW::ENABLE_)
+    pub fn enabled(self) -> &'a mut W {
+        self.variant(HYSW::ENABLED)
     }
     #[doc = r" Sets the field bit"]
     pub fn set_bit(self) -> &'a mut W {
@@ -472,9 +472,9 @@ impl<'a> _HYSW<'a> {
 #[doc = "Values that can be written to the field `INV`"]
 pub enum INVW {
     #[doc = "Input not inverted (HIGH on pin reads as 1, LOW on pin reads as 0)."]
-    INPUT_NOT_INVERTED_,
+    NOT_INVERTED,
     #[doc = "Input inverted (HIGH on pin reads as 0, LOW on pin reads as 1)."]
-    INPUT_INVERTED_HIGH,
+    INVERTED,
 }
 impl INVW {
     #[allow(missing_docs)]
@@ -482,8 +482,8 @@ impl INVW {
     #[inline]
     pub fn _bits(&self) -> bool {
         match *self {
-            INVW::INPUT_NOT_INVERTED_ => false,
-            INVW::INPUT_INVERTED_HIGH => true,
+            INVW::NOT_INVERTED => false,
+            INVW::INVERTED => true,
         }
     }
 }
@@ -501,13 +501,13 @@ impl<'a> _INVW<'a> {
     }
     #[doc = "Input not inverted (HIGH on pin reads as 1, LOW on pin reads as 0)."]
     #[inline]
-    pub fn input_not_inverted_(self) -> &'a mut W {
-        self.variant(INVW::INPUT_NOT_INVERTED_)
+    pub fn not_inverted(self) -> &'a mut W {
+        self.variant(INVW::NOT_INVERTED)
     }
     #[doc = "Input inverted (HIGH on pin reads as 0, LOW on pin reads as 1)."]
     #[inline]
-    pub fn input_inverted_high(self) -> &'a mut W {
-        self.variant(INVW::INPUT_INVERTED_HIGH)
+    pub fn inverted(self) -> &'a mut W {
+        self.variant(INVW::INVERTED)
     }
     #[doc = r" Sets the field bit"]
     pub fn set_bit(self) -> &'a mut W {
@@ -530,9 +530,9 @@ impl<'a> _INVW<'a> {
 #[doc = "Values that can be written to the field `OD`"]
 pub enum ODW {
     #[doc = "Disable."]
-    DISABLE_,
+    DISABLED,
     #[doc = "Open-drain mode enabled.  This is not a true open-drain mode."]
-    OPEN_DRAIN_MODE_ENAB,
+    OPEN_DRAIN,
 }
 impl ODW {
     #[allow(missing_docs)]
@@ -540,8 +540,8 @@ impl ODW {
     #[inline]
     pub fn _bits(&self) -> bool {
         match *self {
-            ODW::DISABLE_ => false,
-            ODW::OPEN_DRAIN_MODE_ENAB => true,
+            ODW::DISABLED => false,
+            ODW::OPEN_DRAIN => true,
         }
     }
 }
@@ -559,13 +559,13 @@ impl<'a> _ODW<'a> {
     }
     #[doc = "Disable."]
     #[inline]
-    pub fn disable_(self) -> &'a mut W {
-        self.variant(ODW::DISABLE_)
+    pub fn disabled(self) -> &'a mut W {
+        self.variant(ODW::DISABLED)
     }
     #[doc = "Open-drain mode enabled. This is not a true open-drain mode."]
     #[inline]
-    pub fn open_drain_mode_enab(self) -> &'a mut W {
-        self.variant(ODW::OPEN_DRAIN_MODE_ENAB)
+    pub fn open_drain(self) -> &'a mut W {
+        self.variant(ODW::OPEN_DRAIN)
     }
     #[doc = r" Sets the field bit"]
     pub fn set_bit(self) -> &'a mut W {

--- a/lpc11uxx/src/iocon/pio1_21.rs
+++ b/lpc11uxx/src/iocon/pio1_21.rs
@@ -46,11 +46,11 @@ impl super::PIO1_21 {
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum FUNCR {
     #[doc = "PIO1_21."]
-    PIO1_21_,
+    PIO1_21,
     #[doc = "DCD."]
-    DCD_,
+    DCD,
     #[doc = "MISO1."]
-    MISO1_,
+    MISO1,
     #[doc = r" Reserved"]
     _Reserved(u8),
 }
@@ -59,9 +59,9 @@ impl FUNCR {
     #[inline]
     pub fn bits(&self) -> u8 {
         match *self {
-            FUNCR::PIO1_21_ => 0,
-            FUNCR::DCD_ => 1,
-            FUNCR::MISO1_ => 2,
+            FUNCR::PIO1_21 => 0,
+            FUNCR::DCD => 1,
+            FUNCR::MISO1 => 2,
             FUNCR::_Reserved(bits) => bits,
         }
     }
@@ -70,49 +70,49 @@ impl FUNCR {
     #[inline]
     pub fn _from(value: u8) -> FUNCR {
         match value {
-            0 => FUNCR::PIO1_21_,
-            1 => FUNCR::DCD_,
-            2 => FUNCR::MISO1_,
+            0 => FUNCR::PIO1_21,
+            1 => FUNCR::DCD,
+            2 => FUNCR::MISO1,
             i => FUNCR::_Reserved(i),
         }
     }
-    #[doc = "Checks if the value of the field is `PIO1_21_`"]
+    #[doc = "Checks if the value of the field is `PIO1_21`"]
     #[inline]
-    pub fn is_pio1_21_(&self) -> bool {
-        *self == FUNCR::PIO1_21_
+    pub fn is_pio1_21(&self) -> bool {
+        *self == FUNCR::PIO1_21
     }
-    #[doc = "Checks if the value of the field is `DCD_`"]
+    #[doc = "Checks if the value of the field is `DCD`"]
     #[inline]
-    pub fn is_dcd_(&self) -> bool {
-        *self == FUNCR::DCD_
+    pub fn is_dcd(&self) -> bool {
+        *self == FUNCR::DCD
     }
-    #[doc = "Checks if the value of the field is `MISO1_`"]
+    #[doc = "Checks if the value of the field is `MISO1`"]
     #[inline]
-    pub fn is_miso1_(&self) -> bool {
-        *self == FUNCR::MISO1_
+    pub fn is_miso1(&self) -> bool {
+        *self == FUNCR::MISO1
     }
 }
 #[doc = "Possible values of the field `MODE`"]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum MODER {
     #[doc = "Inactive (no pull-down/pull-up resistor enabled)."]
-    INACTIVE_NO_PULL_DO,
+    INACTIVE,
     #[doc = "Pull-down resistor enabled."]
-    PULL_DOWN_RESISTOR_E,
+    PULL_DOWN,
     #[doc = "Pull-up resistor enabled."]
-    PULL_UP_RESISTOR_ENA,
+    PULL_UP,
     #[doc = "Repeater mode."]
-    REPEATER_MODE_,
+    REPEATER,
 }
 impl MODER {
     #[doc = r" Value of the field as raw bits"]
     #[inline]
     pub fn bits(&self) -> u8 {
         match *self {
-            MODER::INACTIVE_NO_PULL_DO => 0,
-            MODER::PULL_DOWN_RESISTOR_E => 1,
-            MODER::PULL_UP_RESISTOR_ENA => 2,
-            MODER::REPEATER_MODE_ => 3,
+            MODER::INACTIVE => 0,
+            MODER::PULL_DOWN => 1,
+            MODER::PULL_UP => 2,
+            MODER::REPEATER => 3,
         }
     }
     #[allow(missing_docs)]
@@ -120,41 +120,41 @@ impl MODER {
     #[inline]
     pub fn _from(value: u8) -> MODER {
         match value {
-            0 => MODER::INACTIVE_NO_PULL_DO,
-            1 => MODER::PULL_DOWN_RESISTOR_E,
-            2 => MODER::PULL_UP_RESISTOR_ENA,
-            3 => MODER::REPEATER_MODE_,
+            0 => MODER::INACTIVE,
+            1 => MODER::PULL_DOWN,
+            2 => MODER::PULL_UP,
+            3 => MODER::REPEATER,
             _ => unreachable!(),
         }
     }
-    #[doc = "Checks if the value of the field is `INACTIVE_NO_PULL_DO`"]
+    #[doc = "Checks if the value of the field is `INACTIVE`"]
     #[inline]
-    pub fn is_inactive_no_pull_do(&self) -> bool {
-        *self == MODER::INACTIVE_NO_PULL_DO
+    pub fn is_inactive(&self) -> bool {
+        *self == MODER::INACTIVE
     }
-    #[doc = "Checks if the value of the field is `PULL_DOWN_RESISTOR_E`"]
+    #[doc = "Checks if the value of the field is `PULL_DOWN`"]
     #[inline]
-    pub fn is_pull_down_resistor_e(&self) -> bool {
-        *self == MODER::PULL_DOWN_RESISTOR_E
+    pub fn is_pull_down(&self) -> bool {
+        *self == MODER::PULL_DOWN
     }
-    #[doc = "Checks if the value of the field is `PULL_UP_RESISTOR_ENA`"]
+    #[doc = "Checks if the value of the field is `PULL_UP`"]
     #[inline]
-    pub fn is_pull_up_resistor_ena(&self) -> bool {
-        *self == MODER::PULL_UP_RESISTOR_ENA
+    pub fn is_pull_up(&self) -> bool {
+        *self == MODER::PULL_UP
     }
-    #[doc = "Checks if the value of the field is `REPEATER_MODE_`"]
+    #[doc = "Checks if the value of the field is `REPEATER`"]
     #[inline]
-    pub fn is_repeater_mode_(&self) -> bool {
-        *self == MODER::REPEATER_MODE_
+    pub fn is_repeater(&self) -> bool {
+        *self == MODER::REPEATER
     }
 }
 #[doc = "Possible values of the field `HYS`"]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum HYSR {
     #[doc = "Disable."]
-    DISABLE_,
+    DISABLED,
     #[doc = "Enable."]
-    ENABLE_,
+    ENABLED,
 }
 impl HYSR {
     #[doc = r" Returns `true` if the bit is clear (0)"]
@@ -171,8 +171,8 @@ impl HYSR {
     #[inline]
     pub fn bit(&self) -> bool {
         match *self {
-            HYSR::DISABLE_ => false,
-            HYSR::ENABLE_ => true,
+            HYSR::DISABLED => false,
+            HYSR::ENABLED => true,
         }
     }
     #[allow(missing_docs)]
@@ -180,28 +180,28 @@ impl HYSR {
     #[inline]
     pub fn _from(value: bool) -> HYSR {
         match value {
-            false => HYSR::DISABLE_,
-            true => HYSR::ENABLE_,
+            false => HYSR::DISABLED,
+            true => HYSR::ENABLED,
         }
     }
-    #[doc = "Checks if the value of the field is `DISABLE_`"]
+    #[doc = "Checks if the value of the field is `DISABLED`"]
     #[inline]
-    pub fn is_disable_(&self) -> bool {
-        *self == HYSR::DISABLE_
+    pub fn is_disabled(&self) -> bool {
+        *self == HYSR::DISABLED
     }
-    #[doc = "Checks if the value of the field is `ENABLE_`"]
+    #[doc = "Checks if the value of the field is `ENABLED`"]
     #[inline]
-    pub fn is_enable_(&self) -> bool {
-        *self == HYSR::ENABLE_
+    pub fn is_enabled(&self) -> bool {
+        *self == HYSR::ENABLED
     }
 }
 #[doc = "Possible values of the field `INV`"]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum INVR {
     #[doc = "Input not inverted (HIGH on pin reads as 1, LOW on pin reads as 0)."]
-    INPUT_NOT_INVERTED_,
+    NOT_INVERTED,
     #[doc = "Input inverted (HIGH on pin reads as 0, LOW on pin reads as 1)."]
-    INPUT_INVERTED_HIGH,
+    INVERTED,
 }
 impl INVR {
     #[doc = r" Returns `true` if the bit is clear (0)"]
@@ -218,8 +218,8 @@ impl INVR {
     #[inline]
     pub fn bit(&self) -> bool {
         match *self {
-            INVR::INPUT_NOT_INVERTED_ => false,
-            INVR::INPUT_INVERTED_HIGH => true,
+            INVR::NOT_INVERTED => false,
+            INVR::INVERTED => true,
         }
     }
     #[allow(missing_docs)]
@@ -227,28 +227,28 @@ impl INVR {
     #[inline]
     pub fn _from(value: bool) -> INVR {
         match value {
-            false => INVR::INPUT_NOT_INVERTED_,
-            true => INVR::INPUT_INVERTED_HIGH,
+            false => INVR::NOT_INVERTED,
+            true => INVR::INVERTED,
         }
     }
-    #[doc = "Checks if the value of the field is `INPUT_NOT_INVERTED_`"]
+    #[doc = "Checks if the value of the field is `NOT_INVERTED`"]
     #[inline]
-    pub fn is_input_not_inverted_(&self) -> bool {
-        *self == INVR::INPUT_NOT_INVERTED_
+    pub fn is_not_inverted(&self) -> bool {
+        *self == INVR::NOT_INVERTED
     }
-    #[doc = "Checks if the value of the field is `INPUT_INVERTED_HIGH`"]
+    #[doc = "Checks if the value of the field is `INVERTED`"]
     #[inline]
-    pub fn is_input_inverted_high(&self) -> bool {
-        *self == INVR::INPUT_INVERTED_HIGH
+    pub fn is_inverted(&self) -> bool {
+        *self == INVR::INVERTED
     }
 }
 #[doc = "Possible values of the field `OD`"]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum ODR {
     #[doc = "Disable."]
-    DISABLE_,
+    DISABLED,
     #[doc = "Open-drain mode enabled.  This is not a true open-drain mode."]
-    OPEN_DRAIN_MODE_ENAB,
+    OPEN_DRAIN,
 }
 impl ODR {
     #[doc = r" Returns `true` if the bit is clear (0)"]
@@ -265,8 +265,8 @@ impl ODR {
     #[inline]
     pub fn bit(&self) -> bool {
         match *self {
-            ODR::DISABLE_ => false,
-            ODR::OPEN_DRAIN_MODE_ENAB => true,
+            ODR::DISABLED => false,
+            ODR::OPEN_DRAIN => true,
         }
     }
     #[allow(missing_docs)]
@@ -274,29 +274,29 @@ impl ODR {
     #[inline]
     pub fn _from(value: bool) -> ODR {
         match value {
-            false => ODR::DISABLE_,
-            true => ODR::OPEN_DRAIN_MODE_ENAB,
+            false => ODR::DISABLED,
+            true => ODR::OPEN_DRAIN,
         }
     }
-    #[doc = "Checks if the value of the field is `DISABLE_`"]
+    #[doc = "Checks if the value of the field is `DISABLED`"]
     #[inline]
-    pub fn is_disable_(&self) -> bool {
-        *self == ODR::DISABLE_
+    pub fn is_disabled(&self) -> bool {
+        *self == ODR::DISABLED
     }
-    #[doc = "Checks if the value of the field is `OPEN_DRAIN_MODE_ENAB`"]
+    #[doc = "Checks if the value of the field is `OPEN_DRAIN`"]
     #[inline]
-    pub fn is_open_drain_mode_enab(&self) -> bool {
-        *self == ODR::OPEN_DRAIN_MODE_ENAB
+    pub fn is_open_drain(&self) -> bool {
+        *self == ODR::OPEN_DRAIN
     }
 }
 #[doc = "Values that can be written to the field `FUNC`"]
 pub enum FUNCW {
     #[doc = "PIO1_21."]
-    PIO1_21_,
+    PIO1_21,
     #[doc = "DCD."]
-    DCD_,
+    DCD,
     #[doc = "MISO1."]
-    MISO1_,
+    MISO1,
 }
 impl FUNCW {
     #[allow(missing_docs)]
@@ -304,9 +304,9 @@ impl FUNCW {
     #[inline]
     pub fn _bits(&self) -> u8 {
         match *self {
-            FUNCW::PIO1_21_ => 0,
-            FUNCW::DCD_ => 1,
-            FUNCW::MISO1_ => 2,
+            FUNCW::PIO1_21 => 0,
+            FUNCW::DCD => 1,
+            FUNCW::MISO1 => 2,
         }
     }
 }
@@ -322,18 +322,18 @@ impl<'a> _FUNCW<'a> {
     }
     #[doc = "PIO1_21."]
     #[inline]
-    pub fn pio1_21_(self) -> &'a mut W {
-        self.variant(FUNCW::PIO1_21_)
+    pub fn pio1_21(self) -> &'a mut W {
+        self.variant(FUNCW::PIO1_21)
     }
     #[doc = "DCD."]
     #[inline]
-    pub fn dcd_(self) -> &'a mut W {
-        self.variant(FUNCW::DCD_)
+    pub fn dcd(self) -> &'a mut W {
+        self.variant(FUNCW::DCD)
     }
     #[doc = "MISO1."]
     #[inline]
-    pub fn miso1_(self) -> &'a mut W {
-        self.variant(FUNCW::MISO1_)
+    pub fn miso1(self) -> &'a mut W {
+        self.variant(FUNCW::MISO1)
     }
     #[doc = r" Writes raw bits to the field"]
     #[inline]
@@ -348,13 +348,13 @@ impl<'a> _FUNCW<'a> {
 #[doc = "Values that can be written to the field `MODE`"]
 pub enum MODEW {
     #[doc = "Inactive (no pull-down/pull-up resistor enabled)."]
-    INACTIVE_NO_PULL_DO,
+    INACTIVE,
     #[doc = "Pull-down resistor enabled."]
-    PULL_DOWN_RESISTOR_E,
+    PULL_DOWN,
     #[doc = "Pull-up resistor enabled."]
-    PULL_UP_RESISTOR_ENA,
+    PULL_UP,
     #[doc = "Repeater mode."]
-    REPEATER_MODE_,
+    REPEATER,
 }
 impl MODEW {
     #[allow(missing_docs)]
@@ -362,10 +362,10 @@ impl MODEW {
     #[inline]
     pub fn _bits(&self) -> u8 {
         match *self {
-            MODEW::INACTIVE_NO_PULL_DO => 0,
-            MODEW::PULL_DOWN_RESISTOR_E => 1,
-            MODEW::PULL_UP_RESISTOR_ENA => 2,
-            MODEW::REPEATER_MODE_ => 3,
+            MODEW::INACTIVE => 0,
+            MODEW::PULL_DOWN => 1,
+            MODEW::PULL_UP => 2,
+            MODEW::REPEATER => 3,
         }
     }
 }
@@ -383,23 +383,23 @@ impl<'a> _MODEW<'a> {
     }
     #[doc = "Inactive (no pull-down/pull-up resistor enabled)."]
     #[inline]
-    pub fn inactive_no_pull_do(self) -> &'a mut W {
-        self.variant(MODEW::INACTIVE_NO_PULL_DO)
+    pub fn inactive(self) -> &'a mut W {
+        self.variant(MODEW::INACTIVE)
     }
     #[doc = "Pull-down resistor enabled."]
     #[inline]
-    pub fn pull_down_resistor_e(self) -> &'a mut W {
-        self.variant(MODEW::PULL_DOWN_RESISTOR_E)
+    pub fn pull_down(self) -> &'a mut W {
+        self.variant(MODEW::PULL_DOWN)
     }
     #[doc = "Pull-up resistor enabled."]
     #[inline]
-    pub fn pull_up_resistor_ena(self) -> &'a mut W {
-        self.variant(MODEW::PULL_UP_RESISTOR_ENA)
+    pub fn pull_up(self) -> &'a mut W {
+        self.variant(MODEW::PULL_UP)
     }
     #[doc = "Repeater mode."]
     #[inline]
-    pub fn repeater_mode_(self) -> &'a mut W {
-        self.variant(MODEW::REPEATER_MODE_)
+    pub fn repeater(self) -> &'a mut W {
+        self.variant(MODEW::REPEATER)
     }
     #[doc = r" Writes raw bits to the field"]
     #[inline]
@@ -414,9 +414,9 @@ impl<'a> _MODEW<'a> {
 #[doc = "Values that can be written to the field `HYS`"]
 pub enum HYSW {
     #[doc = "Disable."]
-    DISABLE_,
+    DISABLED,
     #[doc = "Enable."]
-    ENABLE_,
+    ENABLED,
 }
 impl HYSW {
     #[allow(missing_docs)]
@@ -424,8 +424,8 @@ impl HYSW {
     #[inline]
     pub fn _bits(&self) -> bool {
         match *self {
-            HYSW::DISABLE_ => false,
-            HYSW::ENABLE_ => true,
+            HYSW::DISABLED => false,
+            HYSW::ENABLED => true,
         }
     }
 }
@@ -443,13 +443,13 @@ impl<'a> _HYSW<'a> {
     }
     #[doc = "Disable."]
     #[inline]
-    pub fn disable_(self) -> &'a mut W {
-        self.variant(HYSW::DISABLE_)
+    pub fn disabled(self) -> &'a mut W {
+        self.variant(HYSW::DISABLED)
     }
     #[doc = "Enable."]
     #[inline]
-    pub fn enable_(self) -> &'a mut W {
-        self.variant(HYSW::ENABLE_)
+    pub fn enabled(self) -> &'a mut W {
+        self.variant(HYSW::ENABLED)
     }
     #[doc = r" Sets the field bit"]
     pub fn set_bit(self) -> &'a mut W {
@@ -472,9 +472,9 @@ impl<'a> _HYSW<'a> {
 #[doc = "Values that can be written to the field `INV`"]
 pub enum INVW {
     #[doc = "Input not inverted (HIGH on pin reads as 1, LOW on pin reads as 0)."]
-    INPUT_NOT_INVERTED_,
+    NOT_INVERTED,
     #[doc = "Input inverted (HIGH on pin reads as 0, LOW on pin reads as 1)."]
-    INPUT_INVERTED_HIGH,
+    INVERTED,
 }
 impl INVW {
     #[allow(missing_docs)]
@@ -482,8 +482,8 @@ impl INVW {
     #[inline]
     pub fn _bits(&self) -> bool {
         match *self {
-            INVW::INPUT_NOT_INVERTED_ => false,
-            INVW::INPUT_INVERTED_HIGH => true,
+            INVW::NOT_INVERTED => false,
+            INVW::INVERTED => true,
         }
     }
 }
@@ -501,13 +501,13 @@ impl<'a> _INVW<'a> {
     }
     #[doc = "Input not inverted (HIGH on pin reads as 1, LOW on pin reads as 0)."]
     #[inline]
-    pub fn input_not_inverted_(self) -> &'a mut W {
-        self.variant(INVW::INPUT_NOT_INVERTED_)
+    pub fn not_inverted(self) -> &'a mut W {
+        self.variant(INVW::NOT_INVERTED)
     }
     #[doc = "Input inverted (HIGH on pin reads as 0, LOW on pin reads as 1)."]
     #[inline]
-    pub fn input_inverted_high(self) -> &'a mut W {
-        self.variant(INVW::INPUT_INVERTED_HIGH)
+    pub fn inverted(self) -> &'a mut W {
+        self.variant(INVW::INVERTED)
     }
     #[doc = r" Sets the field bit"]
     pub fn set_bit(self) -> &'a mut W {
@@ -530,9 +530,9 @@ impl<'a> _INVW<'a> {
 #[doc = "Values that can be written to the field `OD`"]
 pub enum ODW {
     #[doc = "Disable."]
-    DISABLE_,
+    DISABLED,
     #[doc = "Open-drain mode enabled.  This is not a true open-drain mode."]
-    OPEN_DRAIN_MODE_ENAB,
+    OPEN_DRAIN,
 }
 impl ODW {
     #[allow(missing_docs)]
@@ -540,8 +540,8 @@ impl ODW {
     #[inline]
     pub fn _bits(&self) -> bool {
         match *self {
-            ODW::DISABLE_ => false,
-            ODW::OPEN_DRAIN_MODE_ENAB => true,
+            ODW::DISABLED => false,
+            ODW::OPEN_DRAIN => true,
         }
     }
 }
@@ -559,13 +559,13 @@ impl<'a> _ODW<'a> {
     }
     #[doc = "Disable."]
     #[inline]
-    pub fn disable_(self) -> &'a mut W {
-        self.variant(ODW::DISABLE_)
+    pub fn disabled(self) -> &'a mut W {
+        self.variant(ODW::DISABLED)
     }
     #[doc = "Open-drain mode enabled. This is not a true open-drain mode."]
     #[inline]
-    pub fn open_drain_mode_enab(self) -> &'a mut W {
-        self.variant(ODW::OPEN_DRAIN_MODE_ENAB)
+    pub fn open_drain(self) -> &'a mut W {
+        self.variant(ODW::OPEN_DRAIN)
     }
     #[doc = r" Sets the field bit"]
     pub fn set_bit(self) -> &'a mut W {

--- a/lpc11uxx/src/iocon/pio1_22.rs
+++ b/lpc11uxx/src/iocon/pio1_22.rs
@@ -46,11 +46,11 @@ impl super::PIO1_22 {
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum FUNCR {
     #[doc = "PIO1_22."]
-    PIO1_22_,
+    PIO1_22,
     #[doc = "RI."]
-    RI_,
+    RI,
     #[doc = "MOSI1."]
-    MOSI1_,
+    MOSI1,
     #[doc = r" Reserved"]
     _Reserved(u8),
 }
@@ -59,9 +59,9 @@ impl FUNCR {
     #[inline]
     pub fn bits(&self) -> u8 {
         match *self {
-            FUNCR::PIO1_22_ => 0,
-            FUNCR::RI_ => 1,
-            FUNCR::MOSI1_ => 2,
+            FUNCR::PIO1_22 => 0,
+            FUNCR::RI => 1,
+            FUNCR::MOSI1 => 2,
             FUNCR::_Reserved(bits) => bits,
         }
     }
@@ -70,49 +70,49 @@ impl FUNCR {
     #[inline]
     pub fn _from(value: u8) -> FUNCR {
         match value {
-            0 => FUNCR::PIO1_22_,
-            1 => FUNCR::RI_,
-            2 => FUNCR::MOSI1_,
+            0 => FUNCR::PIO1_22,
+            1 => FUNCR::RI,
+            2 => FUNCR::MOSI1,
             i => FUNCR::_Reserved(i),
         }
     }
-    #[doc = "Checks if the value of the field is `PIO1_22_`"]
+    #[doc = "Checks if the value of the field is `PIO1_22`"]
     #[inline]
-    pub fn is_pio1_22_(&self) -> bool {
-        *self == FUNCR::PIO1_22_
+    pub fn is_pio1_22(&self) -> bool {
+        *self == FUNCR::PIO1_22
     }
-    #[doc = "Checks if the value of the field is `RI_`"]
+    #[doc = "Checks if the value of the field is `RI`"]
     #[inline]
-    pub fn is_ri_(&self) -> bool {
-        *self == FUNCR::RI_
+    pub fn is_ri(&self) -> bool {
+        *self == FUNCR::RI
     }
-    #[doc = "Checks if the value of the field is `MOSI1_`"]
+    #[doc = "Checks if the value of the field is `MOSI1`"]
     #[inline]
-    pub fn is_mosi1_(&self) -> bool {
-        *self == FUNCR::MOSI1_
+    pub fn is_mosi1(&self) -> bool {
+        *self == FUNCR::MOSI1
     }
 }
 #[doc = "Possible values of the field `MODE`"]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum MODER {
     #[doc = "Inactive (no pull-down/pull-up resistor enabled)."]
-    INACTIVE_NO_PULL_DO,
+    INACTIVE,
     #[doc = "Pull-down resistor enabled."]
-    PULL_DOWN_RESISTOR_E,
+    PULL_DOWN,
     #[doc = "Pull-up resistor enabled."]
-    PULL_UP_RESISTOR_ENA,
+    PULL_UP,
     #[doc = "Repeater mode."]
-    REPEATER_MODE_,
+    REPEATER,
 }
 impl MODER {
     #[doc = r" Value of the field as raw bits"]
     #[inline]
     pub fn bits(&self) -> u8 {
         match *self {
-            MODER::INACTIVE_NO_PULL_DO => 0,
-            MODER::PULL_DOWN_RESISTOR_E => 1,
-            MODER::PULL_UP_RESISTOR_ENA => 2,
-            MODER::REPEATER_MODE_ => 3,
+            MODER::INACTIVE => 0,
+            MODER::PULL_DOWN => 1,
+            MODER::PULL_UP => 2,
+            MODER::REPEATER => 3,
         }
     }
     #[allow(missing_docs)]
@@ -120,41 +120,41 @@ impl MODER {
     #[inline]
     pub fn _from(value: u8) -> MODER {
         match value {
-            0 => MODER::INACTIVE_NO_PULL_DO,
-            1 => MODER::PULL_DOWN_RESISTOR_E,
-            2 => MODER::PULL_UP_RESISTOR_ENA,
-            3 => MODER::REPEATER_MODE_,
+            0 => MODER::INACTIVE,
+            1 => MODER::PULL_DOWN,
+            2 => MODER::PULL_UP,
+            3 => MODER::REPEATER,
             _ => unreachable!(),
         }
     }
-    #[doc = "Checks if the value of the field is `INACTIVE_NO_PULL_DO`"]
+    #[doc = "Checks if the value of the field is `INACTIVE`"]
     #[inline]
-    pub fn is_inactive_no_pull_do(&self) -> bool {
-        *self == MODER::INACTIVE_NO_PULL_DO
+    pub fn is_inactive(&self) -> bool {
+        *self == MODER::INACTIVE
     }
-    #[doc = "Checks if the value of the field is `PULL_DOWN_RESISTOR_E`"]
+    #[doc = "Checks if the value of the field is `PULL_DOWN`"]
     #[inline]
-    pub fn is_pull_down_resistor_e(&self) -> bool {
-        *self == MODER::PULL_DOWN_RESISTOR_E
+    pub fn is_pull_down(&self) -> bool {
+        *self == MODER::PULL_DOWN
     }
-    #[doc = "Checks if the value of the field is `PULL_UP_RESISTOR_ENA`"]
+    #[doc = "Checks if the value of the field is `PULL_UP`"]
     #[inline]
-    pub fn is_pull_up_resistor_ena(&self) -> bool {
-        *self == MODER::PULL_UP_RESISTOR_ENA
+    pub fn is_pull_up(&self) -> bool {
+        *self == MODER::PULL_UP
     }
-    #[doc = "Checks if the value of the field is `REPEATER_MODE_`"]
+    #[doc = "Checks if the value of the field is `REPEATER`"]
     #[inline]
-    pub fn is_repeater_mode_(&self) -> bool {
-        *self == MODER::REPEATER_MODE_
+    pub fn is_repeater(&self) -> bool {
+        *self == MODER::REPEATER
     }
 }
 #[doc = "Possible values of the field `HYS`"]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum HYSR {
     #[doc = "Disable."]
-    DISABLE_,
+    DISABLED,
     #[doc = "Enable."]
-    ENABLE_,
+    ENABLED,
 }
 impl HYSR {
     #[doc = r" Returns `true` if the bit is clear (0)"]
@@ -171,8 +171,8 @@ impl HYSR {
     #[inline]
     pub fn bit(&self) -> bool {
         match *self {
-            HYSR::DISABLE_ => false,
-            HYSR::ENABLE_ => true,
+            HYSR::DISABLED => false,
+            HYSR::ENABLED => true,
         }
     }
     #[allow(missing_docs)]
@@ -180,28 +180,28 @@ impl HYSR {
     #[inline]
     pub fn _from(value: bool) -> HYSR {
         match value {
-            false => HYSR::DISABLE_,
-            true => HYSR::ENABLE_,
+            false => HYSR::DISABLED,
+            true => HYSR::ENABLED,
         }
     }
-    #[doc = "Checks if the value of the field is `DISABLE_`"]
+    #[doc = "Checks if the value of the field is `DISABLED`"]
     #[inline]
-    pub fn is_disable_(&self) -> bool {
-        *self == HYSR::DISABLE_
+    pub fn is_disabled(&self) -> bool {
+        *self == HYSR::DISABLED
     }
-    #[doc = "Checks if the value of the field is `ENABLE_`"]
+    #[doc = "Checks if the value of the field is `ENABLED`"]
     #[inline]
-    pub fn is_enable_(&self) -> bool {
-        *self == HYSR::ENABLE_
+    pub fn is_enabled(&self) -> bool {
+        *self == HYSR::ENABLED
     }
 }
 #[doc = "Possible values of the field `INV`"]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum INVR {
     #[doc = "Input not inverted (HIGH on pin reads as 1, LOW on pin reads as 0)."]
-    INPUT_NOT_INVERTED_,
+    NOT_INVERTED,
     #[doc = "Input inverted (HIGH on pin reads as 0, LOW on pin reads as 1)."]
-    INPUT_INVERTED_HIGH,
+    INVERTED,
 }
 impl INVR {
     #[doc = r" Returns `true` if the bit is clear (0)"]
@@ -218,8 +218,8 @@ impl INVR {
     #[inline]
     pub fn bit(&self) -> bool {
         match *self {
-            INVR::INPUT_NOT_INVERTED_ => false,
-            INVR::INPUT_INVERTED_HIGH => true,
+            INVR::NOT_INVERTED => false,
+            INVR::INVERTED => true,
         }
     }
     #[allow(missing_docs)]
@@ -227,28 +227,28 @@ impl INVR {
     #[inline]
     pub fn _from(value: bool) -> INVR {
         match value {
-            false => INVR::INPUT_NOT_INVERTED_,
-            true => INVR::INPUT_INVERTED_HIGH,
+            false => INVR::NOT_INVERTED,
+            true => INVR::INVERTED,
         }
     }
-    #[doc = "Checks if the value of the field is `INPUT_NOT_INVERTED_`"]
+    #[doc = "Checks if the value of the field is `NOT_INVERTED`"]
     #[inline]
-    pub fn is_input_not_inverted_(&self) -> bool {
-        *self == INVR::INPUT_NOT_INVERTED_
+    pub fn is_not_inverted(&self) -> bool {
+        *self == INVR::NOT_INVERTED
     }
-    #[doc = "Checks if the value of the field is `INPUT_INVERTED_HIGH`"]
+    #[doc = "Checks if the value of the field is `INVERTED`"]
     #[inline]
-    pub fn is_input_inverted_high(&self) -> bool {
-        *self == INVR::INPUT_INVERTED_HIGH
+    pub fn is_inverted(&self) -> bool {
+        *self == INVR::INVERTED
     }
 }
 #[doc = "Possible values of the field `OD`"]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum ODR {
     #[doc = "Disable."]
-    DISABLE_,
+    DISABLED,
     #[doc = "Open-drain mode enabled.  This is not a true open-drain mode."]
-    OPEN_DRAIN_MODE_ENAB,
+    OPEN_DRAIN,
 }
 impl ODR {
     #[doc = r" Returns `true` if the bit is clear (0)"]
@@ -265,8 +265,8 @@ impl ODR {
     #[inline]
     pub fn bit(&self) -> bool {
         match *self {
-            ODR::DISABLE_ => false,
-            ODR::OPEN_DRAIN_MODE_ENAB => true,
+            ODR::DISABLED => false,
+            ODR::OPEN_DRAIN => true,
         }
     }
     #[allow(missing_docs)]
@@ -274,29 +274,29 @@ impl ODR {
     #[inline]
     pub fn _from(value: bool) -> ODR {
         match value {
-            false => ODR::DISABLE_,
-            true => ODR::OPEN_DRAIN_MODE_ENAB,
+            false => ODR::DISABLED,
+            true => ODR::OPEN_DRAIN,
         }
     }
-    #[doc = "Checks if the value of the field is `DISABLE_`"]
+    #[doc = "Checks if the value of the field is `DISABLED`"]
     #[inline]
-    pub fn is_disable_(&self) -> bool {
-        *self == ODR::DISABLE_
+    pub fn is_disabled(&self) -> bool {
+        *self == ODR::DISABLED
     }
-    #[doc = "Checks if the value of the field is `OPEN_DRAIN_MODE_ENAB`"]
+    #[doc = "Checks if the value of the field is `OPEN_DRAIN`"]
     #[inline]
-    pub fn is_open_drain_mode_enab(&self) -> bool {
-        *self == ODR::OPEN_DRAIN_MODE_ENAB
+    pub fn is_open_drain(&self) -> bool {
+        *self == ODR::OPEN_DRAIN
     }
 }
 #[doc = "Values that can be written to the field `FUNC`"]
 pub enum FUNCW {
     #[doc = "PIO1_22."]
-    PIO1_22_,
+    PIO1_22,
     #[doc = "RI."]
-    RI_,
+    RI,
     #[doc = "MOSI1."]
-    MOSI1_,
+    MOSI1,
 }
 impl FUNCW {
     #[allow(missing_docs)]
@@ -304,9 +304,9 @@ impl FUNCW {
     #[inline]
     pub fn _bits(&self) -> u8 {
         match *self {
-            FUNCW::PIO1_22_ => 0,
-            FUNCW::RI_ => 1,
-            FUNCW::MOSI1_ => 2,
+            FUNCW::PIO1_22 => 0,
+            FUNCW::RI => 1,
+            FUNCW::MOSI1 => 2,
         }
     }
 }
@@ -322,18 +322,18 @@ impl<'a> _FUNCW<'a> {
     }
     #[doc = "PIO1_22."]
     #[inline]
-    pub fn pio1_22_(self) -> &'a mut W {
-        self.variant(FUNCW::PIO1_22_)
+    pub fn pio1_22(self) -> &'a mut W {
+        self.variant(FUNCW::PIO1_22)
     }
     #[doc = "RI."]
     #[inline]
-    pub fn ri_(self) -> &'a mut W {
-        self.variant(FUNCW::RI_)
+    pub fn ri(self) -> &'a mut W {
+        self.variant(FUNCW::RI)
     }
     #[doc = "MOSI1."]
     #[inline]
-    pub fn mosi1_(self) -> &'a mut W {
-        self.variant(FUNCW::MOSI1_)
+    pub fn mosi1(self) -> &'a mut W {
+        self.variant(FUNCW::MOSI1)
     }
     #[doc = r" Writes raw bits to the field"]
     #[inline]
@@ -348,13 +348,13 @@ impl<'a> _FUNCW<'a> {
 #[doc = "Values that can be written to the field `MODE`"]
 pub enum MODEW {
     #[doc = "Inactive (no pull-down/pull-up resistor enabled)."]
-    INACTIVE_NO_PULL_DO,
+    INACTIVE,
     #[doc = "Pull-down resistor enabled."]
-    PULL_DOWN_RESISTOR_E,
+    PULL_DOWN,
     #[doc = "Pull-up resistor enabled."]
-    PULL_UP_RESISTOR_ENA,
+    PULL_UP,
     #[doc = "Repeater mode."]
-    REPEATER_MODE_,
+    REPEATER,
 }
 impl MODEW {
     #[allow(missing_docs)]
@@ -362,10 +362,10 @@ impl MODEW {
     #[inline]
     pub fn _bits(&self) -> u8 {
         match *self {
-            MODEW::INACTIVE_NO_PULL_DO => 0,
-            MODEW::PULL_DOWN_RESISTOR_E => 1,
-            MODEW::PULL_UP_RESISTOR_ENA => 2,
-            MODEW::REPEATER_MODE_ => 3,
+            MODEW::INACTIVE => 0,
+            MODEW::PULL_DOWN => 1,
+            MODEW::PULL_UP => 2,
+            MODEW::REPEATER => 3,
         }
     }
 }
@@ -383,23 +383,23 @@ impl<'a> _MODEW<'a> {
     }
     #[doc = "Inactive (no pull-down/pull-up resistor enabled)."]
     #[inline]
-    pub fn inactive_no_pull_do(self) -> &'a mut W {
-        self.variant(MODEW::INACTIVE_NO_PULL_DO)
+    pub fn inactive(self) -> &'a mut W {
+        self.variant(MODEW::INACTIVE)
     }
     #[doc = "Pull-down resistor enabled."]
     #[inline]
-    pub fn pull_down_resistor_e(self) -> &'a mut W {
-        self.variant(MODEW::PULL_DOWN_RESISTOR_E)
+    pub fn pull_down(self) -> &'a mut W {
+        self.variant(MODEW::PULL_DOWN)
     }
     #[doc = "Pull-up resistor enabled."]
     #[inline]
-    pub fn pull_up_resistor_ena(self) -> &'a mut W {
-        self.variant(MODEW::PULL_UP_RESISTOR_ENA)
+    pub fn pull_up(self) -> &'a mut W {
+        self.variant(MODEW::PULL_UP)
     }
     #[doc = "Repeater mode."]
     #[inline]
-    pub fn repeater_mode_(self) -> &'a mut W {
-        self.variant(MODEW::REPEATER_MODE_)
+    pub fn repeater(self) -> &'a mut W {
+        self.variant(MODEW::REPEATER)
     }
     #[doc = r" Writes raw bits to the field"]
     #[inline]
@@ -414,9 +414,9 @@ impl<'a> _MODEW<'a> {
 #[doc = "Values that can be written to the field `HYS`"]
 pub enum HYSW {
     #[doc = "Disable."]
-    DISABLE_,
+    DISABLED,
     #[doc = "Enable."]
-    ENABLE_,
+    ENABLED,
 }
 impl HYSW {
     #[allow(missing_docs)]
@@ -424,8 +424,8 @@ impl HYSW {
     #[inline]
     pub fn _bits(&self) -> bool {
         match *self {
-            HYSW::DISABLE_ => false,
-            HYSW::ENABLE_ => true,
+            HYSW::DISABLED => false,
+            HYSW::ENABLED => true,
         }
     }
 }
@@ -443,13 +443,13 @@ impl<'a> _HYSW<'a> {
     }
     #[doc = "Disable."]
     #[inline]
-    pub fn disable_(self) -> &'a mut W {
-        self.variant(HYSW::DISABLE_)
+    pub fn disabled(self) -> &'a mut W {
+        self.variant(HYSW::DISABLED)
     }
     #[doc = "Enable."]
     #[inline]
-    pub fn enable_(self) -> &'a mut W {
-        self.variant(HYSW::ENABLE_)
+    pub fn enabled(self) -> &'a mut W {
+        self.variant(HYSW::ENABLED)
     }
     #[doc = r" Sets the field bit"]
     pub fn set_bit(self) -> &'a mut W {
@@ -472,9 +472,9 @@ impl<'a> _HYSW<'a> {
 #[doc = "Values that can be written to the field `INV`"]
 pub enum INVW {
     #[doc = "Input not inverted (HIGH on pin reads as 1, LOW on pin reads as 0)."]
-    INPUT_NOT_INVERTED_,
+    NOT_INVERTED,
     #[doc = "Input inverted (HIGH on pin reads as 0, LOW on pin reads as 1)."]
-    INPUT_INVERTED_HIGH,
+    INVERTED,
 }
 impl INVW {
     #[allow(missing_docs)]
@@ -482,8 +482,8 @@ impl INVW {
     #[inline]
     pub fn _bits(&self) -> bool {
         match *self {
-            INVW::INPUT_NOT_INVERTED_ => false,
-            INVW::INPUT_INVERTED_HIGH => true,
+            INVW::NOT_INVERTED => false,
+            INVW::INVERTED => true,
         }
     }
 }
@@ -501,13 +501,13 @@ impl<'a> _INVW<'a> {
     }
     #[doc = "Input not inverted (HIGH on pin reads as 1, LOW on pin reads as 0)."]
     #[inline]
-    pub fn input_not_inverted_(self) -> &'a mut W {
-        self.variant(INVW::INPUT_NOT_INVERTED_)
+    pub fn not_inverted(self) -> &'a mut W {
+        self.variant(INVW::NOT_INVERTED)
     }
     #[doc = "Input inverted (HIGH on pin reads as 0, LOW on pin reads as 1)."]
     #[inline]
-    pub fn input_inverted_high(self) -> &'a mut W {
-        self.variant(INVW::INPUT_INVERTED_HIGH)
+    pub fn inverted(self) -> &'a mut W {
+        self.variant(INVW::INVERTED)
     }
     #[doc = r" Sets the field bit"]
     pub fn set_bit(self) -> &'a mut W {
@@ -530,9 +530,9 @@ impl<'a> _INVW<'a> {
 #[doc = "Values that can be written to the field `OD`"]
 pub enum ODW {
     #[doc = "Disable."]
-    DISABLE_,
+    DISABLED,
     #[doc = "Open-drain mode enabled.  This is not a true open-drain mode."]
-    OPEN_DRAIN_MODE_ENAB,
+    OPEN_DRAIN,
 }
 impl ODW {
     #[allow(missing_docs)]
@@ -540,8 +540,8 @@ impl ODW {
     #[inline]
     pub fn _bits(&self) -> bool {
         match *self {
-            ODW::DISABLE_ => false,
-            ODW::OPEN_DRAIN_MODE_ENAB => true,
+            ODW::DISABLED => false,
+            ODW::OPEN_DRAIN => true,
         }
     }
 }
@@ -559,13 +559,13 @@ impl<'a> _ODW<'a> {
     }
     #[doc = "Disable."]
     #[inline]
-    pub fn disable_(self) -> &'a mut W {
-        self.variant(ODW::DISABLE_)
+    pub fn disabled(self) -> &'a mut W {
+        self.variant(ODW::DISABLED)
     }
     #[doc = "Open-drain mode enabled. This is not a true open-drain mode."]
     #[inline]
-    pub fn open_drain_mode_enab(self) -> &'a mut W {
-        self.variant(ODW::OPEN_DRAIN_MODE_ENAB)
+    pub fn open_drain(self) -> &'a mut W {
+        self.variant(ODW::OPEN_DRAIN)
     }
     #[doc = r" Sets the field bit"]
     pub fn set_bit(self) -> &'a mut W {

--- a/lpc11uxx/src/iocon/pio1_23.rs
+++ b/lpc11uxx/src/iocon/pio1_23.rs
@@ -46,11 +46,11 @@ impl super::PIO1_23 {
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum FUNCR {
     #[doc = "PIO1_23."]
-    PIO1_23_,
+    PIO1_23,
     #[doc = "CT16B1_MAT1."]
-    CT16B1_MAT1_,
+    CT16B1_MAT1,
     #[doc = "SSEL1."]
-    SSEL1_,
+    SSEL1,
     #[doc = r" Reserved"]
     _Reserved(u8),
 }
@@ -59,9 +59,9 @@ impl FUNCR {
     #[inline]
     pub fn bits(&self) -> u8 {
         match *self {
-            FUNCR::PIO1_23_ => 0,
-            FUNCR::CT16B1_MAT1_ => 1,
-            FUNCR::SSEL1_ => 2,
+            FUNCR::PIO1_23 => 0,
+            FUNCR::CT16B1_MAT1 => 1,
+            FUNCR::SSEL1 => 2,
             FUNCR::_Reserved(bits) => bits,
         }
     }
@@ -70,49 +70,49 @@ impl FUNCR {
     #[inline]
     pub fn _from(value: u8) -> FUNCR {
         match value {
-            0 => FUNCR::PIO1_23_,
-            1 => FUNCR::CT16B1_MAT1_,
-            2 => FUNCR::SSEL1_,
+            0 => FUNCR::PIO1_23,
+            1 => FUNCR::CT16B1_MAT1,
+            2 => FUNCR::SSEL1,
             i => FUNCR::_Reserved(i),
         }
     }
-    #[doc = "Checks if the value of the field is `PIO1_23_`"]
+    #[doc = "Checks if the value of the field is `PIO1_23`"]
     #[inline]
-    pub fn is_pio1_23_(&self) -> bool {
-        *self == FUNCR::PIO1_23_
+    pub fn is_pio1_23(&self) -> bool {
+        *self == FUNCR::PIO1_23
     }
-    #[doc = "Checks if the value of the field is `CT16B1_MAT1_`"]
+    #[doc = "Checks if the value of the field is `CT16B1_MAT1`"]
     #[inline]
-    pub fn is_ct16b1_mat1_(&self) -> bool {
-        *self == FUNCR::CT16B1_MAT1_
+    pub fn is_ct16b1_mat1(&self) -> bool {
+        *self == FUNCR::CT16B1_MAT1
     }
-    #[doc = "Checks if the value of the field is `SSEL1_`"]
+    #[doc = "Checks if the value of the field is `SSEL1`"]
     #[inline]
-    pub fn is_ssel1_(&self) -> bool {
-        *self == FUNCR::SSEL1_
+    pub fn is_ssel1(&self) -> bool {
+        *self == FUNCR::SSEL1
     }
 }
 #[doc = "Possible values of the field `MODE`"]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum MODER {
     #[doc = "Inactive (no pull-down/pull-up resistor enabled)."]
-    INACTIVE_NO_PULL_DO,
+    INACTIVE,
     #[doc = "Pull-down resistor enabled."]
-    PULL_DOWN_RESISTOR_E,
+    PULL_DOWN,
     #[doc = "Pull-up resistor enabled."]
-    PULL_UP_RESISTOR_ENA,
+    PULL_UP,
     #[doc = "Repeater mode."]
-    REPEATER_MODE_,
+    REPEATER,
 }
 impl MODER {
     #[doc = r" Value of the field as raw bits"]
     #[inline]
     pub fn bits(&self) -> u8 {
         match *self {
-            MODER::INACTIVE_NO_PULL_DO => 0,
-            MODER::PULL_DOWN_RESISTOR_E => 1,
-            MODER::PULL_UP_RESISTOR_ENA => 2,
-            MODER::REPEATER_MODE_ => 3,
+            MODER::INACTIVE => 0,
+            MODER::PULL_DOWN => 1,
+            MODER::PULL_UP => 2,
+            MODER::REPEATER => 3,
         }
     }
     #[allow(missing_docs)]
@@ -120,41 +120,41 @@ impl MODER {
     #[inline]
     pub fn _from(value: u8) -> MODER {
         match value {
-            0 => MODER::INACTIVE_NO_PULL_DO,
-            1 => MODER::PULL_DOWN_RESISTOR_E,
-            2 => MODER::PULL_UP_RESISTOR_ENA,
-            3 => MODER::REPEATER_MODE_,
+            0 => MODER::INACTIVE,
+            1 => MODER::PULL_DOWN,
+            2 => MODER::PULL_UP,
+            3 => MODER::REPEATER,
             _ => unreachable!(),
         }
     }
-    #[doc = "Checks if the value of the field is `INACTIVE_NO_PULL_DO`"]
+    #[doc = "Checks if the value of the field is `INACTIVE`"]
     #[inline]
-    pub fn is_inactive_no_pull_do(&self) -> bool {
-        *self == MODER::INACTIVE_NO_PULL_DO
+    pub fn is_inactive(&self) -> bool {
+        *self == MODER::INACTIVE
     }
-    #[doc = "Checks if the value of the field is `PULL_DOWN_RESISTOR_E`"]
+    #[doc = "Checks if the value of the field is `PULL_DOWN`"]
     #[inline]
-    pub fn is_pull_down_resistor_e(&self) -> bool {
-        *self == MODER::PULL_DOWN_RESISTOR_E
+    pub fn is_pull_down(&self) -> bool {
+        *self == MODER::PULL_DOWN
     }
-    #[doc = "Checks if the value of the field is `PULL_UP_RESISTOR_ENA`"]
+    #[doc = "Checks if the value of the field is `PULL_UP`"]
     #[inline]
-    pub fn is_pull_up_resistor_ena(&self) -> bool {
-        *self == MODER::PULL_UP_RESISTOR_ENA
+    pub fn is_pull_up(&self) -> bool {
+        *self == MODER::PULL_UP
     }
-    #[doc = "Checks if the value of the field is `REPEATER_MODE_`"]
+    #[doc = "Checks if the value of the field is `REPEATER`"]
     #[inline]
-    pub fn is_repeater_mode_(&self) -> bool {
-        *self == MODER::REPEATER_MODE_
+    pub fn is_repeater(&self) -> bool {
+        *self == MODER::REPEATER
     }
 }
 #[doc = "Possible values of the field `HYS`"]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum HYSR {
     #[doc = "Disable."]
-    DISABLE_,
+    DISABLED,
     #[doc = "Enable."]
-    ENABLE_,
+    ENABLED,
 }
 impl HYSR {
     #[doc = r" Returns `true` if the bit is clear (0)"]
@@ -171,8 +171,8 @@ impl HYSR {
     #[inline]
     pub fn bit(&self) -> bool {
         match *self {
-            HYSR::DISABLE_ => false,
-            HYSR::ENABLE_ => true,
+            HYSR::DISABLED => false,
+            HYSR::ENABLED => true,
         }
     }
     #[allow(missing_docs)]
@@ -180,28 +180,28 @@ impl HYSR {
     #[inline]
     pub fn _from(value: bool) -> HYSR {
         match value {
-            false => HYSR::DISABLE_,
-            true => HYSR::ENABLE_,
+            false => HYSR::DISABLED,
+            true => HYSR::ENABLED,
         }
     }
-    #[doc = "Checks if the value of the field is `DISABLE_`"]
+    #[doc = "Checks if the value of the field is `DISABLED`"]
     #[inline]
-    pub fn is_disable_(&self) -> bool {
-        *self == HYSR::DISABLE_
+    pub fn is_disabled(&self) -> bool {
+        *self == HYSR::DISABLED
     }
-    #[doc = "Checks if the value of the field is `ENABLE_`"]
+    #[doc = "Checks if the value of the field is `ENABLED`"]
     #[inline]
-    pub fn is_enable_(&self) -> bool {
-        *self == HYSR::ENABLE_
+    pub fn is_enabled(&self) -> bool {
+        *self == HYSR::ENABLED
     }
 }
 #[doc = "Possible values of the field `INV`"]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum INVR {
     #[doc = "Input not inverted (HIGH on pin reads as 1, LOW on pin reads as 0)."]
-    INPUT_NOT_INVERTED_,
+    NOT_INVERTED,
     #[doc = "Input inverted (HIGH on pin reads as 0, LOW on pin reads as 1)."]
-    INPUT_INVERTED_HIGH,
+    INVERTED,
 }
 impl INVR {
     #[doc = r" Returns `true` if the bit is clear (0)"]
@@ -218,8 +218,8 @@ impl INVR {
     #[inline]
     pub fn bit(&self) -> bool {
         match *self {
-            INVR::INPUT_NOT_INVERTED_ => false,
-            INVR::INPUT_INVERTED_HIGH => true,
+            INVR::NOT_INVERTED => false,
+            INVR::INVERTED => true,
         }
     }
     #[allow(missing_docs)]
@@ -227,28 +227,28 @@ impl INVR {
     #[inline]
     pub fn _from(value: bool) -> INVR {
         match value {
-            false => INVR::INPUT_NOT_INVERTED_,
-            true => INVR::INPUT_INVERTED_HIGH,
+            false => INVR::NOT_INVERTED,
+            true => INVR::INVERTED,
         }
     }
-    #[doc = "Checks if the value of the field is `INPUT_NOT_INVERTED_`"]
+    #[doc = "Checks if the value of the field is `NOT_INVERTED`"]
     #[inline]
-    pub fn is_input_not_inverted_(&self) -> bool {
-        *self == INVR::INPUT_NOT_INVERTED_
+    pub fn is_not_inverted(&self) -> bool {
+        *self == INVR::NOT_INVERTED
     }
-    #[doc = "Checks if the value of the field is `INPUT_INVERTED_HIGH`"]
+    #[doc = "Checks if the value of the field is `INVERTED`"]
     #[inline]
-    pub fn is_input_inverted_high(&self) -> bool {
-        *self == INVR::INPUT_INVERTED_HIGH
+    pub fn is_inverted(&self) -> bool {
+        *self == INVR::INVERTED
     }
 }
 #[doc = "Possible values of the field `OD`"]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum ODR {
     #[doc = "Disable."]
-    DISABLE_,
+    DISABLED,
     #[doc = "Open-drain mode enabled.  This is not a true open-drain mode."]
-    OPEN_DRAIN_MODE_ENAB,
+    OPEN_DRAIN,
 }
 impl ODR {
     #[doc = r" Returns `true` if the bit is clear (0)"]
@@ -265,8 +265,8 @@ impl ODR {
     #[inline]
     pub fn bit(&self) -> bool {
         match *self {
-            ODR::DISABLE_ => false,
-            ODR::OPEN_DRAIN_MODE_ENAB => true,
+            ODR::DISABLED => false,
+            ODR::OPEN_DRAIN => true,
         }
     }
     #[allow(missing_docs)]
@@ -274,29 +274,29 @@ impl ODR {
     #[inline]
     pub fn _from(value: bool) -> ODR {
         match value {
-            false => ODR::DISABLE_,
-            true => ODR::OPEN_DRAIN_MODE_ENAB,
+            false => ODR::DISABLED,
+            true => ODR::OPEN_DRAIN,
         }
     }
-    #[doc = "Checks if the value of the field is `DISABLE_`"]
+    #[doc = "Checks if the value of the field is `DISABLED`"]
     #[inline]
-    pub fn is_disable_(&self) -> bool {
-        *self == ODR::DISABLE_
+    pub fn is_disabled(&self) -> bool {
+        *self == ODR::DISABLED
     }
-    #[doc = "Checks if the value of the field is `OPEN_DRAIN_MODE_ENAB`"]
+    #[doc = "Checks if the value of the field is `OPEN_DRAIN`"]
     #[inline]
-    pub fn is_open_drain_mode_enab(&self) -> bool {
-        *self == ODR::OPEN_DRAIN_MODE_ENAB
+    pub fn is_open_drain(&self) -> bool {
+        *self == ODR::OPEN_DRAIN
     }
 }
 #[doc = "Values that can be written to the field `FUNC`"]
 pub enum FUNCW {
     #[doc = "PIO1_23."]
-    PIO1_23_,
+    PIO1_23,
     #[doc = "CT16B1_MAT1."]
-    CT16B1_MAT1_,
+    CT16B1_MAT1,
     #[doc = "SSEL1."]
-    SSEL1_,
+    SSEL1,
 }
 impl FUNCW {
     #[allow(missing_docs)]
@@ -304,9 +304,9 @@ impl FUNCW {
     #[inline]
     pub fn _bits(&self) -> u8 {
         match *self {
-            FUNCW::PIO1_23_ => 0,
-            FUNCW::CT16B1_MAT1_ => 1,
-            FUNCW::SSEL1_ => 2,
+            FUNCW::PIO1_23 => 0,
+            FUNCW::CT16B1_MAT1 => 1,
+            FUNCW::SSEL1 => 2,
         }
     }
 }
@@ -322,18 +322,18 @@ impl<'a> _FUNCW<'a> {
     }
     #[doc = "PIO1_23."]
     #[inline]
-    pub fn pio1_23_(self) -> &'a mut W {
-        self.variant(FUNCW::PIO1_23_)
+    pub fn pio1_23(self) -> &'a mut W {
+        self.variant(FUNCW::PIO1_23)
     }
     #[doc = "CT16B1_MAT1."]
     #[inline]
-    pub fn ct16b1_mat1_(self) -> &'a mut W {
-        self.variant(FUNCW::CT16B1_MAT1_)
+    pub fn ct16b1_mat1(self) -> &'a mut W {
+        self.variant(FUNCW::CT16B1_MAT1)
     }
     #[doc = "SSEL1."]
     #[inline]
-    pub fn ssel1_(self) -> &'a mut W {
-        self.variant(FUNCW::SSEL1_)
+    pub fn ssel1(self) -> &'a mut W {
+        self.variant(FUNCW::SSEL1)
     }
     #[doc = r" Writes raw bits to the field"]
     #[inline]
@@ -348,13 +348,13 @@ impl<'a> _FUNCW<'a> {
 #[doc = "Values that can be written to the field `MODE`"]
 pub enum MODEW {
     #[doc = "Inactive (no pull-down/pull-up resistor enabled)."]
-    INACTIVE_NO_PULL_DO,
+    INACTIVE,
     #[doc = "Pull-down resistor enabled."]
-    PULL_DOWN_RESISTOR_E,
+    PULL_DOWN,
     #[doc = "Pull-up resistor enabled."]
-    PULL_UP_RESISTOR_ENA,
+    PULL_UP,
     #[doc = "Repeater mode."]
-    REPEATER_MODE_,
+    REPEATER,
 }
 impl MODEW {
     #[allow(missing_docs)]
@@ -362,10 +362,10 @@ impl MODEW {
     #[inline]
     pub fn _bits(&self) -> u8 {
         match *self {
-            MODEW::INACTIVE_NO_PULL_DO => 0,
-            MODEW::PULL_DOWN_RESISTOR_E => 1,
-            MODEW::PULL_UP_RESISTOR_ENA => 2,
-            MODEW::REPEATER_MODE_ => 3,
+            MODEW::INACTIVE => 0,
+            MODEW::PULL_DOWN => 1,
+            MODEW::PULL_UP => 2,
+            MODEW::REPEATER => 3,
         }
     }
 }
@@ -383,23 +383,23 @@ impl<'a> _MODEW<'a> {
     }
     #[doc = "Inactive (no pull-down/pull-up resistor enabled)."]
     #[inline]
-    pub fn inactive_no_pull_do(self) -> &'a mut W {
-        self.variant(MODEW::INACTIVE_NO_PULL_DO)
+    pub fn inactive(self) -> &'a mut W {
+        self.variant(MODEW::INACTIVE)
     }
     #[doc = "Pull-down resistor enabled."]
     #[inline]
-    pub fn pull_down_resistor_e(self) -> &'a mut W {
-        self.variant(MODEW::PULL_DOWN_RESISTOR_E)
+    pub fn pull_down(self) -> &'a mut W {
+        self.variant(MODEW::PULL_DOWN)
     }
     #[doc = "Pull-up resistor enabled."]
     #[inline]
-    pub fn pull_up_resistor_ena(self) -> &'a mut W {
-        self.variant(MODEW::PULL_UP_RESISTOR_ENA)
+    pub fn pull_up(self) -> &'a mut W {
+        self.variant(MODEW::PULL_UP)
     }
     #[doc = "Repeater mode."]
     #[inline]
-    pub fn repeater_mode_(self) -> &'a mut W {
-        self.variant(MODEW::REPEATER_MODE_)
+    pub fn repeater(self) -> &'a mut W {
+        self.variant(MODEW::REPEATER)
     }
     #[doc = r" Writes raw bits to the field"]
     #[inline]
@@ -414,9 +414,9 @@ impl<'a> _MODEW<'a> {
 #[doc = "Values that can be written to the field `HYS`"]
 pub enum HYSW {
     #[doc = "Disable."]
-    DISABLE_,
+    DISABLED,
     #[doc = "Enable."]
-    ENABLE_,
+    ENABLED,
 }
 impl HYSW {
     #[allow(missing_docs)]
@@ -424,8 +424,8 @@ impl HYSW {
     #[inline]
     pub fn _bits(&self) -> bool {
         match *self {
-            HYSW::DISABLE_ => false,
-            HYSW::ENABLE_ => true,
+            HYSW::DISABLED => false,
+            HYSW::ENABLED => true,
         }
     }
 }
@@ -443,13 +443,13 @@ impl<'a> _HYSW<'a> {
     }
     #[doc = "Disable."]
     #[inline]
-    pub fn disable_(self) -> &'a mut W {
-        self.variant(HYSW::DISABLE_)
+    pub fn disabled(self) -> &'a mut W {
+        self.variant(HYSW::DISABLED)
     }
     #[doc = "Enable."]
     #[inline]
-    pub fn enable_(self) -> &'a mut W {
-        self.variant(HYSW::ENABLE_)
+    pub fn enabled(self) -> &'a mut W {
+        self.variant(HYSW::ENABLED)
     }
     #[doc = r" Sets the field bit"]
     pub fn set_bit(self) -> &'a mut W {
@@ -472,9 +472,9 @@ impl<'a> _HYSW<'a> {
 #[doc = "Values that can be written to the field `INV`"]
 pub enum INVW {
     #[doc = "Input not inverted (HIGH on pin reads as 1, LOW on pin reads as 0)."]
-    INPUT_NOT_INVERTED_,
+    NOT_INVERTED,
     #[doc = "Input inverted (HIGH on pin reads as 0, LOW on pin reads as 1)."]
-    INPUT_INVERTED_HIGH,
+    INVERTED,
 }
 impl INVW {
     #[allow(missing_docs)]
@@ -482,8 +482,8 @@ impl INVW {
     #[inline]
     pub fn _bits(&self) -> bool {
         match *self {
-            INVW::INPUT_NOT_INVERTED_ => false,
-            INVW::INPUT_INVERTED_HIGH => true,
+            INVW::NOT_INVERTED => false,
+            INVW::INVERTED => true,
         }
     }
 }
@@ -501,13 +501,13 @@ impl<'a> _INVW<'a> {
     }
     #[doc = "Input not inverted (HIGH on pin reads as 1, LOW on pin reads as 0)."]
     #[inline]
-    pub fn input_not_inverted_(self) -> &'a mut W {
-        self.variant(INVW::INPUT_NOT_INVERTED_)
+    pub fn not_inverted(self) -> &'a mut W {
+        self.variant(INVW::NOT_INVERTED)
     }
     #[doc = "Input inverted (HIGH on pin reads as 0, LOW on pin reads as 1)."]
     #[inline]
-    pub fn input_inverted_high(self) -> &'a mut W {
-        self.variant(INVW::INPUT_INVERTED_HIGH)
+    pub fn inverted(self) -> &'a mut W {
+        self.variant(INVW::INVERTED)
     }
     #[doc = r" Sets the field bit"]
     pub fn set_bit(self) -> &'a mut W {
@@ -530,9 +530,9 @@ impl<'a> _INVW<'a> {
 #[doc = "Values that can be written to the field `OD`"]
 pub enum ODW {
     #[doc = "Disable."]
-    DISABLE_,
+    DISABLED,
     #[doc = "Open-drain mode enabled.  This is not a true open-drain mode."]
-    OPEN_DRAIN_MODE_ENAB,
+    OPEN_DRAIN,
 }
 impl ODW {
     #[allow(missing_docs)]
@@ -540,8 +540,8 @@ impl ODW {
     #[inline]
     pub fn _bits(&self) -> bool {
         match *self {
-            ODW::DISABLE_ => false,
-            ODW::OPEN_DRAIN_MODE_ENAB => true,
+            ODW::DISABLED => false,
+            ODW::OPEN_DRAIN => true,
         }
     }
 }
@@ -559,13 +559,13 @@ impl<'a> _ODW<'a> {
     }
     #[doc = "Disable."]
     #[inline]
-    pub fn disable_(self) -> &'a mut W {
-        self.variant(ODW::DISABLE_)
+    pub fn disabled(self) -> &'a mut W {
+        self.variant(ODW::DISABLED)
     }
     #[doc = "Open-drain mode enabled. This is not a true open-drain mode."]
     #[inline]
-    pub fn open_drain_mode_enab(self) -> &'a mut W {
-        self.variant(ODW::OPEN_DRAIN_MODE_ENAB)
+    pub fn open_drain(self) -> &'a mut W {
+        self.variant(ODW::OPEN_DRAIN)
     }
     #[doc = r" Sets the field bit"]
     pub fn set_bit(self) -> &'a mut W {

--- a/lpc11uxx/src/iocon/pio1_24.rs
+++ b/lpc11uxx/src/iocon/pio1_24.rs
@@ -46,9 +46,9 @@ impl super::PIO1_24 {
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum FUNCR {
     #[doc = "PIO1_24."]
-    PIO1_24_,
+    PIO1_24,
     #[doc = "CT32B0_MAT0."]
-    CT32B0_MAT0_,
+    CT32B0_MAT0,
     #[doc = r" Reserved"]
     _Reserved(u8),
 }
@@ -57,8 +57,8 @@ impl FUNCR {
     #[inline]
     pub fn bits(&self) -> u8 {
         match *self {
-            FUNCR::PIO1_24_ => 0,
-            FUNCR::CT32B0_MAT0_ => 1,
+            FUNCR::PIO1_24 => 0,
+            FUNCR::CT32B0_MAT0 => 1,
             FUNCR::_Reserved(bits) => bits,
         }
     }
@@ -67,43 +67,43 @@ impl FUNCR {
     #[inline]
     pub fn _from(value: u8) -> FUNCR {
         match value {
-            0 => FUNCR::PIO1_24_,
-            1 => FUNCR::CT32B0_MAT0_,
+            0 => FUNCR::PIO1_24,
+            1 => FUNCR::CT32B0_MAT0,
             i => FUNCR::_Reserved(i),
         }
     }
-    #[doc = "Checks if the value of the field is `PIO1_24_`"]
+    #[doc = "Checks if the value of the field is `PIO1_24`"]
     #[inline]
-    pub fn is_pio1_24_(&self) -> bool {
-        *self == FUNCR::PIO1_24_
+    pub fn is_pio1_24(&self) -> bool {
+        *self == FUNCR::PIO1_24
     }
-    #[doc = "Checks if the value of the field is `CT32B0_MAT0_`"]
+    #[doc = "Checks if the value of the field is `CT32B0_MAT0`"]
     #[inline]
-    pub fn is_ct32b0_mat0_(&self) -> bool {
-        *self == FUNCR::CT32B0_MAT0_
+    pub fn is_ct32b0_mat0(&self) -> bool {
+        *self == FUNCR::CT32B0_MAT0
     }
 }
 #[doc = "Possible values of the field `MODE`"]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum MODER {
     #[doc = "Inactive (no pull-down/pull-up resistor enabled)."]
-    INACTIVE_NO_PULL_DO,
+    INACTIVE,
     #[doc = "Pull-down resistor enabled."]
-    PULL_DOWN_RESISTOR_E,
+    PULL_DOWN,
     #[doc = "Pull-up resistor enabled."]
-    PULL_UP_RESISTOR_ENA,
+    PULL_UP,
     #[doc = "Repeater mode."]
-    REPEATER_MODE_,
+    REPEATER,
 }
 impl MODER {
     #[doc = r" Value of the field as raw bits"]
     #[inline]
     pub fn bits(&self) -> u8 {
         match *self {
-            MODER::INACTIVE_NO_PULL_DO => 0,
-            MODER::PULL_DOWN_RESISTOR_E => 1,
-            MODER::PULL_UP_RESISTOR_ENA => 2,
-            MODER::REPEATER_MODE_ => 3,
+            MODER::INACTIVE => 0,
+            MODER::PULL_DOWN => 1,
+            MODER::PULL_UP => 2,
+            MODER::REPEATER => 3,
         }
     }
     #[allow(missing_docs)]
@@ -111,41 +111,41 @@ impl MODER {
     #[inline]
     pub fn _from(value: u8) -> MODER {
         match value {
-            0 => MODER::INACTIVE_NO_PULL_DO,
-            1 => MODER::PULL_DOWN_RESISTOR_E,
-            2 => MODER::PULL_UP_RESISTOR_ENA,
-            3 => MODER::REPEATER_MODE_,
+            0 => MODER::INACTIVE,
+            1 => MODER::PULL_DOWN,
+            2 => MODER::PULL_UP,
+            3 => MODER::REPEATER,
             _ => unreachable!(),
         }
     }
-    #[doc = "Checks if the value of the field is `INACTIVE_NO_PULL_DO`"]
+    #[doc = "Checks if the value of the field is `INACTIVE`"]
     #[inline]
-    pub fn is_inactive_no_pull_do(&self) -> bool {
-        *self == MODER::INACTIVE_NO_PULL_DO
+    pub fn is_inactive(&self) -> bool {
+        *self == MODER::INACTIVE
     }
-    #[doc = "Checks if the value of the field is `PULL_DOWN_RESISTOR_E`"]
+    #[doc = "Checks if the value of the field is `PULL_DOWN`"]
     #[inline]
-    pub fn is_pull_down_resistor_e(&self) -> bool {
-        *self == MODER::PULL_DOWN_RESISTOR_E
+    pub fn is_pull_down(&self) -> bool {
+        *self == MODER::PULL_DOWN
     }
-    #[doc = "Checks if the value of the field is `PULL_UP_RESISTOR_ENA`"]
+    #[doc = "Checks if the value of the field is `PULL_UP`"]
     #[inline]
-    pub fn is_pull_up_resistor_ena(&self) -> bool {
-        *self == MODER::PULL_UP_RESISTOR_ENA
+    pub fn is_pull_up(&self) -> bool {
+        *self == MODER::PULL_UP
     }
-    #[doc = "Checks if the value of the field is `REPEATER_MODE_`"]
+    #[doc = "Checks if the value of the field is `REPEATER`"]
     #[inline]
-    pub fn is_repeater_mode_(&self) -> bool {
-        *self == MODER::REPEATER_MODE_
+    pub fn is_repeater(&self) -> bool {
+        *self == MODER::REPEATER
     }
 }
 #[doc = "Possible values of the field `HYS`"]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum HYSR {
     #[doc = "Disable."]
-    DISABLE_,
+    DISABLED,
     #[doc = "Enable."]
-    ENABLE_,
+    ENABLED,
 }
 impl HYSR {
     #[doc = r" Returns `true` if the bit is clear (0)"]
@@ -162,8 +162,8 @@ impl HYSR {
     #[inline]
     pub fn bit(&self) -> bool {
         match *self {
-            HYSR::DISABLE_ => false,
-            HYSR::ENABLE_ => true,
+            HYSR::DISABLED => false,
+            HYSR::ENABLED => true,
         }
     }
     #[allow(missing_docs)]
@@ -171,28 +171,28 @@ impl HYSR {
     #[inline]
     pub fn _from(value: bool) -> HYSR {
         match value {
-            false => HYSR::DISABLE_,
-            true => HYSR::ENABLE_,
+            false => HYSR::DISABLED,
+            true => HYSR::ENABLED,
         }
     }
-    #[doc = "Checks if the value of the field is `DISABLE_`"]
+    #[doc = "Checks if the value of the field is `DISABLED`"]
     #[inline]
-    pub fn is_disable_(&self) -> bool {
-        *self == HYSR::DISABLE_
+    pub fn is_disabled(&self) -> bool {
+        *self == HYSR::DISABLED
     }
-    #[doc = "Checks if the value of the field is `ENABLE_`"]
+    #[doc = "Checks if the value of the field is `ENABLED`"]
     #[inline]
-    pub fn is_enable_(&self) -> bool {
-        *self == HYSR::ENABLE_
+    pub fn is_enabled(&self) -> bool {
+        *self == HYSR::ENABLED
     }
 }
 #[doc = "Possible values of the field `INV`"]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum INVR {
     #[doc = "Input not inverted (HIGH on pin reads as 1, LOW on pin reads as 0)."]
-    INPUT_NOT_INVERTED_,
+    NOT_INVERTED,
     #[doc = "Input inverted (HIGH on pin reads as 0, LOW on pin reads as 1)."]
-    INPUT_INVERTED_HIGH,
+    INVERTED,
 }
 impl INVR {
     #[doc = r" Returns `true` if the bit is clear (0)"]
@@ -209,8 +209,8 @@ impl INVR {
     #[inline]
     pub fn bit(&self) -> bool {
         match *self {
-            INVR::INPUT_NOT_INVERTED_ => false,
-            INVR::INPUT_INVERTED_HIGH => true,
+            INVR::NOT_INVERTED => false,
+            INVR::INVERTED => true,
         }
     }
     #[allow(missing_docs)]
@@ -218,28 +218,28 @@ impl INVR {
     #[inline]
     pub fn _from(value: bool) -> INVR {
         match value {
-            false => INVR::INPUT_NOT_INVERTED_,
-            true => INVR::INPUT_INVERTED_HIGH,
+            false => INVR::NOT_INVERTED,
+            true => INVR::INVERTED,
         }
     }
-    #[doc = "Checks if the value of the field is `INPUT_NOT_INVERTED_`"]
+    #[doc = "Checks if the value of the field is `NOT_INVERTED`"]
     #[inline]
-    pub fn is_input_not_inverted_(&self) -> bool {
-        *self == INVR::INPUT_NOT_INVERTED_
+    pub fn is_not_inverted(&self) -> bool {
+        *self == INVR::NOT_INVERTED
     }
-    #[doc = "Checks if the value of the field is `INPUT_INVERTED_HIGH`"]
+    #[doc = "Checks if the value of the field is `INVERTED`"]
     #[inline]
-    pub fn is_input_inverted_high(&self) -> bool {
-        *self == INVR::INPUT_INVERTED_HIGH
+    pub fn is_inverted(&self) -> bool {
+        *self == INVR::INVERTED
     }
 }
 #[doc = "Possible values of the field `OD`"]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum ODR {
     #[doc = "Disable."]
-    DISABLE_,
+    DISABLED,
     #[doc = "Open-drain mode enabled.  This is not a true open-drain mode."]
-    OPEN_DRAIN_MODE_ENAB,
+    OPEN_DRAIN,
 }
 impl ODR {
     #[doc = r" Returns `true` if the bit is clear (0)"]
@@ -256,8 +256,8 @@ impl ODR {
     #[inline]
     pub fn bit(&self) -> bool {
         match *self {
-            ODR::DISABLE_ => false,
-            ODR::OPEN_DRAIN_MODE_ENAB => true,
+            ODR::DISABLED => false,
+            ODR::OPEN_DRAIN => true,
         }
     }
     #[allow(missing_docs)]
@@ -265,27 +265,27 @@ impl ODR {
     #[inline]
     pub fn _from(value: bool) -> ODR {
         match value {
-            false => ODR::DISABLE_,
-            true => ODR::OPEN_DRAIN_MODE_ENAB,
+            false => ODR::DISABLED,
+            true => ODR::OPEN_DRAIN,
         }
     }
-    #[doc = "Checks if the value of the field is `DISABLE_`"]
+    #[doc = "Checks if the value of the field is `DISABLED`"]
     #[inline]
-    pub fn is_disable_(&self) -> bool {
-        *self == ODR::DISABLE_
+    pub fn is_disabled(&self) -> bool {
+        *self == ODR::DISABLED
     }
-    #[doc = "Checks if the value of the field is `OPEN_DRAIN_MODE_ENAB`"]
+    #[doc = "Checks if the value of the field is `OPEN_DRAIN`"]
     #[inline]
-    pub fn is_open_drain_mode_enab(&self) -> bool {
-        *self == ODR::OPEN_DRAIN_MODE_ENAB
+    pub fn is_open_drain(&self) -> bool {
+        *self == ODR::OPEN_DRAIN
     }
 }
 #[doc = "Values that can be written to the field `FUNC`"]
 pub enum FUNCW {
     #[doc = "PIO1_24."]
-    PIO1_24_,
+    PIO1_24,
     #[doc = "CT32B0_MAT0."]
-    CT32B0_MAT0_,
+    CT32B0_MAT0,
 }
 impl FUNCW {
     #[allow(missing_docs)]
@@ -293,8 +293,8 @@ impl FUNCW {
     #[inline]
     pub fn _bits(&self) -> u8 {
         match *self {
-            FUNCW::PIO1_24_ => 0,
-            FUNCW::CT32B0_MAT0_ => 1,
+            FUNCW::PIO1_24 => 0,
+            FUNCW::CT32B0_MAT0 => 1,
         }
     }
 }
@@ -310,13 +310,13 @@ impl<'a> _FUNCW<'a> {
     }
     #[doc = "PIO1_24."]
     #[inline]
-    pub fn pio1_24_(self) -> &'a mut W {
-        self.variant(FUNCW::PIO1_24_)
+    pub fn pio1_24(self) -> &'a mut W {
+        self.variant(FUNCW::PIO1_24)
     }
     #[doc = "CT32B0_MAT0."]
     #[inline]
-    pub fn ct32b0_mat0_(self) -> &'a mut W {
-        self.variant(FUNCW::CT32B0_MAT0_)
+    pub fn ct32b0_mat0(self) -> &'a mut W {
+        self.variant(FUNCW::CT32B0_MAT0)
     }
     #[doc = r" Writes raw bits to the field"]
     #[inline]
@@ -331,13 +331,13 @@ impl<'a> _FUNCW<'a> {
 #[doc = "Values that can be written to the field `MODE`"]
 pub enum MODEW {
     #[doc = "Inactive (no pull-down/pull-up resistor enabled)."]
-    INACTIVE_NO_PULL_DO,
+    INACTIVE,
     #[doc = "Pull-down resistor enabled."]
-    PULL_DOWN_RESISTOR_E,
+    PULL_DOWN,
     #[doc = "Pull-up resistor enabled."]
-    PULL_UP_RESISTOR_ENA,
+    PULL_UP,
     #[doc = "Repeater mode."]
-    REPEATER_MODE_,
+    REPEATER,
 }
 impl MODEW {
     #[allow(missing_docs)]
@@ -345,10 +345,10 @@ impl MODEW {
     #[inline]
     pub fn _bits(&self) -> u8 {
         match *self {
-            MODEW::INACTIVE_NO_PULL_DO => 0,
-            MODEW::PULL_DOWN_RESISTOR_E => 1,
-            MODEW::PULL_UP_RESISTOR_ENA => 2,
-            MODEW::REPEATER_MODE_ => 3,
+            MODEW::INACTIVE => 0,
+            MODEW::PULL_DOWN => 1,
+            MODEW::PULL_UP => 2,
+            MODEW::REPEATER => 3,
         }
     }
 }
@@ -366,23 +366,23 @@ impl<'a> _MODEW<'a> {
     }
     #[doc = "Inactive (no pull-down/pull-up resistor enabled)."]
     #[inline]
-    pub fn inactive_no_pull_do(self) -> &'a mut W {
-        self.variant(MODEW::INACTIVE_NO_PULL_DO)
+    pub fn inactive(self) -> &'a mut W {
+        self.variant(MODEW::INACTIVE)
     }
     #[doc = "Pull-down resistor enabled."]
     #[inline]
-    pub fn pull_down_resistor_e(self) -> &'a mut W {
-        self.variant(MODEW::PULL_DOWN_RESISTOR_E)
+    pub fn pull_down(self) -> &'a mut W {
+        self.variant(MODEW::PULL_DOWN)
     }
     #[doc = "Pull-up resistor enabled."]
     #[inline]
-    pub fn pull_up_resistor_ena(self) -> &'a mut W {
-        self.variant(MODEW::PULL_UP_RESISTOR_ENA)
+    pub fn pull_up(self) -> &'a mut W {
+        self.variant(MODEW::PULL_UP)
     }
     #[doc = "Repeater mode."]
     #[inline]
-    pub fn repeater_mode_(self) -> &'a mut W {
-        self.variant(MODEW::REPEATER_MODE_)
+    pub fn repeater(self) -> &'a mut W {
+        self.variant(MODEW::REPEATER)
     }
     #[doc = r" Writes raw bits to the field"]
     #[inline]
@@ -397,9 +397,9 @@ impl<'a> _MODEW<'a> {
 #[doc = "Values that can be written to the field `HYS`"]
 pub enum HYSW {
     #[doc = "Disable."]
-    DISABLE_,
+    DISABLED,
     #[doc = "Enable."]
-    ENABLE_,
+    ENABLED,
 }
 impl HYSW {
     #[allow(missing_docs)]
@@ -407,8 +407,8 @@ impl HYSW {
     #[inline]
     pub fn _bits(&self) -> bool {
         match *self {
-            HYSW::DISABLE_ => false,
-            HYSW::ENABLE_ => true,
+            HYSW::DISABLED => false,
+            HYSW::ENABLED => true,
         }
     }
 }
@@ -426,13 +426,13 @@ impl<'a> _HYSW<'a> {
     }
     #[doc = "Disable."]
     #[inline]
-    pub fn disable_(self) -> &'a mut W {
-        self.variant(HYSW::DISABLE_)
+    pub fn disabled(self) -> &'a mut W {
+        self.variant(HYSW::DISABLED)
     }
     #[doc = "Enable."]
     #[inline]
-    pub fn enable_(self) -> &'a mut W {
-        self.variant(HYSW::ENABLE_)
+    pub fn enabled(self) -> &'a mut W {
+        self.variant(HYSW::ENABLED)
     }
     #[doc = r" Sets the field bit"]
     pub fn set_bit(self) -> &'a mut W {
@@ -455,9 +455,9 @@ impl<'a> _HYSW<'a> {
 #[doc = "Values that can be written to the field `INV`"]
 pub enum INVW {
     #[doc = "Input not inverted (HIGH on pin reads as 1, LOW on pin reads as 0)."]
-    INPUT_NOT_INVERTED_,
+    NOT_INVERTED,
     #[doc = "Input inverted (HIGH on pin reads as 0, LOW on pin reads as 1)."]
-    INPUT_INVERTED_HIGH,
+    INVERTED,
 }
 impl INVW {
     #[allow(missing_docs)]
@@ -465,8 +465,8 @@ impl INVW {
     #[inline]
     pub fn _bits(&self) -> bool {
         match *self {
-            INVW::INPUT_NOT_INVERTED_ => false,
-            INVW::INPUT_INVERTED_HIGH => true,
+            INVW::NOT_INVERTED => false,
+            INVW::INVERTED => true,
         }
     }
 }
@@ -484,13 +484,13 @@ impl<'a> _INVW<'a> {
     }
     #[doc = "Input not inverted (HIGH on pin reads as 1, LOW on pin reads as 0)."]
     #[inline]
-    pub fn input_not_inverted_(self) -> &'a mut W {
-        self.variant(INVW::INPUT_NOT_INVERTED_)
+    pub fn not_inverted(self) -> &'a mut W {
+        self.variant(INVW::NOT_INVERTED)
     }
     #[doc = "Input inverted (HIGH on pin reads as 0, LOW on pin reads as 1)."]
     #[inline]
-    pub fn input_inverted_high(self) -> &'a mut W {
-        self.variant(INVW::INPUT_INVERTED_HIGH)
+    pub fn inverted(self) -> &'a mut W {
+        self.variant(INVW::INVERTED)
     }
     #[doc = r" Sets the field bit"]
     pub fn set_bit(self) -> &'a mut W {
@@ -513,9 +513,9 @@ impl<'a> _INVW<'a> {
 #[doc = "Values that can be written to the field `OD`"]
 pub enum ODW {
     #[doc = "Disable."]
-    DISABLE_,
+    DISABLED,
     #[doc = "Open-drain mode enabled.  This is not a true open-drain mode."]
-    OPEN_DRAIN_MODE_ENAB,
+    OPEN_DRAIN,
 }
 impl ODW {
     #[allow(missing_docs)]
@@ -523,8 +523,8 @@ impl ODW {
     #[inline]
     pub fn _bits(&self) -> bool {
         match *self {
-            ODW::DISABLE_ => false,
-            ODW::OPEN_DRAIN_MODE_ENAB => true,
+            ODW::DISABLED => false,
+            ODW::OPEN_DRAIN => true,
         }
     }
 }
@@ -542,13 +542,13 @@ impl<'a> _ODW<'a> {
     }
     #[doc = "Disable."]
     #[inline]
-    pub fn disable_(self) -> &'a mut W {
-        self.variant(ODW::DISABLE_)
+    pub fn disabled(self) -> &'a mut W {
+        self.variant(ODW::DISABLED)
     }
     #[doc = "Open-drain mode enabled. This is not a true open-drain mode."]
     #[inline]
-    pub fn open_drain_mode_enab(self) -> &'a mut W {
-        self.variant(ODW::OPEN_DRAIN_MODE_ENAB)
+    pub fn open_drain(self) -> &'a mut W {
+        self.variant(ODW::OPEN_DRAIN)
     }
     #[doc = r" Sets the field bit"]
     pub fn set_bit(self) -> &'a mut W {

--- a/lpc11uxx/src/iocon/pio1_25.rs
+++ b/lpc11uxx/src/iocon/pio1_25.rs
@@ -46,9 +46,9 @@ impl super::PIO1_25 {
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum FUNCR {
     #[doc = "PIO1_25."]
-    PIO1_25_,
+    PIO1_25,
     #[doc = "CT32B0_MAT1."]
-    CT32B0_MAT1_,
+    CT32B0_MAT1,
     #[doc = r" Reserved"]
     _Reserved(u8),
 }
@@ -57,8 +57,8 @@ impl FUNCR {
     #[inline]
     pub fn bits(&self) -> u8 {
         match *self {
-            FUNCR::PIO1_25_ => 0,
-            FUNCR::CT32B0_MAT1_ => 1,
+            FUNCR::PIO1_25 => 0,
+            FUNCR::CT32B0_MAT1 => 1,
             FUNCR::_Reserved(bits) => bits,
         }
     }
@@ -67,43 +67,43 @@ impl FUNCR {
     #[inline]
     pub fn _from(value: u8) -> FUNCR {
         match value {
-            0 => FUNCR::PIO1_25_,
-            1 => FUNCR::CT32B0_MAT1_,
+            0 => FUNCR::PIO1_25,
+            1 => FUNCR::CT32B0_MAT1,
             i => FUNCR::_Reserved(i),
         }
     }
-    #[doc = "Checks if the value of the field is `PIO1_25_`"]
+    #[doc = "Checks if the value of the field is `PIO1_25`"]
     #[inline]
-    pub fn is_pio1_25_(&self) -> bool {
-        *self == FUNCR::PIO1_25_
+    pub fn is_pio1_25(&self) -> bool {
+        *self == FUNCR::PIO1_25
     }
-    #[doc = "Checks if the value of the field is `CT32B0_MAT1_`"]
+    #[doc = "Checks if the value of the field is `CT32B0_MAT1`"]
     #[inline]
-    pub fn is_ct32b0_mat1_(&self) -> bool {
-        *self == FUNCR::CT32B0_MAT1_
+    pub fn is_ct32b0_mat1(&self) -> bool {
+        *self == FUNCR::CT32B0_MAT1
     }
 }
 #[doc = "Possible values of the field `MODE`"]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum MODER {
     #[doc = "Inactive (no pull-down/pull-up resistor enabled)."]
-    INACTIVE_NO_PULL_DO,
+    INACTIVE,
     #[doc = "Pull-down resistor enabled."]
-    PULL_DOWN_RESISTOR_E,
+    PULL_DOWN,
     #[doc = "Pull-up resistor enabled."]
-    PULL_UP_RESISTOR_ENA,
+    PULL_UP,
     #[doc = "Repeater mode."]
-    REPEATER_MODE_,
+    REPEATER,
 }
 impl MODER {
     #[doc = r" Value of the field as raw bits"]
     #[inline]
     pub fn bits(&self) -> u8 {
         match *self {
-            MODER::INACTIVE_NO_PULL_DO => 0,
-            MODER::PULL_DOWN_RESISTOR_E => 1,
-            MODER::PULL_UP_RESISTOR_ENA => 2,
-            MODER::REPEATER_MODE_ => 3,
+            MODER::INACTIVE => 0,
+            MODER::PULL_DOWN => 1,
+            MODER::PULL_UP => 2,
+            MODER::REPEATER => 3,
         }
     }
     #[allow(missing_docs)]
@@ -111,41 +111,41 @@ impl MODER {
     #[inline]
     pub fn _from(value: u8) -> MODER {
         match value {
-            0 => MODER::INACTIVE_NO_PULL_DO,
-            1 => MODER::PULL_DOWN_RESISTOR_E,
-            2 => MODER::PULL_UP_RESISTOR_ENA,
-            3 => MODER::REPEATER_MODE_,
+            0 => MODER::INACTIVE,
+            1 => MODER::PULL_DOWN,
+            2 => MODER::PULL_UP,
+            3 => MODER::REPEATER,
             _ => unreachable!(),
         }
     }
-    #[doc = "Checks if the value of the field is `INACTIVE_NO_PULL_DO`"]
+    #[doc = "Checks if the value of the field is `INACTIVE`"]
     #[inline]
-    pub fn is_inactive_no_pull_do(&self) -> bool {
-        *self == MODER::INACTIVE_NO_PULL_DO
+    pub fn is_inactive(&self) -> bool {
+        *self == MODER::INACTIVE
     }
-    #[doc = "Checks if the value of the field is `PULL_DOWN_RESISTOR_E`"]
+    #[doc = "Checks if the value of the field is `PULL_DOWN`"]
     #[inline]
-    pub fn is_pull_down_resistor_e(&self) -> bool {
-        *self == MODER::PULL_DOWN_RESISTOR_E
+    pub fn is_pull_down(&self) -> bool {
+        *self == MODER::PULL_DOWN
     }
-    #[doc = "Checks if the value of the field is `PULL_UP_RESISTOR_ENA`"]
+    #[doc = "Checks if the value of the field is `PULL_UP`"]
     #[inline]
-    pub fn is_pull_up_resistor_ena(&self) -> bool {
-        *self == MODER::PULL_UP_RESISTOR_ENA
+    pub fn is_pull_up(&self) -> bool {
+        *self == MODER::PULL_UP
     }
-    #[doc = "Checks if the value of the field is `REPEATER_MODE_`"]
+    #[doc = "Checks if the value of the field is `REPEATER`"]
     #[inline]
-    pub fn is_repeater_mode_(&self) -> bool {
-        *self == MODER::REPEATER_MODE_
+    pub fn is_repeater(&self) -> bool {
+        *self == MODER::REPEATER
     }
 }
 #[doc = "Possible values of the field `HYS`"]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum HYSR {
     #[doc = "Disable."]
-    DISABLE_,
+    DISABLED,
     #[doc = "Enable."]
-    ENABLE_,
+    ENABLED,
 }
 impl HYSR {
     #[doc = r" Returns `true` if the bit is clear (0)"]
@@ -162,8 +162,8 @@ impl HYSR {
     #[inline]
     pub fn bit(&self) -> bool {
         match *self {
-            HYSR::DISABLE_ => false,
-            HYSR::ENABLE_ => true,
+            HYSR::DISABLED => false,
+            HYSR::ENABLED => true,
         }
     }
     #[allow(missing_docs)]
@@ -171,28 +171,28 @@ impl HYSR {
     #[inline]
     pub fn _from(value: bool) -> HYSR {
         match value {
-            false => HYSR::DISABLE_,
-            true => HYSR::ENABLE_,
+            false => HYSR::DISABLED,
+            true => HYSR::ENABLED,
         }
     }
-    #[doc = "Checks if the value of the field is `DISABLE_`"]
+    #[doc = "Checks if the value of the field is `DISABLED`"]
     #[inline]
-    pub fn is_disable_(&self) -> bool {
-        *self == HYSR::DISABLE_
+    pub fn is_disabled(&self) -> bool {
+        *self == HYSR::DISABLED
     }
-    #[doc = "Checks if the value of the field is `ENABLE_`"]
+    #[doc = "Checks if the value of the field is `ENABLED`"]
     #[inline]
-    pub fn is_enable_(&self) -> bool {
-        *self == HYSR::ENABLE_
+    pub fn is_enabled(&self) -> bool {
+        *self == HYSR::ENABLED
     }
 }
 #[doc = "Possible values of the field `INV`"]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum INVR {
     #[doc = "Input not inverted (HIGH on pin reads as 1, LOW on pin reads as 0)."]
-    INPUT_NOT_INVERTED_,
+    NOT_INVERTED,
     #[doc = "Input inverted (HIGH on pin reads as 0, LOW on pin reads as 1)."]
-    INPUT_INVERTED_HIGH,
+    INVERTED,
 }
 impl INVR {
     #[doc = r" Returns `true` if the bit is clear (0)"]
@@ -209,8 +209,8 @@ impl INVR {
     #[inline]
     pub fn bit(&self) -> bool {
         match *self {
-            INVR::INPUT_NOT_INVERTED_ => false,
-            INVR::INPUT_INVERTED_HIGH => true,
+            INVR::NOT_INVERTED => false,
+            INVR::INVERTED => true,
         }
     }
     #[allow(missing_docs)]
@@ -218,28 +218,28 @@ impl INVR {
     #[inline]
     pub fn _from(value: bool) -> INVR {
         match value {
-            false => INVR::INPUT_NOT_INVERTED_,
-            true => INVR::INPUT_INVERTED_HIGH,
+            false => INVR::NOT_INVERTED,
+            true => INVR::INVERTED,
         }
     }
-    #[doc = "Checks if the value of the field is `INPUT_NOT_INVERTED_`"]
+    #[doc = "Checks if the value of the field is `NOT_INVERTED`"]
     #[inline]
-    pub fn is_input_not_inverted_(&self) -> bool {
-        *self == INVR::INPUT_NOT_INVERTED_
+    pub fn is_not_inverted(&self) -> bool {
+        *self == INVR::NOT_INVERTED
     }
-    #[doc = "Checks if the value of the field is `INPUT_INVERTED_HIGH`"]
+    #[doc = "Checks if the value of the field is `INVERTED`"]
     #[inline]
-    pub fn is_input_inverted_high(&self) -> bool {
-        *self == INVR::INPUT_INVERTED_HIGH
+    pub fn is_inverted(&self) -> bool {
+        *self == INVR::INVERTED
     }
 }
 #[doc = "Possible values of the field `OD`"]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum ODR {
     #[doc = "Disable."]
-    DISABLE_,
+    DISABLED,
     #[doc = "Open-drain mode enabled.  This is not a true open-drain mode."]
-    OPEN_DRAIN_MODE_ENAB,
+    OPEN_DRAIN,
 }
 impl ODR {
     #[doc = r" Returns `true` if the bit is clear (0)"]
@@ -256,8 +256,8 @@ impl ODR {
     #[inline]
     pub fn bit(&self) -> bool {
         match *self {
-            ODR::DISABLE_ => false,
-            ODR::OPEN_DRAIN_MODE_ENAB => true,
+            ODR::DISABLED => false,
+            ODR::OPEN_DRAIN => true,
         }
     }
     #[allow(missing_docs)]
@@ -265,27 +265,27 @@ impl ODR {
     #[inline]
     pub fn _from(value: bool) -> ODR {
         match value {
-            false => ODR::DISABLE_,
-            true => ODR::OPEN_DRAIN_MODE_ENAB,
+            false => ODR::DISABLED,
+            true => ODR::OPEN_DRAIN,
         }
     }
-    #[doc = "Checks if the value of the field is `DISABLE_`"]
+    #[doc = "Checks if the value of the field is `DISABLED`"]
     #[inline]
-    pub fn is_disable_(&self) -> bool {
-        *self == ODR::DISABLE_
+    pub fn is_disabled(&self) -> bool {
+        *self == ODR::DISABLED
     }
-    #[doc = "Checks if the value of the field is `OPEN_DRAIN_MODE_ENAB`"]
+    #[doc = "Checks if the value of the field is `OPEN_DRAIN`"]
     #[inline]
-    pub fn is_open_drain_mode_enab(&self) -> bool {
-        *self == ODR::OPEN_DRAIN_MODE_ENAB
+    pub fn is_open_drain(&self) -> bool {
+        *self == ODR::OPEN_DRAIN
     }
 }
 #[doc = "Values that can be written to the field `FUNC`"]
 pub enum FUNCW {
     #[doc = "PIO1_25."]
-    PIO1_25_,
+    PIO1_25,
     #[doc = "CT32B0_MAT1."]
-    CT32B0_MAT1_,
+    CT32B0_MAT1,
 }
 impl FUNCW {
     #[allow(missing_docs)]
@@ -293,8 +293,8 @@ impl FUNCW {
     #[inline]
     pub fn _bits(&self) -> u8 {
         match *self {
-            FUNCW::PIO1_25_ => 0,
-            FUNCW::CT32B0_MAT1_ => 1,
+            FUNCW::PIO1_25 => 0,
+            FUNCW::CT32B0_MAT1 => 1,
         }
     }
 }
@@ -310,13 +310,13 @@ impl<'a> _FUNCW<'a> {
     }
     #[doc = "PIO1_25."]
     #[inline]
-    pub fn pio1_25_(self) -> &'a mut W {
-        self.variant(FUNCW::PIO1_25_)
+    pub fn pio1_25(self) -> &'a mut W {
+        self.variant(FUNCW::PIO1_25)
     }
     #[doc = "CT32B0_MAT1."]
     #[inline]
-    pub fn ct32b0_mat1_(self) -> &'a mut W {
-        self.variant(FUNCW::CT32B0_MAT1_)
+    pub fn ct32b0_mat1(self) -> &'a mut W {
+        self.variant(FUNCW::CT32B0_MAT1)
     }
     #[doc = r" Writes raw bits to the field"]
     #[inline]
@@ -331,13 +331,13 @@ impl<'a> _FUNCW<'a> {
 #[doc = "Values that can be written to the field `MODE`"]
 pub enum MODEW {
     #[doc = "Inactive (no pull-down/pull-up resistor enabled)."]
-    INACTIVE_NO_PULL_DO,
+    INACTIVE,
     #[doc = "Pull-down resistor enabled."]
-    PULL_DOWN_RESISTOR_E,
+    PULL_DOWN,
     #[doc = "Pull-up resistor enabled."]
-    PULL_UP_RESISTOR_ENA,
+    PULL_UP,
     #[doc = "Repeater mode."]
-    REPEATER_MODE_,
+    REPEATER,
 }
 impl MODEW {
     #[allow(missing_docs)]
@@ -345,10 +345,10 @@ impl MODEW {
     #[inline]
     pub fn _bits(&self) -> u8 {
         match *self {
-            MODEW::INACTIVE_NO_PULL_DO => 0,
-            MODEW::PULL_DOWN_RESISTOR_E => 1,
-            MODEW::PULL_UP_RESISTOR_ENA => 2,
-            MODEW::REPEATER_MODE_ => 3,
+            MODEW::INACTIVE => 0,
+            MODEW::PULL_DOWN => 1,
+            MODEW::PULL_UP => 2,
+            MODEW::REPEATER => 3,
         }
     }
 }
@@ -366,23 +366,23 @@ impl<'a> _MODEW<'a> {
     }
     #[doc = "Inactive (no pull-down/pull-up resistor enabled)."]
     #[inline]
-    pub fn inactive_no_pull_do(self) -> &'a mut W {
-        self.variant(MODEW::INACTIVE_NO_PULL_DO)
+    pub fn inactive(self) -> &'a mut W {
+        self.variant(MODEW::INACTIVE)
     }
     #[doc = "Pull-down resistor enabled."]
     #[inline]
-    pub fn pull_down_resistor_e(self) -> &'a mut W {
-        self.variant(MODEW::PULL_DOWN_RESISTOR_E)
+    pub fn pull_down(self) -> &'a mut W {
+        self.variant(MODEW::PULL_DOWN)
     }
     #[doc = "Pull-up resistor enabled."]
     #[inline]
-    pub fn pull_up_resistor_ena(self) -> &'a mut W {
-        self.variant(MODEW::PULL_UP_RESISTOR_ENA)
+    pub fn pull_up(self) -> &'a mut W {
+        self.variant(MODEW::PULL_UP)
     }
     #[doc = "Repeater mode."]
     #[inline]
-    pub fn repeater_mode_(self) -> &'a mut W {
-        self.variant(MODEW::REPEATER_MODE_)
+    pub fn repeater(self) -> &'a mut W {
+        self.variant(MODEW::REPEATER)
     }
     #[doc = r" Writes raw bits to the field"]
     #[inline]
@@ -397,9 +397,9 @@ impl<'a> _MODEW<'a> {
 #[doc = "Values that can be written to the field `HYS`"]
 pub enum HYSW {
     #[doc = "Disable."]
-    DISABLE_,
+    DISABLED,
     #[doc = "Enable."]
-    ENABLE_,
+    ENABLED,
 }
 impl HYSW {
     #[allow(missing_docs)]
@@ -407,8 +407,8 @@ impl HYSW {
     #[inline]
     pub fn _bits(&self) -> bool {
         match *self {
-            HYSW::DISABLE_ => false,
-            HYSW::ENABLE_ => true,
+            HYSW::DISABLED => false,
+            HYSW::ENABLED => true,
         }
     }
 }
@@ -426,13 +426,13 @@ impl<'a> _HYSW<'a> {
     }
     #[doc = "Disable."]
     #[inline]
-    pub fn disable_(self) -> &'a mut W {
-        self.variant(HYSW::DISABLE_)
+    pub fn disabled(self) -> &'a mut W {
+        self.variant(HYSW::DISABLED)
     }
     #[doc = "Enable."]
     #[inline]
-    pub fn enable_(self) -> &'a mut W {
-        self.variant(HYSW::ENABLE_)
+    pub fn enabled(self) -> &'a mut W {
+        self.variant(HYSW::ENABLED)
     }
     #[doc = r" Sets the field bit"]
     pub fn set_bit(self) -> &'a mut W {
@@ -455,9 +455,9 @@ impl<'a> _HYSW<'a> {
 #[doc = "Values that can be written to the field `INV`"]
 pub enum INVW {
     #[doc = "Input not inverted (HIGH on pin reads as 1, LOW on pin reads as 0)."]
-    INPUT_NOT_INVERTED_,
+    NOT_INVERTED,
     #[doc = "Input inverted (HIGH on pin reads as 0, LOW on pin reads as 1)."]
-    INPUT_INVERTED_HIGH,
+    INVERTED,
 }
 impl INVW {
     #[allow(missing_docs)]
@@ -465,8 +465,8 @@ impl INVW {
     #[inline]
     pub fn _bits(&self) -> bool {
         match *self {
-            INVW::INPUT_NOT_INVERTED_ => false,
-            INVW::INPUT_INVERTED_HIGH => true,
+            INVW::NOT_INVERTED => false,
+            INVW::INVERTED => true,
         }
     }
 }
@@ -484,13 +484,13 @@ impl<'a> _INVW<'a> {
     }
     #[doc = "Input not inverted (HIGH on pin reads as 1, LOW on pin reads as 0)."]
     #[inline]
-    pub fn input_not_inverted_(self) -> &'a mut W {
-        self.variant(INVW::INPUT_NOT_INVERTED_)
+    pub fn not_inverted(self) -> &'a mut W {
+        self.variant(INVW::NOT_INVERTED)
     }
     #[doc = "Input inverted (HIGH on pin reads as 0, LOW on pin reads as 1)."]
     #[inline]
-    pub fn input_inverted_high(self) -> &'a mut W {
-        self.variant(INVW::INPUT_INVERTED_HIGH)
+    pub fn inverted(self) -> &'a mut W {
+        self.variant(INVW::INVERTED)
     }
     #[doc = r" Sets the field bit"]
     pub fn set_bit(self) -> &'a mut W {
@@ -513,9 +513,9 @@ impl<'a> _INVW<'a> {
 #[doc = "Values that can be written to the field `OD`"]
 pub enum ODW {
     #[doc = "Disable."]
-    DISABLE_,
+    DISABLED,
     #[doc = "Open-drain mode enabled.  This is not a true open-drain mode."]
-    OPEN_DRAIN_MODE_ENAB,
+    OPEN_DRAIN,
 }
 impl ODW {
     #[allow(missing_docs)]
@@ -523,8 +523,8 @@ impl ODW {
     #[inline]
     pub fn _bits(&self) -> bool {
         match *self {
-            ODW::DISABLE_ => false,
-            ODW::OPEN_DRAIN_MODE_ENAB => true,
+            ODW::DISABLED => false,
+            ODW::OPEN_DRAIN => true,
         }
     }
 }
@@ -542,13 +542,13 @@ impl<'a> _ODW<'a> {
     }
     #[doc = "Disable."]
     #[inline]
-    pub fn disable_(self) -> &'a mut W {
-        self.variant(ODW::DISABLE_)
+    pub fn disabled(self) -> &'a mut W {
+        self.variant(ODW::DISABLED)
     }
     #[doc = "Open-drain mode enabled. This is not a true open-drain mode."]
     #[inline]
-    pub fn open_drain_mode_enab(self) -> &'a mut W {
-        self.variant(ODW::OPEN_DRAIN_MODE_ENAB)
+    pub fn open_drain(self) -> &'a mut W {
+        self.variant(ODW::OPEN_DRAIN)
     }
     #[doc = r" Sets the field bit"]
     pub fn set_bit(self) -> &'a mut W {

--- a/lpc11uxx/src/iocon/pio1_26.rs
+++ b/lpc11uxx/src/iocon/pio1_26.rs
@@ -46,11 +46,11 @@ impl super::PIO1_26 {
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum FUNCR {
     #[doc = "PIO1_26."]
-    PIO1_26_,
+    PIO1_26,
     #[doc = "CT32B0_MAT2"]
     CT32B0_MAT2,
     #[doc = "RXD."]
-    RXD_,
+    RXD,
     #[doc = r" Reserved"]
     _Reserved(u8),
 }
@@ -59,9 +59,9 @@ impl FUNCR {
     #[inline]
     pub fn bits(&self) -> u8 {
         match *self {
-            FUNCR::PIO1_26_ => 0,
+            FUNCR::PIO1_26 => 0,
             FUNCR::CT32B0_MAT2 => 1,
-            FUNCR::RXD_ => 2,
+            FUNCR::RXD => 2,
             FUNCR::_Reserved(bits) => bits,
         }
     }
@@ -70,49 +70,49 @@ impl FUNCR {
     #[inline]
     pub fn _from(value: u8) -> FUNCR {
         match value {
-            0 => FUNCR::PIO1_26_,
+            0 => FUNCR::PIO1_26,
             1 => FUNCR::CT32B0_MAT2,
-            2 => FUNCR::RXD_,
+            2 => FUNCR::RXD,
             i => FUNCR::_Reserved(i),
         }
     }
-    #[doc = "Checks if the value of the field is `PIO1_26_`"]
+    #[doc = "Checks if the value of the field is `PIO1_26`"]
     #[inline]
-    pub fn is_pio1_26_(&self) -> bool {
-        *self == FUNCR::PIO1_26_
+    pub fn is_pio1_26(&self) -> bool {
+        *self == FUNCR::PIO1_26
     }
     #[doc = "Checks if the value of the field is `CT32B0_MAT2`"]
     #[inline]
     pub fn is_ct32b0_mat2(&self) -> bool {
         *self == FUNCR::CT32B0_MAT2
     }
-    #[doc = "Checks if the value of the field is `RXD_`"]
+    #[doc = "Checks if the value of the field is `RXD`"]
     #[inline]
-    pub fn is_rxd_(&self) -> bool {
-        *self == FUNCR::RXD_
+    pub fn is_rxd(&self) -> bool {
+        *self == FUNCR::RXD
     }
 }
 #[doc = "Possible values of the field `MODE`"]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum MODER {
     #[doc = "Inactive (no pull-down/pull-up resistor enabled)."]
-    INACTIVE_NO_PULL_DO,
+    INACTIVE,
     #[doc = "Pull-down resistor enabled."]
-    PULL_DOWN_RESISTOR_E,
+    PULL_DOWN,
     #[doc = "Pull-up resistor enabled."]
-    PULL_UP_RESISTOR_ENA,
+    PULL_UP,
     #[doc = "Repeater mode."]
-    REPEATER_MODE_,
+    REPEATER,
 }
 impl MODER {
     #[doc = r" Value of the field as raw bits"]
     #[inline]
     pub fn bits(&self) -> u8 {
         match *self {
-            MODER::INACTIVE_NO_PULL_DO => 0,
-            MODER::PULL_DOWN_RESISTOR_E => 1,
-            MODER::PULL_UP_RESISTOR_ENA => 2,
-            MODER::REPEATER_MODE_ => 3,
+            MODER::INACTIVE => 0,
+            MODER::PULL_DOWN => 1,
+            MODER::PULL_UP => 2,
+            MODER::REPEATER => 3,
         }
     }
     #[allow(missing_docs)]
@@ -120,41 +120,41 @@ impl MODER {
     #[inline]
     pub fn _from(value: u8) -> MODER {
         match value {
-            0 => MODER::INACTIVE_NO_PULL_DO,
-            1 => MODER::PULL_DOWN_RESISTOR_E,
-            2 => MODER::PULL_UP_RESISTOR_ENA,
-            3 => MODER::REPEATER_MODE_,
+            0 => MODER::INACTIVE,
+            1 => MODER::PULL_DOWN,
+            2 => MODER::PULL_UP,
+            3 => MODER::REPEATER,
             _ => unreachable!(),
         }
     }
-    #[doc = "Checks if the value of the field is `INACTIVE_NO_PULL_DO`"]
+    #[doc = "Checks if the value of the field is `INACTIVE`"]
     #[inline]
-    pub fn is_inactive_no_pull_do(&self) -> bool {
-        *self == MODER::INACTIVE_NO_PULL_DO
+    pub fn is_inactive(&self) -> bool {
+        *self == MODER::INACTIVE
     }
-    #[doc = "Checks if the value of the field is `PULL_DOWN_RESISTOR_E`"]
+    #[doc = "Checks if the value of the field is `PULL_DOWN`"]
     #[inline]
-    pub fn is_pull_down_resistor_e(&self) -> bool {
-        *self == MODER::PULL_DOWN_RESISTOR_E
+    pub fn is_pull_down(&self) -> bool {
+        *self == MODER::PULL_DOWN
     }
-    #[doc = "Checks if the value of the field is `PULL_UP_RESISTOR_ENA`"]
+    #[doc = "Checks if the value of the field is `PULL_UP`"]
     #[inline]
-    pub fn is_pull_up_resistor_ena(&self) -> bool {
-        *self == MODER::PULL_UP_RESISTOR_ENA
+    pub fn is_pull_up(&self) -> bool {
+        *self == MODER::PULL_UP
     }
-    #[doc = "Checks if the value of the field is `REPEATER_MODE_`"]
+    #[doc = "Checks if the value of the field is `REPEATER`"]
     #[inline]
-    pub fn is_repeater_mode_(&self) -> bool {
-        *self == MODER::REPEATER_MODE_
+    pub fn is_repeater(&self) -> bool {
+        *self == MODER::REPEATER
     }
 }
 #[doc = "Possible values of the field `HYS`"]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum HYSR {
     #[doc = "Disable."]
-    DISABLE_,
+    DISABLED,
     #[doc = "Enable."]
-    ENABLE_,
+    ENABLED,
 }
 impl HYSR {
     #[doc = r" Returns `true` if the bit is clear (0)"]
@@ -171,8 +171,8 @@ impl HYSR {
     #[inline]
     pub fn bit(&self) -> bool {
         match *self {
-            HYSR::DISABLE_ => false,
-            HYSR::ENABLE_ => true,
+            HYSR::DISABLED => false,
+            HYSR::ENABLED => true,
         }
     }
     #[allow(missing_docs)]
@@ -180,28 +180,28 @@ impl HYSR {
     #[inline]
     pub fn _from(value: bool) -> HYSR {
         match value {
-            false => HYSR::DISABLE_,
-            true => HYSR::ENABLE_,
+            false => HYSR::DISABLED,
+            true => HYSR::ENABLED,
         }
     }
-    #[doc = "Checks if the value of the field is `DISABLE_`"]
+    #[doc = "Checks if the value of the field is `DISABLED`"]
     #[inline]
-    pub fn is_disable_(&self) -> bool {
-        *self == HYSR::DISABLE_
+    pub fn is_disabled(&self) -> bool {
+        *self == HYSR::DISABLED
     }
-    #[doc = "Checks if the value of the field is `ENABLE_`"]
+    #[doc = "Checks if the value of the field is `ENABLED`"]
     #[inline]
-    pub fn is_enable_(&self) -> bool {
-        *self == HYSR::ENABLE_
+    pub fn is_enabled(&self) -> bool {
+        *self == HYSR::ENABLED
     }
 }
 #[doc = "Possible values of the field `INV`"]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum INVR {
     #[doc = "Input not inverted (HIGH on pin reads as 1, LOW on pin reads as 0)."]
-    INPUT_NOT_INVERTED_,
+    NOT_INVERTED,
     #[doc = "Input inverted (HIGH on pin reads as 0, LOW on pin reads as 1)."]
-    INPUT_INVERTED_HIGH,
+    INVERTED,
 }
 impl INVR {
     #[doc = r" Returns `true` if the bit is clear (0)"]
@@ -218,8 +218,8 @@ impl INVR {
     #[inline]
     pub fn bit(&self) -> bool {
         match *self {
-            INVR::INPUT_NOT_INVERTED_ => false,
-            INVR::INPUT_INVERTED_HIGH => true,
+            INVR::NOT_INVERTED => false,
+            INVR::INVERTED => true,
         }
     }
     #[allow(missing_docs)]
@@ -227,28 +227,28 @@ impl INVR {
     #[inline]
     pub fn _from(value: bool) -> INVR {
         match value {
-            false => INVR::INPUT_NOT_INVERTED_,
-            true => INVR::INPUT_INVERTED_HIGH,
+            false => INVR::NOT_INVERTED,
+            true => INVR::INVERTED,
         }
     }
-    #[doc = "Checks if the value of the field is `INPUT_NOT_INVERTED_`"]
+    #[doc = "Checks if the value of the field is `NOT_INVERTED`"]
     #[inline]
-    pub fn is_input_not_inverted_(&self) -> bool {
-        *self == INVR::INPUT_NOT_INVERTED_
+    pub fn is_not_inverted(&self) -> bool {
+        *self == INVR::NOT_INVERTED
     }
-    #[doc = "Checks if the value of the field is `INPUT_INVERTED_HIGH`"]
+    #[doc = "Checks if the value of the field is `INVERTED`"]
     #[inline]
-    pub fn is_input_inverted_high(&self) -> bool {
-        *self == INVR::INPUT_INVERTED_HIGH
+    pub fn is_inverted(&self) -> bool {
+        *self == INVR::INVERTED
     }
 }
 #[doc = "Possible values of the field `OD`"]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum ODR {
     #[doc = "Disable."]
-    DISABLE_,
+    DISABLED,
     #[doc = "Open-drain mode enabled.  This is not a true open-drain mode."]
-    OPEN_DRAIN_MODE_ENAB,
+    OPEN_DRAIN,
 }
 impl ODR {
     #[doc = r" Returns `true` if the bit is clear (0)"]
@@ -265,8 +265,8 @@ impl ODR {
     #[inline]
     pub fn bit(&self) -> bool {
         match *self {
-            ODR::DISABLE_ => false,
-            ODR::OPEN_DRAIN_MODE_ENAB => true,
+            ODR::DISABLED => false,
+            ODR::OPEN_DRAIN => true,
         }
     }
     #[allow(missing_docs)]
@@ -274,29 +274,29 @@ impl ODR {
     #[inline]
     pub fn _from(value: bool) -> ODR {
         match value {
-            false => ODR::DISABLE_,
-            true => ODR::OPEN_DRAIN_MODE_ENAB,
+            false => ODR::DISABLED,
+            true => ODR::OPEN_DRAIN,
         }
     }
-    #[doc = "Checks if the value of the field is `DISABLE_`"]
+    #[doc = "Checks if the value of the field is `DISABLED`"]
     #[inline]
-    pub fn is_disable_(&self) -> bool {
-        *self == ODR::DISABLE_
+    pub fn is_disabled(&self) -> bool {
+        *self == ODR::DISABLED
     }
-    #[doc = "Checks if the value of the field is `OPEN_DRAIN_MODE_ENAB`"]
+    #[doc = "Checks if the value of the field is `OPEN_DRAIN`"]
     #[inline]
-    pub fn is_open_drain_mode_enab(&self) -> bool {
-        *self == ODR::OPEN_DRAIN_MODE_ENAB
+    pub fn is_open_drain(&self) -> bool {
+        *self == ODR::OPEN_DRAIN
     }
 }
 #[doc = "Values that can be written to the field `FUNC`"]
 pub enum FUNCW {
     #[doc = "PIO1_26."]
-    PIO1_26_,
+    PIO1_26,
     #[doc = "CT32B0_MAT2"]
     CT32B0_MAT2,
     #[doc = "RXD."]
-    RXD_,
+    RXD,
 }
 impl FUNCW {
     #[allow(missing_docs)]
@@ -304,9 +304,9 @@ impl FUNCW {
     #[inline]
     pub fn _bits(&self) -> u8 {
         match *self {
-            FUNCW::PIO1_26_ => 0,
+            FUNCW::PIO1_26 => 0,
             FUNCW::CT32B0_MAT2 => 1,
-            FUNCW::RXD_ => 2,
+            FUNCW::RXD => 2,
         }
     }
 }
@@ -322,8 +322,8 @@ impl<'a> _FUNCW<'a> {
     }
     #[doc = "PIO1_26."]
     #[inline]
-    pub fn pio1_26_(self) -> &'a mut W {
-        self.variant(FUNCW::PIO1_26_)
+    pub fn pio1_26(self) -> &'a mut W {
+        self.variant(FUNCW::PIO1_26)
     }
     #[doc = "CT32B0_MAT2"]
     #[inline]
@@ -332,8 +332,8 @@ impl<'a> _FUNCW<'a> {
     }
     #[doc = "RXD."]
     #[inline]
-    pub fn rxd_(self) -> &'a mut W {
-        self.variant(FUNCW::RXD_)
+    pub fn rxd(self) -> &'a mut W {
+        self.variant(FUNCW::RXD)
     }
     #[doc = r" Writes raw bits to the field"]
     #[inline]
@@ -348,13 +348,13 @@ impl<'a> _FUNCW<'a> {
 #[doc = "Values that can be written to the field `MODE`"]
 pub enum MODEW {
     #[doc = "Inactive (no pull-down/pull-up resistor enabled)."]
-    INACTIVE_NO_PULL_DO,
+    INACTIVE,
     #[doc = "Pull-down resistor enabled."]
-    PULL_DOWN_RESISTOR_E,
+    PULL_DOWN,
     #[doc = "Pull-up resistor enabled."]
-    PULL_UP_RESISTOR_ENA,
+    PULL_UP,
     #[doc = "Repeater mode."]
-    REPEATER_MODE_,
+    REPEATER,
 }
 impl MODEW {
     #[allow(missing_docs)]
@@ -362,10 +362,10 @@ impl MODEW {
     #[inline]
     pub fn _bits(&self) -> u8 {
         match *self {
-            MODEW::INACTIVE_NO_PULL_DO => 0,
-            MODEW::PULL_DOWN_RESISTOR_E => 1,
-            MODEW::PULL_UP_RESISTOR_ENA => 2,
-            MODEW::REPEATER_MODE_ => 3,
+            MODEW::INACTIVE => 0,
+            MODEW::PULL_DOWN => 1,
+            MODEW::PULL_UP => 2,
+            MODEW::REPEATER => 3,
         }
     }
 }
@@ -383,23 +383,23 @@ impl<'a> _MODEW<'a> {
     }
     #[doc = "Inactive (no pull-down/pull-up resistor enabled)."]
     #[inline]
-    pub fn inactive_no_pull_do(self) -> &'a mut W {
-        self.variant(MODEW::INACTIVE_NO_PULL_DO)
+    pub fn inactive(self) -> &'a mut W {
+        self.variant(MODEW::INACTIVE)
     }
     #[doc = "Pull-down resistor enabled."]
     #[inline]
-    pub fn pull_down_resistor_e(self) -> &'a mut W {
-        self.variant(MODEW::PULL_DOWN_RESISTOR_E)
+    pub fn pull_down(self) -> &'a mut W {
+        self.variant(MODEW::PULL_DOWN)
     }
     #[doc = "Pull-up resistor enabled."]
     #[inline]
-    pub fn pull_up_resistor_ena(self) -> &'a mut W {
-        self.variant(MODEW::PULL_UP_RESISTOR_ENA)
+    pub fn pull_up(self) -> &'a mut W {
+        self.variant(MODEW::PULL_UP)
     }
     #[doc = "Repeater mode."]
     #[inline]
-    pub fn repeater_mode_(self) -> &'a mut W {
-        self.variant(MODEW::REPEATER_MODE_)
+    pub fn repeater(self) -> &'a mut W {
+        self.variant(MODEW::REPEATER)
     }
     #[doc = r" Writes raw bits to the field"]
     #[inline]
@@ -414,9 +414,9 @@ impl<'a> _MODEW<'a> {
 #[doc = "Values that can be written to the field `HYS`"]
 pub enum HYSW {
     #[doc = "Disable."]
-    DISABLE_,
+    DISABLED,
     #[doc = "Enable."]
-    ENABLE_,
+    ENABLED,
 }
 impl HYSW {
     #[allow(missing_docs)]
@@ -424,8 +424,8 @@ impl HYSW {
     #[inline]
     pub fn _bits(&self) -> bool {
         match *self {
-            HYSW::DISABLE_ => false,
-            HYSW::ENABLE_ => true,
+            HYSW::DISABLED => false,
+            HYSW::ENABLED => true,
         }
     }
 }
@@ -443,13 +443,13 @@ impl<'a> _HYSW<'a> {
     }
     #[doc = "Disable."]
     #[inline]
-    pub fn disable_(self) -> &'a mut W {
-        self.variant(HYSW::DISABLE_)
+    pub fn disabled(self) -> &'a mut W {
+        self.variant(HYSW::DISABLED)
     }
     #[doc = "Enable."]
     #[inline]
-    pub fn enable_(self) -> &'a mut W {
-        self.variant(HYSW::ENABLE_)
+    pub fn enabled(self) -> &'a mut W {
+        self.variant(HYSW::ENABLED)
     }
     #[doc = r" Sets the field bit"]
     pub fn set_bit(self) -> &'a mut W {
@@ -472,9 +472,9 @@ impl<'a> _HYSW<'a> {
 #[doc = "Values that can be written to the field `INV`"]
 pub enum INVW {
     #[doc = "Input not inverted (HIGH on pin reads as 1, LOW on pin reads as 0)."]
-    INPUT_NOT_INVERTED_,
+    NOT_INVERTED,
     #[doc = "Input inverted (HIGH on pin reads as 0, LOW on pin reads as 1)."]
-    INPUT_INVERTED_HIGH,
+    INVERTED,
 }
 impl INVW {
     #[allow(missing_docs)]
@@ -482,8 +482,8 @@ impl INVW {
     #[inline]
     pub fn _bits(&self) -> bool {
         match *self {
-            INVW::INPUT_NOT_INVERTED_ => false,
-            INVW::INPUT_INVERTED_HIGH => true,
+            INVW::NOT_INVERTED => false,
+            INVW::INVERTED => true,
         }
     }
 }
@@ -501,13 +501,13 @@ impl<'a> _INVW<'a> {
     }
     #[doc = "Input not inverted (HIGH on pin reads as 1, LOW on pin reads as 0)."]
     #[inline]
-    pub fn input_not_inverted_(self) -> &'a mut W {
-        self.variant(INVW::INPUT_NOT_INVERTED_)
+    pub fn not_inverted(self) -> &'a mut W {
+        self.variant(INVW::NOT_INVERTED)
     }
     #[doc = "Input inverted (HIGH on pin reads as 0, LOW on pin reads as 1)."]
     #[inline]
-    pub fn input_inverted_high(self) -> &'a mut W {
-        self.variant(INVW::INPUT_INVERTED_HIGH)
+    pub fn inverted(self) -> &'a mut W {
+        self.variant(INVW::INVERTED)
     }
     #[doc = r" Sets the field bit"]
     pub fn set_bit(self) -> &'a mut W {
@@ -530,9 +530,9 @@ impl<'a> _INVW<'a> {
 #[doc = "Values that can be written to the field `OD`"]
 pub enum ODW {
     #[doc = "Disable."]
-    DISABLE_,
+    DISABLED,
     #[doc = "Open-drain mode enabled.  This is not a true open-drain mode."]
-    OPEN_DRAIN_MODE_ENAB,
+    OPEN_DRAIN,
 }
 impl ODW {
     #[allow(missing_docs)]
@@ -540,8 +540,8 @@ impl ODW {
     #[inline]
     pub fn _bits(&self) -> bool {
         match *self {
-            ODW::DISABLE_ => false,
-            ODW::OPEN_DRAIN_MODE_ENAB => true,
+            ODW::DISABLED => false,
+            ODW::OPEN_DRAIN => true,
         }
     }
 }
@@ -559,13 +559,13 @@ impl<'a> _ODW<'a> {
     }
     #[doc = "Disable."]
     #[inline]
-    pub fn disable_(self) -> &'a mut W {
-        self.variant(ODW::DISABLE_)
+    pub fn disabled(self) -> &'a mut W {
+        self.variant(ODW::DISABLED)
     }
     #[doc = "Open-drain mode enabled. This is not a true open-drain mode."]
     #[inline]
-    pub fn open_drain_mode_enab(self) -> &'a mut W {
-        self.variant(ODW::OPEN_DRAIN_MODE_ENAB)
+    pub fn open_drain(self) -> &'a mut W {
+        self.variant(ODW::OPEN_DRAIN)
     }
     #[doc = r" Sets the field bit"]
     pub fn set_bit(self) -> &'a mut W {

--- a/lpc11uxx/src/iocon/pio1_27.rs
+++ b/lpc11uxx/src/iocon/pio1_27.rs
@@ -46,11 +46,11 @@ impl super::PIO1_27 {
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum FUNCR {
     #[doc = "PIO1_27."]
-    PIO1_27_,
+    PIO1_27,
     #[doc = "CT32B0_MAT3."]
-    CT32B0_MAT3_,
+    CT32B0_MAT3,
     #[doc = "TXD."]
-    TXD_,
+    TXD,
     #[doc = r" Reserved"]
     _Reserved(u8),
 }
@@ -59,9 +59,9 @@ impl FUNCR {
     #[inline]
     pub fn bits(&self) -> u8 {
         match *self {
-            FUNCR::PIO1_27_ => 0,
-            FUNCR::CT32B0_MAT3_ => 1,
-            FUNCR::TXD_ => 2,
+            FUNCR::PIO1_27 => 0,
+            FUNCR::CT32B0_MAT3 => 1,
+            FUNCR::TXD => 2,
             FUNCR::_Reserved(bits) => bits,
         }
     }
@@ -70,49 +70,49 @@ impl FUNCR {
     #[inline]
     pub fn _from(value: u8) -> FUNCR {
         match value {
-            0 => FUNCR::PIO1_27_,
-            1 => FUNCR::CT32B0_MAT3_,
-            2 => FUNCR::TXD_,
+            0 => FUNCR::PIO1_27,
+            1 => FUNCR::CT32B0_MAT3,
+            2 => FUNCR::TXD,
             i => FUNCR::_Reserved(i),
         }
     }
-    #[doc = "Checks if the value of the field is `PIO1_27_`"]
+    #[doc = "Checks if the value of the field is `PIO1_27`"]
     #[inline]
-    pub fn is_pio1_27_(&self) -> bool {
-        *self == FUNCR::PIO1_27_
+    pub fn is_pio1_27(&self) -> bool {
+        *self == FUNCR::PIO1_27
     }
-    #[doc = "Checks if the value of the field is `CT32B0_MAT3_`"]
+    #[doc = "Checks if the value of the field is `CT32B0_MAT3`"]
     #[inline]
-    pub fn is_ct32b0_mat3_(&self) -> bool {
-        *self == FUNCR::CT32B0_MAT3_
+    pub fn is_ct32b0_mat3(&self) -> bool {
+        *self == FUNCR::CT32B0_MAT3
     }
-    #[doc = "Checks if the value of the field is `TXD_`"]
+    #[doc = "Checks if the value of the field is `TXD`"]
     #[inline]
-    pub fn is_txd_(&self) -> bool {
-        *self == FUNCR::TXD_
+    pub fn is_txd(&self) -> bool {
+        *self == FUNCR::TXD
     }
 }
 #[doc = "Possible values of the field `MODE`"]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum MODER {
     #[doc = "Inactive (no pull-down/pull-up resistor enabled)."]
-    INACTIVE_NO_PULL_DO,
+    INACTIVE,
     #[doc = "Pull-down resistor enabled."]
-    PULL_DOWN_RESISTOR_E,
+    PULL_DOWN,
     #[doc = "Pull-up resistor enabled."]
-    PULL_UP_RESISTOR_ENA,
+    PULL_UP,
     #[doc = "Repeater mode."]
-    REPEATER_MODE_,
+    REPEATER,
 }
 impl MODER {
     #[doc = r" Value of the field as raw bits"]
     #[inline]
     pub fn bits(&self) -> u8 {
         match *self {
-            MODER::INACTIVE_NO_PULL_DO => 0,
-            MODER::PULL_DOWN_RESISTOR_E => 1,
-            MODER::PULL_UP_RESISTOR_ENA => 2,
-            MODER::REPEATER_MODE_ => 3,
+            MODER::INACTIVE => 0,
+            MODER::PULL_DOWN => 1,
+            MODER::PULL_UP => 2,
+            MODER::REPEATER => 3,
         }
     }
     #[allow(missing_docs)]
@@ -120,41 +120,41 @@ impl MODER {
     #[inline]
     pub fn _from(value: u8) -> MODER {
         match value {
-            0 => MODER::INACTIVE_NO_PULL_DO,
-            1 => MODER::PULL_DOWN_RESISTOR_E,
-            2 => MODER::PULL_UP_RESISTOR_ENA,
-            3 => MODER::REPEATER_MODE_,
+            0 => MODER::INACTIVE,
+            1 => MODER::PULL_DOWN,
+            2 => MODER::PULL_UP,
+            3 => MODER::REPEATER,
             _ => unreachable!(),
         }
     }
-    #[doc = "Checks if the value of the field is `INACTIVE_NO_PULL_DO`"]
+    #[doc = "Checks if the value of the field is `INACTIVE`"]
     #[inline]
-    pub fn is_inactive_no_pull_do(&self) -> bool {
-        *self == MODER::INACTIVE_NO_PULL_DO
+    pub fn is_inactive(&self) -> bool {
+        *self == MODER::INACTIVE
     }
-    #[doc = "Checks if the value of the field is `PULL_DOWN_RESISTOR_E`"]
+    #[doc = "Checks if the value of the field is `PULL_DOWN`"]
     #[inline]
-    pub fn is_pull_down_resistor_e(&self) -> bool {
-        *self == MODER::PULL_DOWN_RESISTOR_E
+    pub fn is_pull_down(&self) -> bool {
+        *self == MODER::PULL_DOWN
     }
-    #[doc = "Checks if the value of the field is `PULL_UP_RESISTOR_ENA`"]
+    #[doc = "Checks if the value of the field is `PULL_UP`"]
     #[inline]
-    pub fn is_pull_up_resistor_ena(&self) -> bool {
-        *self == MODER::PULL_UP_RESISTOR_ENA
+    pub fn is_pull_up(&self) -> bool {
+        *self == MODER::PULL_UP
     }
-    #[doc = "Checks if the value of the field is `REPEATER_MODE_`"]
+    #[doc = "Checks if the value of the field is `REPEATER`"]
     #[inline]
-    pub fn is_repeater_mode_(&self) -> bool {
-        *self == MODER::REPEATER_MODE_
+    pub fn is_repeater(&self) -> bool {
+        *self == MODER::REPEATER
     }
 }
 #[doc = "Possible values of the field `HYS`"]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum HYSR {
     #[doc = "Disable."]
-    DISABLE_,
+    DISABLED,
     #[doc = "Enable."]
-    ENABLE_,
+    ENABLED,
 }
 impl HYSR {
     #[doc = r" Returns `true` if the bit is clear (0)"]
@@ -171,8 +171,8 @@ impl HYSR {
     #[inline]
     pub fn bit(&self) -> bool {
         match *self {
-            HYSR::DISABLE_ => false,
-            HYSR::ENABLE_ => true,
+            HYSR::DISABLED => false,
+            HYSR::ENABLED => true,
         }
     }
     #[allow(missing_docs)]
@@ -180,28 +180,28 @@ impl HYSR {
     #[inline]
     pub fn _from(value: bool) -> HYSR {
         match value {
-            false => HYSR::DISABLE_,
-            true => HYSR::ENABLE_,
+            false => HYSR::DISABLED,
+            true => HYSR::ENABLED,
         }
     }
-    #[doc = "Checks if the value of the field is `DISABLE_`"]
+    #[doc = "Checks if the value of the field is `DISABLED`"]
     #[inline]
-    pub fn is_disable_(&self) -> bool {
-        *self == HYSR::DISABLE_
+    pub fn is_disabled(&self) -> bool {
+        *self == HYSR::DISABLED
     }
-    #[doc = "Checks if the value of the field is `ENABLE_`"]
+    #[doc = "Checks if the value of the field is `ENABLED`"]
     #[inline]
-    pub fn is_enable_(&self) -> bool {
-        *self == HYSR::ENABLE_
+    pub fn is_enabled(&self) -> bool {
+        *self == HYSR::ENABLED
     }
 }
 #[doc = "Possible values of the field `INV`"]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum INVR {
     #[doc = "Input not inverted (HIGH on pin reads as 1, LOW on pin reads as 0)."]
-    INPUT_NOT_INVERTED_,
+    NOT_INVERTED,
     #[doc = "Input inverted (HIGH on pin reads as 0, LOW on pin reads as 1)."]
-    INPUT_INVERTED_HIGH,
+    INVERTED,
 }
 impl INVR {
     #[doc = r" Returns `true` if the bit is clear (0)"]
@@ -218,8 +218,8 @@ impl INVR {
     #[inline]
     pub fn bit(&self) -> bool {
         match *self {
-            INVR::INPUT_NOT_INVERTED_ => false,
-            INVR::INPUT_INVERTED_HIGH => true,
+            INVR::NOT_INVERTED => false,
+            INVR::INVERTED => true,
         }
     }
     #[allow(missing_docs)]
@@ -227,28 +227,28 @@ impl INVR {
     #[inline]
     pub fn _from(value: bool) -> INVR {
         match value {
-            false => INVR::INPUT_NOT_INVERTED_,
-            true => INVR::INPUT_INVERTED_HIGH,
+            false => INVR::NOT_INVERTED,
+            true => INVR::INVERTED,
         }
     }
-    #[doc = "Checks if the value of the field is `INPUT_NOT_INVERTED_`"]
+    #[doc = "Checks if the value of the field is `NOT_INVERTED`"]
     #[inline]
-    pub fn is_input_not_inverted_(&self) -> bool {
-        *self == INVR::INPUT_NOT_INVERTED_
+    pub fn is_not_inverted(&self) -> bool {
+        *self == INVR::NOT_INVERTED
     }
-    #[doc = "Checks if the value of the field is `INPUT_INVERTED_HIGH`"]
+    #[doc = "Checks if the value of the field is `INVERTED`"]
     #[inline]
-    pub fn is_input_inverted_high(&self) -> bool {
-        *self == INVR::INPUT_INVERTED_HIGH
+    pub fn is_inverted(&self) -> bool {
+        *self == INVR::INVERTED
     }
 }
 #[doc = "Possible values of the field `OD`"]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum ODR {
     #[doc = "Disable."]
-    DISABLE_,
+    DISABLED,
     #[doc = "Open-drain mode enabled.  This is not a true open-drain mode."]
-    OPEN_DRAIN_MODE_ENAB,
+    OPEN_DRAIN,
 }
 impl ODR {
     #[doc = r" Returns `true` if the bit is clear (0)"]
@@ -265,8 +265,8 @@ impl ODR {
     #[inline]
     pub fn bit(&self) -> bool {
         match *self {
-            ODR::DISABLE_ => false,
-            ODR::OPEN_DRAIN_MODE_ENAB => true,
+            ODR::DISABLED => false,
+            ODR::OPEN_DRAIN => true,
         }
     }
     #[allow(missing_docs)]
@@ -274,29 +274,29 @@ impl ODR {
     #[inline]
     pub fn _from(value: bool) -> ODR {
         match value {
-            false => ODR::DISABLE_,
-            true => ODR::OPEN_DRAIN_MODE_ENAB,
+            false => ODR::DISABLED,
+            true => ODR::OPEN_DRAIN,
         }
     }
-    #[doc = "Checks if the value of the field is `DISABLE_`"]
+    #[doc = "Checks if the value of the field is `DISABLED`"]
     #[inline]
-    pub fn is_disable_(&self) -> bool {
-        *self == ODR::DISABLE_
+    pub fn is_disabled(&self) -> bool {
+        *self == ODR::DISABLED
     }
-    #[doc = "Checks if the value of the field is `OPEN_DRAIN_MODE_ENAB`"]
+    #[doc = "Checks if the value of the field is `OPEN_DRAIN`"]
     #[inline]
-    pub fn is_open_drain_mode_enab(&self) -> bool {
-        *self == ODR::OPEN_DRAIN_MODE_ENAB
+    pub fn is_open_drain(&self) -> bool {
+        *self == ODR::OPEN_DRAIN
     }
 }
 #[doc = "Values that can be written to the field `FUNC`"]
 pub enum FUNCW {
     #[doc = "PIO1_27."]
-    PIO1_27_,
+    PIO1_27,
     #[doc = "CT32B0_MAT3."]
-    CT32B0_MAT3_,
+    CT32B0_MAT3,
     #[doc = "TXD."]
-    TXD_,
+    TXD,
 }
 impl FUNCW {
     #[allow(missing_docs)]
@@ -304,9 +304,9 @@ impl FUNCW {
     #[inline]
     pub fn _bits(&self) -> u8 {
         match *self {
-            FUNCW::PIO1_27_ => 0,
-            FUNCW::CT32B0_MAT3_ => 1,
-            FUNCW::TXD_ => 2,
+            FUNCW::PIO1_27 => 0,
+            FUNCW::CT32B0_MAT3 => 1,
+            FUNCW::TXD => 2,
         }
     }
 }
@@ -322,18 +322,18 @@ impl<'a> _FUNCW<'a> {
     }
     #[doc = "PIO1_27."]
     #[inline]
-    pub fn pio1_27_(self) -> &'a mut W {
-        self.variant(FUNCW::PIO1_27_)
+    pub fn pio1_27(self) -> &'a mut W {
+        self.variant(FUNCW::PIO1_27)
     }
     #[doc = "CT32B0_MAT3."]
     #[inline]
-    pub fn ct32b0_mat3_(self) -> &'a mut W {
-        self.variant(FUNCW::CT32B0_MAT3_)
+    pub fn ct32b0_mat3(self) -> &'a mut W {
+        self.variant(FUNCW::CT32B0_MAT3)
     }
     #[doc = "TXD."]
     #[inline]
-    pub fn txd_(self) -> &'a mut W {
-        self.variant(FUNCW::TXD_)
+    pub fn txd(self) -> &'a mut W {
+        self.variant(FUNCW::TXD)
     }
     #[doc = r" Writes raw bits to the field"]
     #[inline]
@@ -348,13 +348,13 @@ impl<'a> _FUNCW<'a> {
 #[doc = "Values that can be written to the field `MODE`"]
 pub enum MODEW {
     #[doc = "Inactive (no pull-down/pull-up resistor enabled)."]
-    INACTIVE_NO_PULL_DO,
+    INACTIVE,
     #[doc = "Pull-down resistor enabled."]
-    PULL_DOWN_RESISTOR_E,
+    PULL_DOWN,
     #[doc = "Pull-up resistor enabled."]
-    PULL_UP_RESISTOR_ENA,
+    PULL_UP,
     #[doc = "Repeater mode."]
-    REPEATER_MODE_,
+    REPEATER,
 }
 impl MODEW {
     #[allow(missing_docs)]
@@ -362,10 +362,10 @@ impl MODEW {
     #[inline]
     pub fn _bits(&self) -> u8 {
         match *self {
-            MODEW::INACTIVE_NO_PULL_DO => 0,
-            MODEW::PULL_DOWN_RESISTOR_E => 1,
-            MODEW::PULL_UP_RESISTOR_ENA => 2,
-            MODEW::REPEATER_MODE_ => 3,
+            MODEW::INACTIVE => 0,
+            MODEW::PULL_DOWN => 1,
+            MODEW::PULL_UP => 2,
+            MODEW::REPEATER => 3,
         }
     }
 }
@@ -383,23 +383,23 @@ impl<'a> _MODEW<'a> {
     }
     #[doc = "Inactive (no pull-down/pull-up resistor enabled)."]
     #[inline]
-    pub fn inactive_no_pull_do(self) -> &'a mut W {
-        self.variant(MODEW::INACTIVE_NO_PULL_DO)
+    pub fn inactive(self) -> &'a mut W {
+        self.variant(MODEW::INACTIVE)
     }
     #[doc = "Pull-down resistor enabled."]
     #[inline]
-    pub fn pull_down_resistor_e(self) -> &'a mut W {
-        self.variant(MODEW::PULL_DOWN_RESISTOR_E)
+    pub fn pull_down(self) -> &'a mut W {
+        self.variant(MODEW::PULL_DOWN)
     }
     #[doc = "Pull-up resistor enabled."]
     #[inline]
-    pub fn pull_up_resistor_ena(self) -> &'a mut W {
-        self.variant(MODEW::PULL_UP_RESISTOR_ENA)
+    pub fn pull_up(self) -> &'a mut W {
+        self.variant(MODEW::PULL_UP)
     }
     #[doc = "Repeater mode."]
     #[inline]
-    pub fn repeater_mode_(self) -> &'a mut W {
-        self.variant(MODEW::REPEATER_MODE_)
+    pub fn repeater(self) -> &'a mut W {
+        self.variant(MODEW::REPEATER)
     }
     #[doc = r" Writes raw bits to the field"]
     #[inline]
@@ -414,9 +414,9 @@ impl<'a> _MODEW<'a> {
 #[doc = "Values that can be written to the field `HYS`"]
 pub enum HYSW {
     #[doc = "Disable."]
-    DISABLE_,
+    DISABLED,
     #[doc = "Enable."]
-    ENABLE_,
+    ENABLED,
 }
 impl HYSW {
     #[allow(missing_docs)]
@@ -424,8 +424,8 @@ impl HYSW {
     #[inline]
     pub fn _bits(&self) -> bool {
         match *self {
-            HYSW::DISABLE_ => false,
-            HYSW::ENABLE_ => true,
+            HYSW::DISABLED => false,
+            HYSW::ENABLED => true,
         }
     }
 }
@@ -443,13 +443,13 @@ impl<'a> _HYSW<'a> {
     }
     #[doc = "Disable."]
     #[inline]
-    pub fn disable_(self) -> &'a mut W {
-        self.variant(HYSW::DISABLE_)
+    pub fn disabled(self) -> &'a mut W {
+        self.variant(HYSW::DISABLED)
     }
     #[doc = "Enable."]
     #[inline]
-    pub fn enable_(self) -> &'a mut W {
-        self.variant(HYSW::ENABLE_)
+    pub fn enabled(self) -> &'a mut W {
+        self.variant(HYSW::ENABLED)
     }
     #[doc = r" Sets the field bit"]
     pub fn set_bit(self) -> &'a mut W {
@@ -472,9 +472,9 @@ impl<'a> _HYSW<'a> {
 #[doc = "Values that can be written to the field `INV`"]
 pub enum INVW {
     #[doc = "Input not inverted (HIGH on pin reads as 1, LOW on pin reads as 0)."]
-    INPUT_NOT_INVERTED_,
+    NOT_INVERTED,
     #[doc = "Input inverted (HIGH on pin reads as 0, LOW on pin reads as 1)."]
-    INPUT_INVERTED_HIGH,
+    INVERTED,
 }
 impl INVW {
     #[allow(missing_docs)]
@@ -482,8 +482,8 @@ impl INVW {
     #[inline]
     pub fn _bits(&self) -> bool {
         match *self {
-            INVW::INPUT_NOT_INVERTED_ => false,
-            INVW::INPUT_INVERTED_HIGH => true,
+            INVW::NOT_INVERTED => false,
+            INVW::INVERTED => true,
         }
     }
 }
@@ -501,13 +501,13 @@ impl<'a> _INVW<'a> {
     }
     #[doc = "Input not inverted (HIGH on pin reads as 1, LOW on pin reads as 0)."]
     #[inline]
-    pub fn input_not_inverted_(self) -> &'a mut W {
-        self.variant(INVW::INPUT_NOT_INVERTED_)
+    pub fn not_inverted(self) -> &'a mut W {
+        self.variant(INVW::NOT_INVERTED)
     }
     #[doc = "Input inverted (HIGH on pin reads as 0, LOW on pin reads as 1)."]
     #[inline]
-    pub fn input_inverted_high(self) -> &'a mut W {
-        self.variant(INVW::INPUT_INVERTED_HIGH)
+    pub fn inverted(self) -> &'a mut W {
+        self.variant(INVW::INVERTED)
     }
     #[doc = r" Sets the field bit"]
     pub fn set_bit(self) -> &'a mut W {
@@ -530,9 +530,9 @@ impl<'a> _INVW<'a> {
 #[doc = "Values that can be written to the field `OD`"]
 pub enum ODW {
     #[doc = "Disable."]
-    DISABLE_,
+    DISABLED,
     #[doc = "Open-drain mode enabled.  This is not a true open-drain mode."]
-    OPEN_DRAIN_MODE_ENAB,
+    OPEN_DRAIN,
 }
 impl ODW {
     #[allow(missing_docs)]
@@ -540,8 +540,8 @@ impl ODW {
     #[inline]
     pub fn _bits(&self) -> bool {
         match *self {
-            ODW::DISABLE_ => false,
-            ODW::OPEN_DRAIN_MODE_ENAB => true,
+            ODW::DISABLED => false,
+            ODW::OPEN_DRAIN => true,
         }
     }
 }
@@ -559,13 +559,13 @@ impl<'a> _ODW<'a> {
     }
     #[doc = "Disable."]
     #[inline]
-    pub fn disable_(self) -> &'a mut W {
-        self.variant(ODW::DISABLE_)
+    pub fn disabled(self) -> &'a mut W {
+        self.variant(ODW::DISABLED)
     }
     #[doc = "Open-drain mode enabled. This is not a true open-drain mode."]
     #[inline]
-    pub fn open_drain_mode_enab(self) -> &'a mut W {
-        self.variant(ODW::OPEN_DRAIN_MODE_ENAB)
+    pub fn open_drain(self) -> &'a mut W {
+        self.variant(ODW::OPEN_DRAIN)
     }
     #[doc = r" Sets the field bit"]
     pub fn set_bit(self) -> &'a mut W {

--- a/lpc11uxx/src/iocon/pio1_28.rs
+++ b/lpc11uxx/src/iocon/pio1_28.rs
@@ -46,11 +46,11 @@ impl super::PIO1_28 {
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum FUNCR {
     #[doc = "PIO1_28."]
-    PIO1_28_,
+    PIO1_28,
     #[doc = "CT32B0_CAP0."]
-    CT32B0_CAP0_,
+    CT32B0_CAP0,
     #[doc = "SCLK."]
-    SCLK_,
+    SCLK,
     #[doc = r" Reserved"]
     _Reserved(u8),
 }
@@ -59,9 +59,9 @@ impl FUNCR {
     #[inline]
     pub fn bits(&self) -> u8 {
         match *self {
-            FUNCR::PIO1_28_ => 0,
-            FUNCR::CT32B0_CAP0_ => 1,
-            FUNCR::SCLK_ => 2,
+            FUNCR::PIO1_28 => 0,
+            FUNCR::CT32B0_CAP0 => 1,
+            FUNCR::SCLK => 2,
             FUNCR::_Reserved(bits) => bits,
         }
     }
@@ -70,49 +70,49 @@ impl FUNCR {
     #[inline]
     pub fn _from(value: u8) -> FUNCR {
         match value {
-            0 => FUNCR::PIO1_28_,
-            1 => FUNCR::CT32B0_CAP0_,
-            2 => FUNCR::SCLK_,
+            0 => FUNCR::PIO1_28,
+            1 => FUNCR::CT32B0_CAP0,
+            2 => FUNCR::SCLK,
             i => FUNCR::_Reserved(i),
         }
     }
-    #[doc = "Checks if the value of the field is `PIO1_28_`"]
+    #[doc = "Checks if the value of the field is `PIO1_28`"]
     #[inline]
-    pub fn is_pio1_28_(&self) -> bool {
-        *self == FUNCR::PIO1_28_
+    pub fn is_pio1_28(&self) -> bool {
+        *self == FUNCR::PIO1_28
     }
-    #[doc = "Checks if the value of the field is `CT32B0_CAP0_`"]
+    #[doc = "Checks if the value of the field is `CT32B0_CAP0`"]
     #[inline]
-    pub fn is_ct32b0_cap0_(&self) -> bool {
-        *self == FUNCR::CT32B0_CAP0_
+    pub fn is_ct32b0_cap0(&self) -> bool {
+        *self == FUNCR::CT32B0_CAP0
     }
-    #[doc = "Checks if the value of the field is `SCLK_`"]
+    #[doc = "Checks if the value of the field is `SCLK`"]
     #[inline]
-    pub fn is_sclk_(&self) -> bool {
-        *self == FUNCR::SCLK_
+    pub fn is_sclk(&self) -> bool {
+        *self == FUNCR::SCLK
     }
 }
 #[doc = "Possible values of the field `MODE`"]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum MODER {
     #[doc = "Inactive (no pull-down/pull-up resistor enabled)."]
-    INACTIVE_NO_PULL_DO,
+    INACTIVE,
     #[doc = "Pull-down resistor enabled."]
-    PULL_DOWN_RESISTOR_E,
+    PULL_DOWN,
     #[doc = "Pull-up resistor enabled."]
-    PULL_UP_RESISTOR_ENA,
+    PULL_UP,
     #[doc = "Repeater mode."]
-    REPEATER_MODE_,
+    REPEATER,
 }
 impl MODER {
     #[doc = r" Value of the field as raw bits"]
     #[inline]
     pub fn bits(&self) -> u8 {
         match *self {
-            MODER::INACTIVE_NO_PULL_DO => 0,
-            MODER::PULL_DOWN_RESISTOR_E => 1,
-            MODER::PULL_UP_RESISTOR_ENA => 2,
-            MODER::REPEATER_MODE_ => 3,
+            MODER::INACTIVE => 0,
+            MODER::PULL_DOWN => 1,
+            MODER::PULL_UP => 2,
+            MODER::REPEATER => 3,
         }
     }
     #[allow(missing_docs)]
@@ -120,41 +120,41 @@ impl MODER {
     #[inline]
     pub fn _from(value: u8) -> MODER {
         match value {
-            0 => MODER::INACTIVE_NO_PULL_DO,
-            1 => MODER::PULL_DOWN_RESISTOR_E,
-            2 => MODER::PULL_UP_RESISTOR_ENA,
-            3 => MODER::REPEATER_MODE_,
+            0 => MODER::INACTIVE,
+            1 => MODER::PULL_DOWN,
+            2 => MODER::PULL_UP,
+            3 => MODER::REPEATER,
             _ => unreachable!(),
         }
     }
-    #[doc = "Checks if the value of the field is `INACTIVE_NO_PULL_DO`"]
+    #[doc = "Checks if the value of the field is `INACTIVE`"]
     #[inline]
-    pub fn is_inactive_no_pull_do(&self) -> bool {
-        *self == MODER::INACTIVE_NO_PULL_DO
+    pub fn is_inactive(&self) -> bool {
+        *self == MODER::INACTIVE
     }
-    #[doc = "Checks if the value of the field is `PULL_DOWN_RESISTOR_E`"]
+    #[doc = "Checks if the value of the field is `PULL_DOWN`"]
     #[inline]
-    pub fn is_pull_down_resistor_e(&self) -> bool {
-        *self == MODER::PULL_DOWN_RESISTOR_E
+    pub fn is_pull_down(&self) -> bool {
+        *self == MODER::PULL_DOWN
     }
-    #[doc = "Checks if the value of the field is `PULL_UP_RESISTOR_ENA`"]
+    #[doc = "Checks if the value of the field is `PULL_UP`"]
     #[inline]
-    pub fn is_pull_up_resistor_ena(&self) -> bool {
-        *self == MODER::PULL_UP_RESISTOR_ENA
+    pub fn is_pull_up(&self) -> bool {
+        *self == MODER::PULL_UP
     }
-    #[doc = "Checks if the value of the field is `REPEATER_MODE_`"]
+    #[doc = "Checks if the value of the field is `REPEATER`"]
     #[inline]
-    pub fn is_repeater_mode_(&self) -> bool {
-        *self == MODER::REPEATER_MODE_
+    pub fn is_repeater(&self) -> bool {
+        *self == MODER::REPEATER
     }
 }
 #[doc = "Possible values of the field `HYS`"]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum HYSR {
     #[doc = "Disable."]
-    DISABLE_,
+    DISABLED,
     #[doc = "Enable."]
-    ENABLE_,
+    ENABLED,
 }
 impl HYSR {
     #[doc = r" Returns `true` if the bit is clear (0)"]
@@ -171,8 +171,8 @@ impl HYSR {
     #[inline]
     pub fn bit(&self) -> bool {
         match *self {
-            HYSR::DISABLE_ => false,
-            HYSR::ENABLE_ => true,
+            HYSR::DISABLED => false,
+            HYSR::ENABLED => true,
         }
     }
     #[allow(missing_docs)]
@@ -180,28 +180,28 @@ impl HYSR {
     #[inline]
     pub fn _from(value: bool) -> HYSR {
         match value {
-            false => HYSR::DISABLE_,
-            true => HYSR::ENABLE_,
+            false => HYSR::DISABLED,
+            true => HYSR::ENABLED,
         }
     }
-    #[doc = "Checks if the value of the field is `DISABLE_`"]
+    #[doc = "Checks if the value of the field is `DISABLED`"]
     #[inline]
-    pub fn is_disable_(&self) -> bool {
-        *self == HYSR::DISABLE_
+    pub fn is_disabled(&self) -> bool {
+        *self == HYSR::DISABLED
     }
-    #[doc = "Checks if the value of the field is `ENABLE_`"]
+    #[doc = "Checks if the value of the field is `ENABLED`"]
     #[inline]
-    pub fn is_enable_(&self) -> bool {
-        *self == HYSR::ENABLE_
+    pub fn is_enabled(&self) -> bool {
+        *self == HYSR::ENABLED
     }
 }
 #[doc = "Possible values of the field `INV`"]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum INVR {
     #[doc = "Input not inverted (HIGH on pin reads as 1, LOW on pin reads as 0)."]
-    INPUT_NOT_INVERTED_,
+    NOT_INVERTED,
     #[doc = "Input inverted (HIGH on pin reads as 0, LOW on pin reads as 1)."]
-    INPUT_INVERTED_HIGH,
+    INVERTED,
 }
 impl INVR {
     #[doc = r" Returns `true` if the bit is clear (0)"]
@@ -218,8 +218,8 @@ impl INVR {
     #[inline]
     pub fn bit(&self) -> bool {
         match *self {
-            INVR::INPUT_NOT_INVERTED_ => false,
-            INVR::INPUT_INVERTED_HIGH => true,
+            INVR::NOT_INVERTED => false,
+            INVR::INVERTED => true,
         }
     }
     #[allow(missing_docs)]
@@ -227,28 +227,28 @@ impl INVR {
     #[inline]
     pub fn _from(value: bool) -> INVR {
         match value {
-            false => INVR::INPUT_NOT_INVERTED_,
-            true => INVR::INPUT_INVERTED_HIGH,
+            false => INVR::NOT_INVERTED,
+            true => INVR::INVERTED,
         }
     }
-    #[doc = "Checks if the value of the field is `INPUT_NOT_INVERTED_`"]
+    #[doc = "Checks if the value of the field is `NOT_INVERTED`"]
     #[inline]
-    pub fn is_input_not_inverted_(&self) -> bool {
-        *self == INVR::INPUT_NOT_INVERTED_
+    pub fn is_not_inverted(&self) -> bool {
+        *self == INVR::NOT_INVERTED
     }
-    #[doc = "Checks if the value of the field is `INPUT_INVERTED_HIGH`"]
+    #[doc = "Checks if the value of the field is `INVERTED`"]
     #[inline]
-    pub fn is_input_inverted_high(&self) -> bool {
-        *self == INVR::INPUT_INVERTED_HIGH
+    pub fn is_inverted(&self) -> bool {
+        *self == INVR::INVERTED
     }
 }
 #[doc = "Possible values of the field `OD`"]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum ODR {
     #[doc = "Disable."]
-    DISABLE_,
+    DISABLED,
     #[doc = "Open-drain mode enabled.  This is not a true open-drain mode."]
-    OPEN_DRAIN_MODE_ENAB,
+    OPEN_DRAIN,
 }
 impl ODR {
     #[doc = r" Returns `true` if the bit is clear (0)"]
@@ -265,8 +265,8 @@ impl ODR {
     #[inline]
     pub fn bit(&self) -> bool {
         match *self {
-            ODR::DISABLE_ => false,
-            ODR::OPEN_DRAIN_MODE_ENAB => true,
+            ODR::DISABLED => false,
+            ODR::OPEN_DRAIN => true,
         }
     }
     #[allow(missing_docs)]
@@ -274,29 +274,29 @@ impl ODR {
     #[inline]
     pub fn _from(value: bool) -> ODR {
         match value {
-            false => ODR::DISABLE_,
-            true => ODR::OPEN_DRAIN_MODE_ENAB,
+            false => ODR::DISABLED,
+            true => ODR::OPEN_DRAIN,
         }
     }
-    #[doc = "Checks if the value of the field is `DISABLE_`"]
+    #[doc = "Checks if the value of the field is `DISABLED`"]
     #[inline]
-    pub fn is_disable_(&self) -> bool {
-        *self == ODR::DISABLE_
+    pub fn is_disabled(&self) -> bool {
+        *self == ODR::DISABLED
     }
-    #[doc = "Checks if the value of the field is `OPEN_DRAIN_MODE_ENAB`"]
+    #[doc = "Checks if the value of the field is `OPEN_DRAIN`"]
     #[inline]
-    pub fn is_open_drain_mode_enab(&self) -> bool {
-        *self == ODR::OPEN_DRAIN_MODE_ENAB
+    pub fn is_open_drain(&self) -> bool {
+        *self == ODR::OPEN_DRAIN
     }
 }
 #[doc = "Values that can be written to the field `FUNC`"]
 pub enum FUNCW {
     #[doc = "PIO1_28."]
-    PIO1_28_,
+    PIO1_28,
     #[doc = "CT32B0_CAP0."]
-    CT32B0_CAP0_,
+    CT32B0_CAP0,
     #[doc = "SCLK."]
-    SCLK_,
+    SCLK,
 }
 impl FUNCW {
     #[allow(missing_docs)]
@@ -304,9 +304,9 @@ impl FUNCW {
     #[inline]
     pub fn _bits(&self) -> u8 {
         match *self {
-            FUNCW::PIO1_28_ => 0,
-            FUNCW::CT32B0_CAP0_ => 1,
-            FUNCW::SCLK_ => 2,
+            FUNCW::PIO1_28 => 0,
+            FUNCW::CT32B0_CAP0 => 1,
+            FUNCW::SCLK => 2,
         }
     }
 }
@@ -322,18 +322,18 @@ impl<'a> _FUNCW<'a> {
     }
     #[doc = "PIO1_28."]
     #[inline]
-    pub fn pio1_28_(self) -> &'a mut W {
-        self.variant(FUNCW::PIO1_28_)
+    pub fn pio1_28(self) -> &'a mut W {
+        self.variant(FUNCW::PIO1_28)
     }
     #[doc = "CT32B0_CAP0."]
     #[inline]
-    pub fn ct32b0_cap0_(self) -> &'a mut W {
-        self.variant(FUNCW::CT32B0_CAP0_)
+    pub fn ct32b0_cap0(self) -> &'a mut W {
+        self.variant(FUNCW::CT32B0_CAP0)
     }
     #[doc = "SCLK."]
     #[inline]
-    pub fn sclk_(self) -> &'a mut W {
-        self.variant(FUNCW::SCLK_)
+    pub fn sclk(self) -> &'a mut W {
+        self.variant(FUNCW::SCLK)
     }
     #[doc = r" Writes raw bits to the field"]
     #[inline]
@@ -348,13 +348,13 @@ impl<'a> _FUNCW<'a> {
 #[doc = "Values that can be written to the field `MODE`"]
 pub enum MODEW {
     #[doc = "Inactive (no pull-down/pull-up resistor enabled)."]
-    INACTIVE_NO_PULL_DO,
+    INACTIVE,
     #[doc = "Pull-down resistor enabled."]
-    PULL_DOWN_RESISTOR_E,
+    PULL_DOWN,
     #[doc = "Pull-up resistor enabled."]
-    PULL_UP_RESISTOR_ENA,
+    PULL_UP,
     #[doc = "Repeater mode."]
-    REPEATER_MODE_,
+    REPEATER,
 }
 impl MODEW {
     #[allow(missing_docs)]
@@ -362,10 +362,10 @@ impl MODEW {
     #[inline]
     pub fn _bits(&self) -> u8 {
         match *self {
-            MODEW::INACTIVE_NO_PULL_DO => 0,
-            MODEW::PULL_DOWN_RESISTOR_E => 1,
-            MODEW::PULL_UP_RESISTOR_ENA => 2,
-            MODEW::REPEATER_MODE_ => 3,
+            MODEW::INACTIVE => 0,
+            MODEW::PULL_DOWN => 1,
+            MODEW::PULL_UP => 2,
+            MODEW::REPEATER => 3,
         }
     }
 }
@@ -383,23 +383,23 @@ impl<'a> _MODEW<'a> {
     }
     #[doc = "Inactive (no pull-down/pull-up resistor enabled)."]
     #[inline]
-    pub fn inactive_no_pull_do(self) -> &'a mut W {
-        self.variant(MODEW::INACTIVE_NO_PULL_DO)
+    pub fn inactive(self) -> &'a mut W {
+        self.variant(MODEW::INACTIVE)
     }
     #[doc = "Pull-down resistor enabled."]
     #[inline]
-    pub fn pull_down_resistor_e(self) -> &'a mut W {
-        self.variant(MODEW::PULL_DOWN_RESISTOR_E)
+    pub fn pull_down(self) -> &'a mut W {
+        self.variant(MODEW::PULL_DOWN)
     }
     #[doc = "Pull-up resistor enabled."]
     #[inline]
-    pub fn pull_up_resistor_ena(self) -> &'a mut W {
-        self.variant(MODEW::PULL_UP_RESISTOR_ENA)
+    pub fn pull_up(self) -> &'a mut W {
+        self.variant(MODEW::PULL_UP)
     }
     #[doc = "Repeater mode."]
     #[inline]
-    pub fn repeater_mode_(self) -> &'a mut W {
-        self.variant(MODEW::REPEATER_MODE_)
+    pub fn repeater(self) -> &'a mut W {
+        self.variant(MODEW::REPEATER)
     }
     #[doc = r" Writes raw bits to the field"]
     #[inline]
@@ -414,9 +414,9 @@ impl<'a> _MODEW<'a> {
 #[doc = "Values that can be written to the field `HYS`"]
 pub enum HYSW {
     #[doc = "Disable."]
-    DISABLE_,
+    DISABLED,
     #[doc = "Enable."]
-    ENABLE_,
+    ENABLED,
 }
 impl HYSW {
     #[allow(missing_docs)]
@@ -424,8 +424,8 @@ impl HYSW {
     #[inline]
     pub fn _bits(&self) -> bool {
         match *self {
-            HYSW::DISABLE_ => false,
-            HYSW::ENABLE_ => true,
+            HYSW::DISABLED => false,
+            HYSW::ENABLED => true,
         }
     }
 }
@@ -443,13 +443,13 @@ impl<'a> _HYSW<'a> {
     }
     #[doc = "Disable."]
     #[inline]
-    pub fn disable_(self) -> &'a mut W {
-        self.variant(HYSW::DISABLE_)
+    pub fn disabled(self) -> &'a mut W {
+        self.variant(HYSW::DISABLED)
     }
     #[doc = "Enable."]
     #[inline]
-    pub fn enable_(self) -> &'a mut W {
-        self.variant(HYSW::ENABLE_)
+    pub fn enabled(self) -> &'a mut W {
+        self.variant(HYSW::ENABLED)
     }
     #[doc = r" Sets the field bit"]
     pub fn set_bit(self) -> &'a mut W {
@@ -472,9 +472,9 @@ impl<'a> _HYSW<'a> {
 #[doc = "Values that can be written to the field `INV`"]
 pub enum INVW {
     #[doc = "Input not inverted (HIGH on pin reads as 1, LOW on pin reads as 0)."]
-    INPUT_NOT_INVERTED_,
+    NOT_INVERTED,
     #[doc = "Input inverted (HIGH on pin reads as 0, LOW on pin reads as 1)."]
-    INPUT_INVERTED_HIGH,
+    INVERTED,
 }
 impl INVW {
     #[allow(missing_docs)]
@@ -482,8 +482,8 @@ impl INVW {
     #[inline]
     pub fn _bits(&self) -> bool {
         match *self {
-            INVW::INPUT_NOT_INVERTED_ => false,
-            INVW::INPUT_INVERTED_HIGH => true,
+            INVW::NOT_INVERTED => false,
+            INVW::INVERTED => true,
         }
     }
 }
@@ -501,13 +501,13 @@ impl<'a> _INVW<'a> {
     }
     #[doc = "Input not inverted (HIGH on pin reads as 1, LOW on pin reads as 0)."]
     #[inline]
-    pub fn input_not_inverted_(self) -> &'a mut W {
-        self.variant(INVW::INPUT_NOT_INVERTED_)
+    pub fn not_inverted(self) -> &'a mut W {
+        self.variant(INVW::NOT_INVERTED)
     }
     #[doc = "Input inverted (HIGH on pin reads as 0, LOW on pin reads as 1)."]
     #[inline]
-    pub fn input_inverted_high(self) -> &'a mut W {
-        self.variant(INVW::INPUT_INVERTED_HIGH)
+    pub fn inverted(self) -> &'a mut W {
+        self.variant(INVW::INVERTED)
     }
     #[doc = r" Sets the field bit"]
     pub fn set_bit(self) -> &'a mut W {
@@ -530,9 +530,9 @@ impl<'a> _INVW<'a> {
 #[doc = "Values that can be written to the field `OD`"]
 pub enum ODW {
     #[doc = "Disable."]
-    DISABLE_,
+    DISABLED,
     #[doc = "Open-drain mode enabled.  This is not a true open-drain mode."]
-    OPEN_DRAIN_MODE_ENAB,
+    OPEN_DRAIN,
 }
 impl ODW {
     #[allow(missing_docs)]
@@ -540,8 +540,8 @@ impl ODW {
     #[inline]
     pub fn _bits(&self) -> bool {
         match *self {
-            ODW::DISABLE_ => false,
-            ODW::OPEN_DRAIN_MODE_ENAB => true,
+            ODW::DISABLED => false,
+            ODW::OPEN_DRAIN => true,
         }
     }
 }
@@ -559,13 +559,13 @@ impl<'a> _ODW<'a> {
     }
     #[doc = "Disable."]
     #[inline]
-    pub fn disable_(self) -> &'a mut W {
-        self.variant(ODW::DISABLE_)
+    pub fn disabled(self) -> &'a mut W {
+        self.variant(ODW::DISABLED)
     }
     #[doc = "Open-drain mode enabled. This is not a true open-drain mode."]
     #[inline]
-    pub fn open_drain_mode_enab(self) -> &'a mut W {
-        self.variant(ODW::OPEN_DRAIN_MODE_ENAB)
+    pub fn open_drain(self) -> &'a mut W {
+        self.variant(ODW::OPEN_DRAIN)
     }
     #[doc = r" Sets the field bit"]
     pub fn set_bit(self) -> &'a mut W {

--- a/lpc11uxx/src/iocon/pio1_29.rs
+++ b/lpc11uxx/src/iocon/pio1_29.rs
@@ -46,11 +46,11 @@ impl super::PIO1_29 {
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum FUNCR {
     #[doc = "PIO1_29."]
-    PIO1_29_,
+    PIO1_29,
     #[doc = "SCK0."]
-    SCK0_,
+    SCK0,
     #[doc = "CT32B0_CAP1."]
-    CT32B0_CAP1_,
+    CT32B0_CAP1,
     #[doc = r" Reserved"]
     _Reserved(u8),
 }
@@ -59,9 +59,9 @@ impl FUNCR {
     #[inline]
     pub fn bits(&self) -> u8 {
         match *self {
-            FUNCR::PIO1_29_ => 0,
-            FUNCR::SCK0_ => 1,
-            FUNCR::CT32B0_CAP1_ => 2,
+            FUNCR::PIO1_29 => 0,
+            FUNCR::SCK0 => 1,
+            FUNCR::CT32B0_CAP1 => 2,
             FUNCR::_Reserved(bits) => bits,
         }
     }
@@ -70,49 +70,49 @@ impl FUNCR {
     #[inline]
     pub fn _from(value: u8) -> FUNCR {
         match value {
-            0 => FUNCR::PIO1_29_,
-            1 => FUNCR::SCK0_,
-            2 => FUNCR::CT32B0_CAP1_,
+            0 => FUNCR::PIO1_29,
+            1 => FUNCR::SCK0,
+            2 => FUNCR::CT32B0_CAP1,
             i => FUNCR::_Reserved(i),
         }
     }
-    #[doc = "Checks if the value of the field is `PIO1_29_`"]
+    #[doc = "Checks if the value of the field is `PIO1_29`"]
     #[inline]
-    pub fn is_pio1_29_(&self) -> bool {
-        *self == FUNCR::PIO1_29_
+    pub fn is_pio1_29(&self) -> bool {
+        *self == FUNCR::PIO1_29
     }
-    #[doc = "Checks if the value of the field is `SCK0_`"]
+    #[doc = "Checks if the value of the field is `SCK0`"]
     #[inline]
-    pub fn is_sck0_(&self) -> bool {
-        *self == FUNCR::SCK0_
+    pub fn is_sck0(&self) -> bool {
+        *self == FUNCR::SCK0
     }
-    #[doc = "Checks if the value of the field is `CT32B0_CAP1_`"]
+    #[doc = "Checks if the value of the field is `CT32B0_CAP1`"]
     #[inline]
-    pub fn is_ct32b0_cap1_(&self) -> bool {
-        *self == FUNCR::CT32B0_CAP1_
+    pub fn is_ct32b0_cap1(&self) -> bool {
+        *self == FUNCR::CT32B0_CAP1
     }
 }
 #[doc = "Possible values of the field `MODE`"]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum MODER {
     #[doc = "Inactive (no pull-down/pull-up resistor enabled)."]
-    INACTIVE_NO_PULL_DO,
+    INACTIVE,
     #[doc = "Pull-down resistor enabled."]
-    PULL_DOWN_RESISTOR_E,
+    PULL_DOWN,
     #[doc = "Pull-up resistor enabled."]
-    PULL_UP_RESISTOR_ENA,
+    PULL_UP,
     #[doc = "Repeater mode."]
-    REPEATER_MODE_,
+    REPEATER,
 }
 impl MODER {
     #[doc = r" Value of the field as raw bits"]
     #[inline]
     pub fn bits(&self) -> u8 {
         match *self {
-            MODER::INACTIVE_NO_PULL_DO => 0,
-            MODER::PULL_DOWN_RESISTOR_E => 1,
-            MODER::PULL_UP_RESISTOR_ENA => 2,
-            MODER::REPEATER_MODE_ => 3,
+            MODER::INACTIVE => 0,
+            MODER::PULL_DOWN => 1,
+            MODER::PULL_UP => 2,
+            MODER::REPEATER => 3,
         }
     }
     #[allow(missing_docs)]
@@ -120,41 +120,41 @@ impl MODER {
     #[inline]
     pub fn _from(value: u8) -> MODER {
         match value {
-            0 => MODER::INACTIVE_NO_PULL_DO,
-            1 => MODER::PULL_DOWN_RESISTOR_E,
-            2 => MODER::PULL_UP_RESISTOR_ENA,
-            3 => MODER::REPEATER_MODE_,
+            0 => MODER::INACTIVE,
+            1 => MODER::PULL_DOWN,
+            2 => MODER::PULL_UP,
+            3 => MODER::REPEATER,
             _ => unreachable!(),
         }
     }
-    #[doc = "Checks if the value of the field is `INACTIVE_NO_PULL_DO`"]
+    #[doc = "Checks if the value of the field is `INACTIVE`"]
     #[inline]
-    pub fn is_inactive_no_pull_do(&self) -> bool {
-        *self == MODER::INACTIVE_NO_PULL_DO
+    pub fn is_inactive(&self) -> bool {
+        *self == MODER::INACTIVE
     }
-    #[doc = "Checks if the value of the field is `PULL_DOWN_RESISTOR_E`"]
+    #[doc = "Checks if the value of the field is `PULL_DOWN`"]
     #[inline]
-    pub fn is_pull_down_resistor_e(&self) -> bool {
-        *self == MODER::PULL_DOWN_RESISTOR_E
+    pub fn is_pull_down(&self) -> bool {
+        *self == MODER::PULL_DOWN
     }
-    #[doc = "Checks if the value of the field is `PULL_UP_RESISTOR_ENA`"]
+    #[doc = "Checks if the value of the field is `PULL_UP`"]
     #[inline]
-    pub fn is_pull_up_resistor_ena(&self) -> bool {
-        *self == MODER::PULL_UP_RESISTOR_ENA
+    pub fn is_pull_up(&self) -> bool {
+        *self == MODER::PULL_UP
     }
-    #[doc = "Checks if the value of the field is `REPEATER_MODE_`"]
+    #[doc = "Checks if the value of the field is `REPEATER`"]
     #[inline]
-    pub fn is_repeater_mode_(&self) -> bool {
-        *self == MODER::REPEATER_MODE_
+    pub fn is_repeater(&self) -> bool {
+        *self == MODER::REPEATER
     }
 }
 #[doc = "Possible values of the field `HYS`"]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum HYSR {
     #[doc = "Disable."]
-    DISABLE_,
+    DISABLED,
     #[doc = "Enable."]
-    ENABLE_,
+    ENABLED,
 }
 impl HYSR {
     #[doc = r" Returns `true` if the bit is clear (0)"]
@@ -171,8 +171,8 @@ impl HYSR {
     #[inline]
     pub fn bit(&self) -> bool {
         match *self {
-            HYSR::DISABLE_ => false,
-            HYSR::ENABLE_ => true,
+            HYSR::DISABLED => false,
+            HYSR::ENABLED => true,
         }
     }
     #[allow(missing_docs)]
@@ -180,28 +180,28 @@ impl HYSR {
     #[inline]
     pub fn _from(value: bool) -> HYSR {
         match value {
-            false => HYSR::DISABLE_,
-            true => HYSR::ENABLE_,
+            false => HYSR::DISABLED,
+            true => HYSR::ENABLED,
         }
     }
-    #[doc = "Checks if the value of the field is `DISABLE_`"]
+    #[doc = "Checks if the value of the field is `DISABLED`"]
     #[inline]
-    pub fn is_disable_(&self) -> bool {
-        *self == HYSR::DISABLE_
+    pub fn is_disabled(&self) -> bool {
+        *self == HYSR::DISABLED
     }
-    #[doc = "Checks if the value of the field is `ENABLE_`"]
+    #[doc = "Checks if the value of the field is `ENABLED`"]
     #[inline]
-    pub fn is_enable_(&self) -> bool {
-        *self == HYSR::ENABLE_
+    pub fn is_enabled(&self) -> bool {
+        *self == HYSR::ENABLED
     }
 }
 #[doc = "Possible values of the field `INV`"]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum INVR {
     #[doc = "Input not inverted (HIGH on pin reads as 1, LOW on pin reads as 0)."]
-    INPUT_NOT_INVERTED_,
+    NOT_INVERTED,
     #[doc = "Input inverted (HIGH on pin reads as 0, LOW on pin reads as 1)."]
-    INPUT_INVERTED_HIGH,
+    INVERTED,
 }
 impl INVR {
     #[doc = r" Returns `true` if the bit is clear (0)"]
@@ -218,8 +218,8 @@ impl INVR {
     #[inline]
     pub fn bit(&self) -> bool {
         match *self {
-            INVR::INPUT_NOT_INVERTED_ => false,
-            INVR::INPUT_INVERTED_HIGH => true,
+            INVR::NOT_INVERTED => false,
+            INVR::INVERTED => true,
         }
     }
     #[allow(missing_docs)]
@@ -227,28 +227,28 @@ impl INVR {
     #[inline]
     pub fn _from(value: bool) -> INVR {
         match value {
-            false => INVR::INPUT_NOT_INVERTED_,
-            true => INVR::INPUT_INVERTED_HIGH,
+            false => INVR::NOT_INVERTED,
+            true => INVR::INVERTED,
         }
     }
-    #[doc = "Checks if the value of the field is `INPUT_NOT_INVERTED_`"]
+    #[doc = "Checks if the value of the field is `NOT_INVERTED`"]
     #[inline]
-    pub fn is_input_not_inverted_(&self) -> bool {
-        *self == INVR::INPUT_NOT_INVERTED_
+    pub fn is_not_inverted(&self) -> bool {
+        *self == INVR::NOT_INVERTED
     }
-    #[doc = "Checks if the value of the field is `INPUT_INVERTED_HIGH`"]
+    #[doc = "Checks if the value of the field is `INVERTED`"]
     #[inline]
-    pub fn is_input_inverted_high(&self) -> bool {
-        *self == INVR::INPUT_INVERTED_HIGH
+    pub fn is_inverted(&self) -> bool {
+        *self == INVR::INVERTED
     }
 }
 #[doc = "Possible values of the field `OD`"]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum ODR {
     #[doc = "Disable."]
-    DISABLE_,
+    DISABLED,
     #[doc = "Open-drain mode enabled.  This is not a true open-drain mode."]
-    OPEN_DRAIN_MODE_ENAB,
+    OPEN_DRAIN,
 }
 impl ODR {
     #[doc = r" Returns `true` if the bit is clear (0)"]
@@ -265,8 +265,8 @@ impl ODR {
     #[inline]
     pub fn bit(&self) -> bool {
         match *self {
-            ODR::DISABLE_ => false,
-            ODR::OPEN_DRAIN_MODE_ENAB => true,
+            ODR::DISABLED => false,
+            ODR::OPEN_DRAIN => true,
         }
     }
     #[allow(missing_docs)]
@@ -274,29 +274,29 @@ impl ODR {
     #[inline]
     pub fn _from(value: bool) -> ODR {
         match value {
-            false => ODR::DISABLE_,
-            true => ODR::OPEN_DRAIN_MODE_ENAB,
+            false => ODR::DISABLED,
+            true => ODR::OPEN_DRAIN,
         }
     }
-    #[doc = "Checks if the value of the field is `DISABLE_`"]
+    #[doc = "Checks if the value of the field is `DISABLED`"]
     #[inline]
-    pub fn is_disable_(&self) -> bool {
-        *self == ODR::DISABLE_
+    pub fn is_disabled(&self) -> bool {
+        *self == ODR::DISABLED
     }
-    #[doc = "Checks if the value of the field is `OPEN_DRAIN_MODE_ENAB`"]
+    #[doc = "Checks if the value of the field is `OPEN_DRAIN`"]
     #[inline]
-    pub fn is_open_drain_mode_enab(&self) -> bool {
-        *self == ODR::OPEN_DRAIN_MODE_ENAB
+    pub fn is_open_drain(&self) -> bool {
+        *self == ODR::OPEN_DRAIN
     }
 }
 #[doc = "Values that can be written to the field `FUNC`"]
 pub enum FUNCW {
     #[doc = "PIO1_29."]
-    PIO1_29_,
+    PIO1_29,
     #[doc = "SCK0."]
-    SCK0_,
+    SCK0,
     #[doc = "CT32B0_CAP1."]
-    CT32B0_CAP1_,
+    CT32B0_CAP1,
 }
 impl FUNCW {
     #[allow(missing_docs)]
@@ -304,9 +304,9 @@ impl FUNCW {
     #[inline]
     pub fn _bits(&self) -> u8 {
         match *self {
-            FUNCW::PIO1_29_ => 0,
-            FUNCW::SCK0_ => 1,
-            FUNCW::CT32B0_CAP1_ => 2,
+            FUNCW::PIO1_29 => 0,
+            FUNCW::SCK0 => 1,
+            FUNCW::CT32B0_CAP1 => 2,
         }
     }
 }
@@ -322,18 +322,18 @@ impl<'a> _FUNCW<'a> {
     }
     #[doc = "PIO1_29."]
     #[inline]
-    pub fn pio1_29_(self) -> &'a mut W {
-        self.variant(FUNCW::PIO1_29_)
+    pub fn pio1_29(self) -> &'a mut W {
+        self.variant(FUNCW::PIO1_29)
     }
     #[doc = "SCK0."]
     #[inline]
-    pub fn sck0_(self) -> &'a mut W {
-        self.variant(FUNCW::SCK0_)
+    pub fn sck0(self) -> &'a mut W {
+        self.variant(FUNCW::SCK0)
     }
     #[doc = "CT32B0_CAP1."]
     #[inline]
-    pub fn ct32b0_cap1_(self) -> &'a mut W {
-        self.variant(FUNCW::CT32B0_CAP1_)
+    pub fn ct32b0_cap1(self) -> &'a mut W {
+        self.variant(FUNCW::CT32B0_CAP1)
     }
     #[doc = r" Writes raw bits to the field"]
     #[inline]
@@ -348,13 +348,13 @@ impl<'a> _FUNCW<'a> {
 #[doc = "Values that can be written to the field `MODE`"]
 pub enum MODEW {
     #[doc = "Inactive (no pull-down/pull-up resistor enabled)."]
-    INACTIVE_NO_PULL_DO,
+    INACTIVE,
     #[doc = "Pull-down resistor enabled."]
-    PULL_DOWN_RESISTOR_E,
+    PULL_DOWN,
     #[doc = "Pull-up resistor enabled."]
-    PULL_UP_RESISTOR_ENA,
+    PULL_UP,
     #[doc = "Repeater mode."]
-    REPEATER_MODE_,
+    REPEATER,
 }
 impl MODEW {
     #[allow(missing_docs)]
@@ -362,10 +362,10 @@ impl MODEW {
     #[inline]
     pub fn _bits(&self) -> u8 {
         match *self {
-            MODEW::INACTIVE_NO_PULL_DO => 0,
-            MODEW::PULL_DOWN_RESISTOR_E => 1,
-            MODEW::PULL_UP_RESISTOR_ENA => 2,
-            MODEW::REPEATER_MODE_ => 3,
+            MODEW::INACTIVE => 0,
+            MODEW::PULL_DOWN => 1,
+            MODEW::PULL_UP => 2,
+            MODEW::REPEATER => 3,
         }
     }
 }
@@ -383,23 +383,23 @@ impl<'a> _MODEW<'a> {
     }
     #[doc = "Inactive (no pull-down/pull-up resistor enabled)."]
     #[inline]
-    pub fn inactive_no_pull_do(self) -> &'a mut W {
-        self.variant(MODEW::INACTIVE_NO_PULL_DO)
+    pub fn inactive(self) -> &'a mut W {
+        self.variant(MODEW::INACTIVE)
     }
     #[doc = "Pull-down resistor enabled."]
     #[inline]
-    pub fn pull_down_resistor_e(self) -> &'a mut W {
-        self.variant(MODEW::PULL_DOWN_RESISTOR_E)
+    pub fn pull_down(self) -> &'a mut W {
+        self.variant(MODEW::PULL_DOWN)
     }
     #[doc = "Pull-up resistor enabled."]
     #[inline]
-    pub fn pull_up_resistor_ena(self) -> &'a mut W {
-        self.variant(MODEW::PULL_UP_RESISTOR_ENA)
+    pub fn pull_up(self) -> &'a mut W {
+        self.variant(MODEW::PULL_UP)
     }
     #[doc = "Repeater mode."]
     #[inline]
-    pub fn repeater_mode_(self) -> &'a mut W {
-        self.variant(MODEW::REPEATER_MODE_)
+    pub fn repeater(self) -> &'a mut W {
+        self.variant(MODEW::REPEATER)
     }
     #[doc = r" Writes raw bits to the field"]
     #[inline]
@@ -414,9 +414,9 @@ impl<'a> _MODEW<'a> {
 #[doc = "Values that can be written to the field `HYS`"]
 pub enum HYSW {
     #[doc = "Disable."]
-    DISABLE_,
+    DISABLED,
     #[doc = "Enable."]
-    ENABLE_,
+    ENABLED,
 }
 impl HYSW {
     #[allow(missing_docs)]
@@ -424,8 +424,8 @@ impl HYSW {
     #[inline]
     pub fn _bits(&self) -> bool {
         match *self {
-            HYSW::DISABLE_ => false,
-            HYSW::ENABLE_ => true,
+            HYSW::DISABLED => false,
+            HYSW::ENABLED => true,
         }
     }
 }
@@ -443,13 +443,13 @@ impl<'a> _HYSW<'a> {
     }
     #[doc = "Disable."]
     #[inline]
-    pub fn disable_(self) -> &'a mut W {
-        self.variant(HYSW::DISABLE_)
+    pub fn disabled(self) -> &'a mut W {
+        self.variant(HYSW::DISABLED)
     }
     #[doc = "Enable."]
     #[inline]
-    pub fn enable_(self) -> &'a mut W {
-        self.variant(HYSW::ENABLE_)
+    pub fn enabled(self) -> &'a mut W {
+        self.variant(HYSW::ENABLED)
     }
     #[doc = r" Sets the field bit"]
     pub fn set_bit(self) -> &'a mut W {
@@ -472,9 +472,9 @@ impl<'a> _HYSW<'a> {
 #[doc = "Values that can be written to the field `INV`"]
 pub enum INVW {
     #[doc = "Input not inverted (HIGH on pin reads as 1, LOW on pin reads as 0)."]
-    INPUT_NOT_INVERTED_,
+    NOT_INVERTED,
     #[doc = "Input inverted (HIGH on pin reads as 0, LOW on pin reads as 1)."]
-    INPUT_INVERTED_HIGH,
+    INVERTED,
 }
 impl INVW {
     #[allow(missing_docs)]
@@ -482,8 +482,8 @@ impl INVW {
     #[inline]
     pub fn _bits(&self) -> bool {
         match *self {
-            INVW::INPUT_NOT_INVERTED_ => false,
-            INVW::INPUT_INVERTED_HIGH => true,
+            INVW::NOT_INVERTED => false,
+            INVW::INVERTED => true,
         }
     }
 }
@@ -501,13 +501,13 @@ impl<'a> _INVW<'a> {
     }
     #[doc = "Input not inverted (HIGH on pin reads as 1, LOW on pin reads as 0)."]
     #[inline]
-    pub fn input_not_inverted_(self) -> &'a mut W {
-        self.variant(INVW::INPUT_NOT_INVERTED_)
+    pub fn not_inverted(self) -> &'a mut W {
+        self.variant(INVW::NOT_INVERTED)
     }
     #[doc = "Input inverted (HIGH on pin reads as 0, LOW on pin reads as 1)."]
     #[inline]
-    pub fn input_inverted_high(self) -> &'a mut W {
-        self.variant(INVW::INPUT_INVERTED_HIGH)
+    pub fn inverted(self) -> &'a mut W {
+        self.variant(INVW::INVERTED)
     }
     #[doc = r" Sets the field bit"]
     pub fn set_bit(self) -> &'a mut W {
@@ -530,9 +530,9 @@ impl<'a> _INVW<'a> {
 #[doc = "Values that can be written to the field `OD`"]
 pub enum ODW {
     #[doc = "Disable."]
-    DISABLE_,
+    DISABLED,
     #[doc = "Open-drain mode enabled.  This is not a true open-drain mode."]
-    OPEN_DRAIN_MODE_ENAB,
+    OPEN_DRAIN,
 }
 impl ODW {
     #[allow(missing_docs)]
@@ -540,8 +540,8 @@ impl ODW {
     #[inline]
     pub fn _bits(&self) -> bool {
         match *self {
-            ODW::DISABLE_ => false,
-            ODW::OPEN_DRAIN_MODE_ENAB => true,
+            ODW::DISABLED => false,
+            ODW::OPEN_DRAIN => true,
         }
     }
 }
@@ -559,13 +559,13 @@ impl<'a> _ODW<'a> {
     }
     #[doc = "Disable."]
     #[inline]
-    pub fn disable_(self) -> &'a mut W {
-        self.variant(ODW::DISABLE_)
+    pub fn disabled(self) -> &'a mut W {
+        self.variant(ODW::DISABLED)
     }
     #[doc = "Open-drain mode enabled. This is not a true open-drain mode."]
     #[inline]
-    pub fn open_drain_mode_enab(self) -> &'a mut W {
-        self.variant(ODW::OPEN_DRAIN_MODE_ENAB)
+    pub fn open_drain(self) -> &'a mut W {
+        self.variant(ODW::OPEN_DRAIN)
     }
     #[doc = r" Sets the field bit"]
     pub fn set_bit(self) -> &'a mut W {

--- a/lpc11uxx/src/iocon/pio1_3.rs
+++ b/lpc11uxx/src/iocon/pio1_3.rs
@@ -46,9 +46,9 @@ impl super::PIO1_3 {
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum FUNCR {
     #[doc = "PIO1_3."]
-    PIO1_3_,
+    PIO1_3,
     #[doc = "CT32B1_MAT3."]
-    CT32B1_MAT3_,
+    CT32B1_MAT3,
     #[doc = r" Reserved"]
     _Reserved(u8),
 }
@@ -57,8 +57,8 @@ impl FUNCR {
     #[inline]
     pub fn bits(&self) -> u8 {
         match *self {
-            FUNCR::PIO1_3_ => 0,
-            FUNCR::CT32B1_MAT3_ => 1,
+            FUNCR::PIO1_3 => 0,
+            FUNCR::CT32B1_MAT3 => 1,
             FUNCR::_Reserved(bits) => bits,
         }
     }
@@ -67,43 +67,43 @@ impl FUNCR {
     #[inline]
     pub fn _from(value: u8) -> FUNCR {
         match value {
-            0 => FUNCR::PIO1_3_,
-            1 => FUNCR::CT32B1_MAT3_,
+            0 => FUNCR::PIO1_3,
+            1 => FUNCR::CT32B1_MAT3,
             i => FUNCR::_Reserved(i),
         }
     }
-    #[doc = "Checks if the value of the field is `PIO1_3_`"]
+    #[doc = "Checks if the value of the field is `PIO1_3`"]
     #[inline]
-    pub fn is_pio1_3_(&self) -> bool {
-        *self == FUNCR::PIO1_3_
+    pub fn is_pio1_3(&self) -> bool {
+        *self == FUNCR::PIO1_3
     }
-    #[doc = "Checks if the value of the field is `CT32B1_MAT3_`"]
+    #[doc = "Checks if the value of the field is `CT32B1_MAT3`"]
     #[inline]
-    pub fn is_ct32b1_mat3_(&self) -> bool {
-        *self == FUNCR::CT32B1_MAT3_
+    pub fn is_ct32b1_mat3(&self) -> bool {
+        *self == FUNCR::CT32B1_MAT3
     }
 }
 #[doc = "Possible values of the field `MODE`"]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum MODER {
     #[doc = "Inactive (no pull-down/pull-up resistor enabled)."]
-    INACTIVE_NO_PULL_DO,
+    INACTIVE,
     #[doc = "Pull-down resistor enabled."]
-    PULL_DOWN_RESISTOR_E,
+    PULL_DOWN,
     #[doc = "Pull-up resistor enabled."]
-    PULL_UP_RESISTOR_ENA,
+    PULL_UP,
     #[doc = "Repeater mode."]
-    REPEATER_MODE_,
+    REPEATER,
 }
 impl MODER {
     #[doc = r" Value of the field as raw bits"]
     #[inline]
     pub fn bits(&self) -> u8 {
         match *self {
-            MODER::INACTIVE_NO_PULL_DO => 0,
-            MODER::PULL_DOWN_RESISTOR_E => 1,
-            MODER::PULL_UP_RESISTOR_ENA => 2,
-            MODER::REPEATER_MODE_ => 3,
+            MODER::INACTIVE => 0,
+            MODER::PULL_DOWN => 1,
+            MODER::PULL_UP => 2,
+            MODER::REPEATER => 3,
         }
     }
     #[allow(missing_docs)]
@@ -111,41 +111,41 @@ impl MODER {
     #[inline]
     pub fn _from(value: u8) -> MODER {
         match value {
-            0 => MODER::INACTIVE_NO_PULL_DO,
-            1 => MODER::PULL_DOWN_RESISTOR_E,
-            2 => MODER::PULL_UP_RESISTOR_ENA,
-            3 => MODER::REPEATER_MODE_,
+            0 => MODER::INACTIVE,
+            1 => MODER::PULL_DOWN,
+            2 => MODER::PULL_UP,
+            3 => MODER::REPEATER,
             _ => unreachable!(),
         }
     }
-    #[doc = "Checks if the value of the field is `INACTIVE_NO_PULL_DO`"]
+    #[doc = "Checks if the value of the field is `INACTIVE`"]
     #[inline]
-    pub fn is_inactive_no_pull_do(&self) -> bool {
-        *self == MODER::INACTIVE_NO_PULL_DO
+    pub fn is_inactive(&self) -> bool {
+        *self == MODER::INACTIVE
     }
-    #[doc = "Checks if the value of the field is `PULL_DOWN_RESISTOR_E`"]
+    #[doc = "Checks if the value of the field is `PULL_DOWN`"]
     #[inline]
-    pub fn is_pull_down_resistor_e(&self) -> bool {
-        *self == MODER::PULL_DOWN_RESISTOR_E
+    pub fn is_pull_down(&self) -> bool {
+        *self == MODER::PULL_DOWN
     }
-    #[doc = "Checks if the value of the field is `PULL_UP_RESISTOR_ENA`"]
+    #[doc = "Checks if the value of the field is `PULL_UP`"]
     #[inline]
-    pub fn is_pull_up_resistor_ena(&self) -> bool {
-        *self == MODER::PULL_UP_RESISTOR_ENA
+    pub fn is_pull_up(&self) -> bool {
+        *self == MODER::PULL_UP
     }
-    #[doc = "Checks if the value of the field is `REPEATER_MODE_`"]
+    #[doc = "Checks if the value of the field is `REPEATER`"]
     #[inline]
-    pub fn is_repeater_mode_(&self) -> bool {
-        *self == MODER::REPEATER_MODE_
+    pub fn is_repeater(&self) -> bool {
+        *self == MODER::REPEATER
     }
 }
 #[doc = "Possible values of the field `HYS`"]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum HYSR {
     #[doc = "Disable."]
-    DISABLE_,
+    DISABLED,
     #[doc = "Enable."]
-    ENABLE_,
+    ENABLED,
 }
 impl HYSR {
     #[doc = r" Returns `true` if the bit is clear (0)"]
@@ -162,8 +162,8 @@ impl HYSR {
     #[inline]
     pub fn bit(&self) -> bool {
         match *self {
-            HYSR::DISABLE_ => false,
-            HYSR::ENABLE_ => true,
+            HYSR::DISABLED => false,
+            HYSR::ENABLED => true,
         }
     }
     #[allow(missing_docs)]
@@ -171,28 +171,28 @@ impl HYSR {
     #[inline]
     pub fn _from(value: bool) -> HYSR {
         match value {
-            false => HYSR::DISABLE_,
-            true => HYSR::ENABLE_,
+            false => HYSR::DISABLED,
+            true => HYSR::ENABLED,
         }
     }
-    #[doc = "Checks if the value of the field is `DISABLE_`"]
+    #[doc = "Checks if the value of the field is `DISABLED`"]
     #[inline]
-    pub fn is_disable_(&self) -> bool {
-        *self == HYSR::DISABLE_
+    pub fn is_disabled(&self) -> bool {
+        *self == HYSR::DISABLED
     }
-    #[doc = "Checks if the value of the field is `ENABLE_`"]
+    #[doc = "Checks if the value of the field is `ENABLED`"]
     #[inline]
-    pub fn is_enable_(&self) -> bool {
-        *self == HYSR::ENABLE_
+    pub fn is_enabled(&self) -> bool {
+        *self == HYSR::ENABLED
     }
 }
 #[doc = "Possible values of the field `INV`"]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum INVR {
     #[doc = "Input not inverted (HIGH on pin reads as 1, LOW on pin reads as 0)."]
-    INPUT_NOT_INVERTED_,
+    NOT_INVERTED,
     #[doc = "Input inverted (HIGH on pin reads as 0, LOW on pin reads as 1)."]
-    INPUT_INVERTED_HIGH,
+    INVERTED,
 }
 impl INVR {
     #[doc = r" Returns `true` if the bit is clear (0)"]
@@ -209,8 +209,8 @@ impl INVR {
     #[inline]
     pub fn bit(&self) -> bool {
         match *self {
-            INVR::INPUT_NOT_INVERTED_ => false,
-            INVR::INPUT_INVERTED_HIGH => true,
+            INVR::NOT_INVERTED => false,
+            INVR::INVERTED => true,
         }
     }
     #[allow(missing_docs)]
@@ -218,28 +218,28 @@ impl INVR {
     #[inline]
     pub fn _from(value: bool) -> INVR {
         match value {
-            false => INVR::INPUT_NOT_INVERTED_,
-            true => INVR::INPUT_INVERTED_HIGH,
+            false => INVR::NOT_INVERTED,
+            true => INVR::INVERTED,
         }
     }
-    #[doc = "Checks if the value of the field is `INPUT_NOT_INVERTED_`"]
+    #[doc = "Checks if the value of the field is `NOT_INVERTED`"]
     #[inline]
-    pub fn is_input_not_inverted_(&self) -> bool {
-        *self == INVR::INPUT_NOT_INVERTED_
+    pub fn is_not_inverted(&self) -> bool {
+        *self == INVR::NOT_INVERTED
     }
-    #[doc = "Checks if the value of the field is `INPUT_INVERTED_HIGH`"]
+    #[doc = "Checks if the value of the field is `INVERTED`"]
     #[inline]
-    pub fn is_input_inverted_high(&self) -> bool {
-        *self == INVR::INPUT_INVERTED_HIGH
+    pub fn is_inverted(&self) -> bool {
+        *self == INVR::INVERTED
     }
 }
 #[doc = "Possible values of the field `OD`"]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum ODR {
     #[doc = "Disable."]
-    DISABLE_,
+    DISABLED,
     #[doc = "Open-drain mode enabled. This is not a true open-drain mode. Input cannot be pulled up above VDD."]
-    OPEN_DRAIN_MODE_ENAB,
+    OPEN_DRAIN,
 }
 impl ODR {
     #[doc = r" Returns `true` if the bit is clear (0)"]
@@ -256,8 +256,8 @@ impl ODR {
     #[inline]
     pub fn bit(&self) -> bool {
         match *self {
-            ODR::DISABLE_ => false,
-            ODR::OPEN_DRAIN_MODE_ENAB => true,
+            ODR::DISABLED => false,
+            ODR::OPEN_DRAIN => true,
         }
     }
     #[allow(missing_docs)]
@@ -265,27 +265,27 @@ impl ODR {
     #[inline]
     pub fn _from(value: bool) -> ODR {
         match value {
-            false => ODR::DISABLE_,
-            true => ODR::OPEN_DRAIN_MODE_ENAB,
+            false => ODR::DISABLED,
+            true => ODR::OPEN_DRAIN,
         }
     }
-    #[doc = "Checks if the value of the field is `DISABLE_`"]
+    #[doc = "Checks if the value of the field is `DISABLED`"]
     #[inline]
-    pub fn is_disable_(&self) -> bool {
-        *self == ODR::DISABLE_
+    pub fn is_disabled(&self) -> bool {
+        *self == ODR::DISABLED
     }
-    #[doc = "Checks if the value of the field is `OPEN_DRAIN_MODE_ENAB`"]
+    #[doc = "Checks if the value of the field is `OPEN_DRAIN`"]
     #[inline]
-    pub fn is_open_drain_mode_enab(&self) -> bool {
-        *self == ODR::OPEN_DRAIN_MODE_ENAB
+    pub fn is_open_drain(&self) -> bool {
+        *self == ODR::OPEN_DRAIN
     }
 }
 #[doc = "Values that can be written to the field `FUNC`"]
 pub enum FUNCW {
     #[doc = "PIO1_3."]
-    PIO1_3_,
+    PIO1_3,
     #[doc = "CT32B1_MAT3."]
-    CT32B1_MAT3_,
+    CT32B1_MAT3,
 }
 impl FUNCW {
     #[allow(missing_docs)]
@@ -293,8 +293,8 @@ impl FUNCW {
     #[inline]
     pub fn _bits(&self) -> u8 {
         match *self {
-            FUNCW::PIO1_3_ => 0,
-            FUNCW::CT32B1_MAT3_ => 1,
+            FUNCW::PIO1_3 => 0,
+            FUNCW::CT32B1_MAT3 => 1,
         }
     }
 }
@@ -310,13 +310,13 @@ impl<'a> _FUNCW<'a> {
     }
     #[doc = "PIO1_3."]
     #[inline]
-    pub fn pio1_3_(self) -> &'a mut W {
-        self.variant(FUNCW::PIO1_3_)
+    pub fn pio1_3(self) -> &'a mut W {
+        self.variant(FUNCW::PIO1_3)
     }
     #[doc = "CT32B1_MAT3."]
     #[inline]
-    pub fn ct32b1_mat3_(self) -> &'a mut W {
-        self.variant(FUNCW::CT32B1_MAT3_)
+    pub fn ct32b1_mat3(self) -> &'a mut W {
+        self.variant(FUNCW::CT32B1_MAT3)
     }
     #[doc = r" Writes raw bits to the field"]
     #[inline]
@@ -331,13 +331,13 @@ impl<'a> _FUNCW<'a> {
 #[doc = "Values that can be written to the field `MODE`"]
 pub enum MODEW {
     #[doc = "Inactive (no pull-down/pull-up resistor enabled)."]
-    INACTIVE_NO_PULL_DO,
+    INACTIVE,
     #[doc = "Pull-down resistor enabled."]
-    PULL_DOWN_RESISTOR_E,
+    PULL_DOWN,
     #[doc = "Pull-up resistor enabled."]
-    PULL_UP_RESISTOR_ENA,
+    PULL_UP,
     #[doc = "Repeater mode."]
-    REPEATER_MODE_,
+    REPEATER,
 }
 impl MODEW {
     #[allow(missing_docs)]
@@ -345,10 +345,10 @@ impl MODEW {
     #[inline]
     pub fn _bits(&self) -> u8 {
         match *self {
-            MODEW::INACTIVE_NO_PULL_DO => 0,
-            MODEW::PULL_DOWN_RESISTOR_E => 1,
-            MODEW::PULL_UP_RESISTOR_ENA => 2,
-            MODEW::REPEATER_MODE_ => 3,
+            MODEW::INACTIVE => 0,
+            MODEW::PULL_DOWN => 1,
+            MODEW::PULL_UP => 2,
+            MODEW::REPEATER => 3,
         }
     }
 }
@@ -366,23 +366,23 @@ impl<'a> _MODEW<'a> {
     }
     #[doc = "Inactive (no pull-down/pull-up resistor enabled)."]
     #[inline]
-    pub fn inactive_no_pull_do(self) -> &'a mut W {
-        self.variant(MODEW::INACTIVE_NO_PULL_DO)
+    pub fn inactive(self) -> &'a mut W {
+        self.variant(MODEW::INACTIVE)
     }
     #[doc = "Pull-down resistor enabled."]
     #[inline]
-    pub fn pull_down_resistor_e(self) -> &'a mut W {
-        self.variant(MODEW::PULL_DOWN_RESISTOR_E)
+    pub fn pull_down(self) -> &'a mut W {
+        self.variant(MODEW::PULL_DOWN)
     }
     #[doc = "Pull-up resistor enabled."]
     #[inline]
-    pub fn pull_up_resistor_ena(self) -> &'a mut W {
-        self.variant(MODEW::PULL_UP_RESISTOR_ENA)
+    pub fn pull_up(self) -> &'a mut W {
+        self.variant(MODEW::PULL_UP)
     }
     #[doc = "Repeater mode."]
     #[inline]
-    pub fn repeater_mode_(self) -> &'a mut W {
-        self.variant(MODEW::REPEATER_MODE_)
+    pub fn repeater(self) -> &'a mut W {
+        self.variant(MODEW::REPEATER)
     }
     #[doc = r" Writes raw bits to the field"]
     #[inline]
@@ -397,9 +397,9 @@ impl<'a> _MODEW<'a> {
 #[doc = "Values that can be written to the field `HYS`"]
 pub enum HYSW {
     #[doc = "Disable."]
-    DISABLE_,
+    DISABLED,
     #[doc = "Enable."]
-    ENABLE_,
+    ENABLED,
 }
 impl HYSW {
     #[allow(missing_docs)]
@@ -407,8 +407,8 @@ impl HYSW {
     #[inline]
     pub fn _bits(&self) -> bool {
         match *self {
-            HYSW::DISABLE_ => false,
-            HYSW::ENABLE_ => true,
+            HYSW::DISABLED => false,
+            HYSW::ENABLED => true,
         }
     }
 }
@@ -426,13 +426,13 @@ impl<'a> _HYSW<'a> {
     }
     #[doc = "Disable."]
     #[inline]
-    pub fn disable_(self) -> &'a mut W {
-        self.variant(HYSW::DISABLE_)
+    pub fn disabled(self) -> &'a mut W {
+        self.variant(HYSW::DISABLED)
     }
     #[doc = "Enable."]
     #[inline]
-    pub fn enable_(self) -> &'a mut W {
-        self.variant(HYSW::ENABLE_)
+    pub fn enabled(self) -> &'a mut W {
+        self.variant(HYSW::ENABLED)
     }
     #[doc = r" Sets the field bit"]
     pub fn set_bit(self) -> &'a mut W {
@@ -455,9 +455,9 @@ impl<'a> _HYSW<'a> {
 #[doc = "Values that can be written to the field `INV`"]
 pub enum INVW {
     #[doc = "Input not inverted (HIGH on pin reads as 1, LOW on pin reads as 0)."]
-    INPUT_NOT_INVERTED_,
+    NOT_INVERTED,
     #[doc = "Input inverted (HIGH on pin reads as 0, LOW on pin reads as 1)."]
-    INPUT_INVERTED_HIGH,
+    INVERTED,
 }
 impl INVW {
     #[allow(missing_docs)]
@@ -465,8 +465,8 @@ impl INVW {
     #[inline]
     pub fn _bits(&self) -> bool {
         match *self {
-            INVW::INPUT_NOT_INVERTED_ => false,
-            INVW::INPUT_INVERTED_HIGH => true,
+            INVW::NOT_INVERTED => false,
+            INVW::INVERTED => true,
         }
     }
 }
@@ -484,13 +484,13 @@ impl<'a> _INVW<'a> {
     }
     #[doc = "Input not inverted (HIGH on pin reads as 1, LOW on pin reads as 0)."]
     #[inline]
-    pub fn input_not_inverted_(self) -> &'a mut W {
-        self.variant(INVW::INPUT_NOT_INVERTED_)
+    pub fn not_inverted(self) -> &'a mut W {
+        self.variant(INVW::NOT_INVERTED)
     }
     #[doc = "Input inverted (HIGH on pin reads as 0, LOW on pin reads as 1)."]
     #[inline]
-    pub fn input_inverted_high(self) -> &'a mut W {
-        self.variant(INVW::INPUT_INVERTED_HIGH)
+    pub fn inverted(self) -> &'a mut W {
+        self.variant(INVW::INVERTED)
     }
     #[doc = r" Sets the field bit"]
     pub fn set_bit(self) -> &'a mut W {
@@ -513,9 +513,9 @@ impl<'a> _INVW<'a> {
 #[doc = "Values that can be written to the field `OD`"]
 pub enum ODW {
     #[doc = "Disable."]
-    DISABLE_,
+    DISABLED,
     #[doc = "Open-drain mode enabled. This is not a true open-drain mode. Input cannot be pulled up above VDD."]
-    OPEN_DRAIN_MODE_ENAB,
+    OPEN_DRAIN,
 }
 impl ODW {
     #[allow(missing_docs)]
@@ -523,8 +523,8 @@ impl ODW {
     #[inline]
     pub fn _bits(&self) -> bool {
         match *self {
-            ODW::DISABLE_ => false,
-            ODW::OPEN_DRAIN_MODE_ENAB => true,
+            ODW::DISABLED => false,
+            ODW::OPEN_DRAIN => true,
         }
     }
 }
@@ -542,13 +542,13 @@ impl<'a> _ODW<'a> {
     }
     #[doc = "Disable."]
     #[inline]
-    pub fn disable_(self) -> &'a mut W {
-        self.variant(ODW::DISABLE_)
+    pub fn disabled(self) -> &'a mut W {
+        self.variant(ODW::DISABLED)
     }
     #[doc = "Open-drain mode enabled. This is not a true open-drain mode. Input cannot be pulled up above VDD."]
     #[inline]
-    pub fn open_drain_mode_enab(self) -> &'a mut W {
-        self.variant(ODW::OPEN_DRAIN_MODE_ENAB)
+    pub fn open_drain(self) -> &'a mut W {
+        self.variant(ODW::OPEN_DRAIN)
     }
     #[doc = r" Sets the field bit"]
     pub fn set_bit(self) -> &'a mut W {

--- a/lpc11uxx/src/iocon/pio1_31.rs
+++ b/lpc11uxx/src/iocon/pio1_31.rs
@@ -46,7 +46,7 @@ impl super::PIO1_31 {
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum FUNCR {
     #[doc = "PIO1_31."]
-    PIO1_31_,
+    PIO1_31,
     #[doc = r" Reserved"]
     _Reserved(u8),
 }
@@ -55,7 +55,7 @@ impl FUNCR {
     #[inline]
     pub fn bits(&self) -> u8 {
         match *self {
-            FUNCR::PIO1_31_ => 0,
+            FUNCR::PIO1_31 => 0,
             FUNCR::_Reserved(bits) => bits,
         }
     }
@@ -64,37 +64,37 @@ impl FUNCR {
     #[inline]
     pub fn _from(value: u8) -> FUNCR {
         match value {
-            0 => FUNCR::PIO1_31_,
+            0 => FUNCR::PIO1_31,
             i => FUNCR::_Reserved(i),
         }
     }
-    #[doc = "Checks if the value of the field is `PIO1_31_`"]
+    #[doc = "Checks if the value of the field is `PIO1_31`"]
     #[inline]
-    pub fn is_pio1_31_(&self) -> bool {
-        *self == FUNCR::PIO1_31_
+    pub fn is_pio1_31(&self) -> bool {
+        *self == FUNCR::PIO1_31
     }
 }
 #[doc = "Possible values of the field `MODE`"]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum MODER {
     #[doc = "Inactive (no pull-down/pull-up resistor enabled)."]
-    INACTIVE_NO_PULL_DO,
+    INACTIVE,
     #[doc = "Pull-down resistor enabled."]
-    PULL_DOWN_RESISTOR_E,
+    PULL_DOWN,
     #[doc = "Pull-up resistor enabled."]
-    PULL_UP_RESISTOR_ENA,
+    PULL_UP,
     #[doc = "Repeater mode."]
-    REPEATER_MODE_,
+    REPEATER,
 }
 impl MODER {
     #[doc = r" Value of the field as raw bits"]
     #[inline]
     pub fn bits(&self) -> u8 {
         match *self {
-            MODER::INACTIVE_NO_PULL_DO => 0,
-            MODER::PULL_DOWN_RESISTOR_E => 1,
-            MODER::PULL_UP_RESISTOR_ENA => 2,
-            MODER::REPEATER_MODE_ => 3,
+            MODER::INACTIVE => 0,
+            MODER::PULL_DOWN => 1,
+            MODER::PULL_UP => 2,
+            MODER::REPEATER => 3,
         }
     }
     #[allow(missing_docs)]
@@ -102,41 +102,41 @@ impl MODER {
     #[inline]
     pub fn _from(value: u8) -> MODER {
         match value {
-            0 => MODER::INACTIVE_NO_PULL_DO,
-            1 => MODER::PULL_DOWN_RESISTOR_E,
-            2 => MODER::PULL_UP_RESISTOR_ENA,
-            3 => MODER::REPEATER_MODE_,
+            0 => MODER::INACTIVE,
+            1 => MODER::PULL_DOWN,
+            2 => MODER::PULL_UP,
+            3 => MODER::REPEATER,
             _ => unreachable!(),
         }
     }
-    #[doc = "Checks if the value of the field is `INACTIVE_NO_PULL_DO`"]
+    #[doc = "Checks if the value of the field is `INACTIVE`"]
     #[inline]
-    pub fn is_inactive_no_pull_do(&self) -> bool {
-        *self == MODER::INACTIVE_NO_PULL_DO
+    pub fn is_inactive(&self) -> bool {
+        *self == MODER::INACTIVE
     }
-    #[doc = "Checks if the value of the field is `PULL_DOWN_RESISTOR_E`"]
+    #[doc = "Checks if the value of the field is `PULL_DOWN`"]
     #[inline]
-    pub fn is_pull_down_resistor_e(&self) -> bool {
-        *self == MODER::PULL_DOWN_RESISTOR_E
+    pub fn is_pull_down(&self) -> bool {
+        *self == MODER::PULL_DOWN
     }
-    #[doc = "Checks if the value of the field is `PULL_UP_RESISTOR_ENA`"]
+    #[doc = "Checks if the value of the field is `PULL_UP`"]
     #[inline]
-    pub fn is_pull_up_resistor_ena(&self) -> bool {
-        *self == MODER::PULL_UP_RESISTOR_ENA
+    pub fn is_pull_up(&self) -> bool {
+        *self == MODER::PULL_UP
     }
-    #[doc = "Checks if the value of the field is `REPEATER_MODE_`"]
+    #[doc = "Checks if the value of the field is `REPEATER`"]
     #[inline]
-    pub fn is_repeater_mode_(&self) -> bool {
-        *self == MODER::REPEATER_MODE_
+    pub fn is_repeater(&self) -> bool {
+        *self == MODER::REPEATER
     }
 }
 #[doc = "Possible values of the field `HYS`"]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum HYSR {
     #[doc = "Disable."]
-    DISABLE_,
+    DISABLED,
     #[doc = "Enable."]
-    ENABLE_,
+    ENABLED,
 }
 impl HYSR {
     #[doc = r" Returns `true` if the bit is clear (0)"]
@@ -153,8 +153,8 @@ impl HYSR {
     #[inline]
     pub fn bit(&self) -> bool {
         match *self {
-            HYSR::DISABLE_ => false,
-            HYSR::ENABLE_ => true,
+            HYSR::DISABLED => false,
+            HYSR::ENABLED => true,
         }
     }
     #[allow(missing_docs)]
@@ -162,28 +162,28 @@ impl HYSR {
     #[inline]
     pub fn _from(value: bool) -> HYSR {
         match value {
-            false => HYSR::DISABLE_,
-            true => HYSR::ENABLE_,
+            false => HYSR::DISABLED,
+            true => HYSR::ENABLED,
         }
     }
-    #[doc = "Checks if the value of the field is `DISABLE_`"]
+    #[doc = "Checks if the value of the field is `DISABLED`"]
     #[inline]
-    pub fn is_disable_(&self) -> bool {
-        *self == HYSR::DISABLE_
+    pub fn is_disabled(&self) -> bool {
+        *self == HYSR::DISABLED
     }
-    #[doc = "Checks if the value of the field is `ENABLE_`"]
+    #[doc = "Checks if the value of the field is `ENABLED`"]
     #[inline]
-    pub fn is_enable_(&self) -> bool {
-        *self == HYSR::ENABLE_
+    pub fn is_enabled(&self) -> bool {
+        *self == HYSR::ENABLED
     }
 }
 #[doc = "Possible values of the field `INV`"]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum INVR {
     #[doc = "Input not inverted (HIGH on pin reads as 1, LOW on pin reads as 0)."]
-    INPUT_NOT_INVERTED_,
+    NOT_INVERTED,
     #[doc = "Input inverted (HIGH on pin reads as 0, LOW on pin reads as 1)."]
-    INPUT_INVERTED_HIGH,
+    INVERTED,
 }
 impl INVR {
     #[doc = r" Returns `true` if the bit is clear (0)"]
@@ -200,8 +200,8 @@ impl INVR {
     #[inline]
     pub fn bit(&self) -> bool {
         match *self {
-            INVR::INPUT_NOT_INVERTED_ => false,
-            INVR::INPUT_INVERTED_HIGH => true,
+            INVR::NOT_INVERTED => false,
+            INVR::INVERTED => true,
         }
     }
     #[allow(missing_docs)]
@@ -209,28 +209,28 @@ impl INVR {
     #[inline]
     pub fn _from(value: bool) -> INVR {
         match value {
-            false => INVR::INPUT_NOT_INVERTED_,
-            true => INVR::INPUT_INVERTED_HIGH,
+            false => INVR::NOT_INVERTED,
+            true => INVR::INVERTED,
         }
     }
-    #[doc = "Checks if the value of the field is `INPUT_NOT_INVERTED_`"]
+    #[doc = "Checks if the value of the field is `NOT_INVERTED`"]
     #[inline]
-    pub fn is_input_not_inverted_(&self) -> bool {
-        *self == INVR::INPUT_NOT_INVERTED_
+    pub fn is_not_inverted(&self) -> bool {
+        *self == INVR::NOT_INVERTED
     }
-    #[doc = "Checks if the value of the field is `INPUT_INVERTED_HIGH`"]
+    #[doc = "Checks if the value of the field is `INVERTED`"]
     #[inline]
-    pub fn is_input_inverted_high(&self) -> bool {
-        *self == INVR::INPUT_INVERTED_HIGH
+    pub fn is_inverted(&self) -> bool {
+        *self == INVR::INVERTED
     }
 }
 #[doc = "Possible values of the field `OD`"]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum ODR {
     #[doc = "Disable."]
-    DISABLE_,
+    DISABLED,
     #[doc = "Open-drain mode enabled.  This is not a true open-drain mode."]
-    OPEN_DRAIN_MODE_ENAB,
+    OPEN_DRAIN,
 }
 impl ODR {
     #[doc = r" Returns `true` if the bit is clear (0)"]
@@ -247,8 +247,8 @@ impl ODR {
     #[inline]
     pub fn bit(&self) -> bool {
         match *self {
-            ODR::DISABLE_ => false,
-            ODR::OPEN_DRAIN_MODE_ENAB => true,
+            ODR::DISABLED => false,
+            ODR::OPEN_DRAIN => true,
         }
     }
     #[allow(missing_docs)]
@@ -256,25 +256,25 @@ impl ODR {
     #[inline]
     pub fn _from(value: bool) -> ODR {
         match value {
-            false => ODR::DISABLE_,
-            true => ODR::OPEN_DRAIN_MODE_ENAB,
+            false => ODR::DISABLED,
+            true => ODR::OPEN_DRAIN,
         }
     }
-    #[doc = "Checks if the value of the field is `DISABLE_`"]
+    #[doc = "Checks if the value of the field is `DISABLED`"]
     #[inline]
-    pub fn is_disable_(&self) -> bool {
-        *self == ODR::DISABLE_
+    pub fn is_disabled(&self) -> bool {
+        *self == ODR::DISABLED
     }
-    #[doc = "Checks if the value of the field is `OPEN_DRAIN_MODE_ENAB`"]
+    #[doc = "Checks if the value of the field is `OPEN_DRAIN`"]
     #[inline]
-    pub fn is_open_drain_mode_enab(&self) -> bool {
-        *self == ODR::OPEN_DRAIN_MODE_ENAB
+    pub fn is_open_drain(&self) -> bool {
+        *self == ODR::OPEN_DRAIN
     }
 }
 #[doc = "Values that can be written to the field `FUNC`"]
 pub enum FUNCW {
     #[doc = "PIO1_31."]
-    PIO1_31_,
+    PIO1_31,
 }
 impl FUNCW {
     #[allow(missing_docs)]
@@ -282,7 +282,7 @@ impl FUNCW {
     #[inline]
     pub fn _bits(&self) -> u8 {
         match *self {
-            FUNCW::PIO1_31_ => 0,
+            FUNCW::PIO1_31 => 0,
         }
     }
 }
@@ -298,8 +298,8 @@ impl<'a> _FUNCW<'a> {
     }
     #[doc = "PIO1_31."]
     #[inline]
-    pub fn pio1_31_(self) -> &'a mut W {
-        self.variant(FUNCW::PIO1_31_)
+    pub fn pio1_31(self) -> &'a mut W {
+        self.variant(FUNCW::PIO1_31)
     }
     #[doc = r" Writes raw bits to the field"]
     #[inline]
@@ -314,13 +314,13 @@ impl<'a> _FUNCW<'a> {
 #[doc = "Values that can be written to the field `MODE`"]
 pub enum MODEW {
     #[doc = "Inactive (no pull-down/pull-up resistor enabled)."]
-    INACTIVE_NO_PULL_DO,
+    INACTIVE,
     #[doc = "Pull-down resistor enabled."]
-    PULL_DOWN_RESISTOR_E,
+    PULL_DOWN,
     #[doc = "Pull-up resistor enabled."]
-    PULL_UP_RESISTOR_ENA,
+    PULL_UP,
     #[doc = "Repeater mode."]
-    REPEATER_MODE_,
+    REPEATER,
 }
 impl MODEW {
     #[allow(missing_docs)]
@@ -328,10 +328,10 @@ impl MODEW {
     #[inline]
     pub fn _bits(&self) -> u8 {
         match *self {
-            MODEW::INACTIVE_NO_PULL_DO => 0,
-            MODEW::PULL_DOWN_RESISTOR_E => 1,
-            MODEW::PULL_UP_RESISTOR_ENA => 2,
-            MODEW::REPEATER_MODE_ => 3,
+            MODEW::INACTIVE => 0,
+            MODEW::PULL_DOWN => 1,
+            MODEW::PULL_UP => 2,
+            MODEW::REPEATER => 3,
         }
     }
 }
@@ -349,23 +349,23 @@ impl<'a> _MODEW<'a> {
     }
     #[doc = "Inactive (no pull-down/pull-up resistor enabled)."]
     #[inline]
-    pub fn inactive_no_pull_do(self) -> &'a mut W {
-        self.variant(MODEW::INACTIVE_NO_PULL_DO)
+    pub fn inactive(self) -> &'a mut W {
+        self.variant(MODEW::INACTIVE)
     }
     #[doc = "Pull-down resistor enabled."]
     #[inline]
-    pub fn pull_down_resistor_e(self) -> &'a mut W {
-        self.variant(MODEW::PULL_DOWN_RESISTOR_E)
+    pub fn pull_down(self) -> &'a mut W {
+        self.variant(MODEW::PULL_DOWN)
     }
     #[doc = "Pull-up resistor enabled."]
     #[inline]
-    pub fn pull_up_resistor_ena(self) -> &'a mut W {
-        self.variant(MODEW::PULL_UP_RESISTOR_ENA)
+    pub fn pull_up(self) -> &'a mut W {
+        self.variant(MODEW::PULL_UP)
     }
     #[doc = "Repeater mode."]
     #[inline]
-    pub fn repeater_mode_(self) -> &'a mut W {
-        self.variant(MODEW::REPEATER_MODE_)
+    pub fn repeater(self) -> &'a mut W {
+        self.variant(MODEW::REPEATER)
     }
     #[doc = r" Writes raw bits to the field"]
     #[inline]
@@ -380,9 +380,9 @@ impl<'a> _MODEW<'a> {
 #[doc = "Values that can be written to the field `HYS`"]
 pub enum HYSW {
     #[doc = "Disable."]
-    DISABLE_,
+    DISABLED,
     #[doc = "Enable."]
-    ENABLE_,
+    ENABLED,
 }
 impl HYSW {
     #[allow(missing_docs)]
@@ -390,8 +390,8 @@ impl HYSW {
     #[inline]
     pub fn _bits(&self) -> bool {
         match *self {
-            HYSW::DISABLE_ => false,
-            HYSW::ENABLE_ => true,
+            HYSW::DISABLED => false,
+            HYSW::ENABLED => true,
         }
     }
 }
@@ -409,13 +409,13 @@ impl<'a> _HYSW<'a> {
     }
     #[doc = "Disable."]
     #[inline]
-    pub fn disable_(self) -> &'a mut W {
-        self.variant(HYSW::DISABLE_)
+    pub fn disabled(self) -> &'a mut W {
+        self.variant(HYSW::DISABLED)
     }
     #[doc = "Enable."]
     #[inline]
-    pub fn enable_(self) -> &'a mut W {
-        self.variant(HYSW::ENABLE_)
+    pub fn enabled(self) -> &'a mut W {
+        self.variant(HYSW::ENABLED)
     }
     #[doc = r" Sets the field bit"]
     pub fn set_bit(self) -> &'a mut W {
@@ -438,9 +438,9 @@ impl<'a> _HYSW<'a> {
 #[doc = "Values that can be written to the field `INV`"]
 pub enum INVW {
     #[doc = "Input not inverted (HIGH on pin reads as 1, LOW on pin reads as 0)."]
-    INPUT_NOT_INVERTED_,
+    NOT_INVERTED,
     #[doc = "Input inverted (HIGH on pin reads as 0, LOW on pin reads as 1)."]
-    INPUT_INVERTED_HIGH,
+    INVERTED,
 }
 impl INVW {
     #[allow(missing_docs)]
@@ -448,8 +448,8 @@ impl INVW {
     #[inline]
     pub fn _bits(&self) -> bool {
         match *self {
-            INVW::INPUT_NOT_INVERTED_ => false,
-            INVW::INPUT_INVERTED_HIGH => true,
+            INVW::NOT_INVERTED => false,
+            INVW::INVERTED => true,
         }
     }
 }
@@ -467,13 +467,13 @@ impl<'a> _INVW<'a> {
     }
     #[doc = "Input not inverted (HIGH on pin reads as 1, LOW on pin reads as 0)."]
     #[inline]
-    pub fn input_not_inverted_(self) -> &'a mut W {
-        self.variant(INVW::INPUT_NOT_INVERTED_)
+    pub fn not_inverted(self) -> &'a mut W {
+        self.variant(INVW::NOT_INVERTED)
     }
     #[doc = "Input inverted (HIGH on pin reads as 0, LOW on pin reads as 1)."]
     #[inline]
-    pub fn input_inverted_high(self) -> &'a mut W {
-        self.variant(INVW::INPUT_INVERTED_HIGH)
+    pub fn inverted(self) -> &'a mut W {
+        self.variant(INVW::INVERTED)
     }
     #[doc = r" Sets the field bit"]
     pub fn set_bit(self) -> &'a mut W {
@@ -496,9 +496,9 @@ impl<'a> _INVW<'a> {
 #[doc = "Values that can be written to the field `OD`"]
 pub enum ODW {
     #[doc = "Disable."]
-    DISABLE_,
+    DISABLED,
     #[doc = "Open-drain mode enabled.  This is not a true open-drain mode."]
-    OPEN_DRAIN_MODE_ENAB,
+    OPEN_DRAIN,
 }
 impl ODW {
     #[allow(missing_docs)]
@@ -506,8 +506,8 @@ impl ODW {
     #[inline]
     pub fn _bits(&self) -> bool {
         match *self {
-            ODW::DISABLE_ => false,
-            ODW::OPEN_DRAIN_MODE_ENAB => true,
+            ODW::DISABLED => false,
+            ODW::OPEN_DRAIN => true,
         }
     }
 }
@@ -525,13 +525,13 @@ impl<'a> _ODW<'a> {
     }
     #[doc = "Disable."]
     #[inline]
-    pub fn disable_(self) -> &'a mut W {
-        self.variant(ODW::DISABLE_)
+    pub fn disabled(self) -> &'a mut W {
+        self.variant(ODW::DISABLED)
     }
     #[doc = "Open-drain mode enabled. This is not a true open-drain mode."]
     #[inline]
-    pub fn open_drain_mode_enab(self) -> &'a mut W {
-        self.variant(ODW::OPEN_DRAIN_MODE_ENAB)
+    pub fn open_drain(self) -> &'a mut W {
+        self.variant(ODW::OPEN_DRAIN)
     }
     #[doc = r" Sets the field bit"]
     pub fn set_bit(self) -> &'a mut W {

--- a/lpc11uxx/src/iocon/pio1_4.rs
+++ b/lpc11uxx/src/iocon/pio1_4.rs
@@ -46,9 +46,9 @@ impl super::PIO1_4 {
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum FUNCR {
     #[doc = "PIO1_4."]
-    PIO1_4_,
+    PIO1_4,
     #[doc = "CT32B1_CAP0."]
-    CT32B1_CAP0_,
+    CT32B1_CAP0,
     #[doc = r" Reserved"]
     _Reserved(u8),
 }
@@ -57,8 +57,8 @@ impl FUNCR {
     #[inline]
     pub fn bits(&self) -> u8 {
         match *self {
-            FUNCR::PIO1_4_ => 0,
-            FUNCR::CT32B1_CAP0_ => 1,
+            FUNCR::PIO1_4 => 0,
+            FUNCR::CT32B1_CAP0 => 1,
             FUNCR::_Reserved(bits) => bits,
         }
     }
@@ -67,43 +67,43 @@ impl FUNCR {
     #[inline]
     pub fn _from(value: u8) -> FUNCR {
         match value {
-            0 => FUNCR::PIO1_4_,
-            1 => FUNCR::CT32B1_CAP0_,
+            0 => FUNCR::PIO1_4,
+            1 => FUNCR::CT32B1_CAP0,
             i => FUNCR::_Reserved(i),
         }
     }
-    #[doc = "Checks if the value of the field is `PIO1_4_`"]
+    #[doc = "Checks if the value of the field is `PIO1_4`"]
     #[inline]
-    pub fn is_pio1_4_(&self) -> bool {
-        *self == FUNCR::PIO1_4_
+    pub fn is_pio1_4(&self) -> bool {
+        *self == FUNCR::PIO1_4
     }
-    #[doc = "Checks if the value of the field is `CT32B1_CAP0_`"]
+    #[doc = "Checks if the value of the field is `CT32B1_CAP0`"]
     #[inline]
-    pub fn is_ct32b1_cap0_(&self) -> bool {
-        *self == FUNCR::CT32B1_CAP0_
+    pub fn is_ct32b1_cap0(&self) -> bool {
+        *self == FUNCR::CT32B1_CAP0
     }
 }
 #[doc = "Possible values of the field `MODE`"]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum MODER {
     #[doc = "Inactive (no pull-down/pull-up resistor enabled)."]
-    INACTIVE_NO_PULL_DO,
+    INACTIVE,
     #[doc = "Pull-down resistor enabled."]
-    PULL_DOWN_RESISTOR_E,
+    PULL_DOWN,
     #[doc = "Pull-up resistor enabled."]
-    PULL_UP_RESISTOR_ENA,
+    PULL_UP,
     #[doc = "Repeater mode."]
-    REPEATER_MODE_,
+    REPEATER,
 }
 impl MODER {
     #[doc = r" Value of the field as raw bits"]
     #[inline]
     pub fn bits(&self) -> u8 {
         match *self {
-            MODER::INACTIVE_NO_PULL_DO => 0,
-            MODER::PULL_DOWN_RESISTOR_E => 1,
-            MODER::PULL_UP_RESISTOR_ENA => 2,
-            MODER::REPEATER_MODE_ => 3,
+            MODER::INACTIVE => 0,
+            MODER::PULL_DOWN => 1,
+            MODER::PULL_UP => 2,
+            MODER::REPEATER => 3,
         }
     }
     #[allow(missing_docs)]
@@ -111,41 +111,41 @@ impl MODER {
     #[inline]
     pub fn _from(value: u8) -> MODER {
         match value {
-            0 => MODER::INACTIVE_NO_PULL_DO,
-            1 => MODER::PULL_DOWN_RESISTOR_E,
-            2 => MODER::PULL_UP_RESISTOR_ENA,
-            3 => MODER::REPEATER_MODE_,
+            0 => MODER::INACTIVE,
+            1 => MODER::PULL_DOWN,
+            2 => MODER::PULL_UP,
+            3 => MODER::REPEATER,
             _ => unreachable!(),
         }
     }
-    #[doc = "Checks if the value of the field is `INACTIVE_NO_PULL_DO`"]
+    #[doc = "Checks if the value of the field is `INACTIVE`"]
     #[inline]
-    pub fn is_inactive_no_pull_do(&self) -> bool {
-        *self == MODER::INACTIVE_NO_PULL_DO
+    pub fn is_inactive(&self) -> bool {
+        *self == MODER::INACTIVE
     }
-    #[doc = "Checks if the value of the field is `PULL_DOWN_RESISTOR_E`"]
+    #[doc = "Checks if the value of the field is `PULL_DOWN`"]
     #[inline]
-    pub fn is_pull_down_resistor_e(&self) -> bool {
-        *self == MODER::PULL_DOWN_RESISTOR_E
+    pub fn is_pull_down(&self) -> bool {
+        *self == MODER::PULL_DOWN
     }
-    #[doc = "Checks if the value of the field is `PULL_UP_RESISTOR_ENA`"]
+    #[doc = "Checks if the value of the field is `PULL_UP`"]
     #[inline]
-    pub fn is_pull_up_resistor_ena(&self) -> bool {
-        *self == MODER::PULL_UP_RESISTOR_ENA
+    pub fn is_pull_up(&self) -> bool {
+        *self == MODER::PULL_UP
     }
-    #[doc = "Checks if the value of the field is `REPEATER_MODE_`"]
+    #[doc = "Checks if the value of the field is `REPEATER`"]
     #[inline]
-    pub fn is_repeater_mode_(&self) -> bool {
-        *self == MODER::REPEATER_MODE_
+    pub fn is_repeater(&self) -> bool {
+        *self == MODER::REPEATER
     }
 }
 #[doc = "Possible values of the field `HYS`"]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum HYSR {
     #[doc = "Disable."]
-    DISABLE_,
+    DISABLED,
     #[doc = "Enable."]
-    ENABLE_,
+    ENABLED,
 }
 impl HYSR {
     #[doc = r" Returns `true` if the bit is clear (0)"]
@@ -162,8 +162,8 @@ impl HYSR {
     #[inline]
     pub fn bit(&self) -> bool {
         match *self {
-            HYSR::DISABLE_ => false,
-            HYSR::ENABLE_ => true,
+            HYSR::DISABLED => false,
+            HYSR::ENABLED => true,
         }
     }
     #[allow(missing_docs)]
@@ -171,28 +171,28 @@ impl HYSR {
     #[inline]
     pub fn _from(value: bool) -> HYSR {
         match value {
-            false => HYSR::DISABLE_,
-            true => HYSR::ENABLE_,
+            false => HYSR::DISABLED,
+            true => HYSR::ENABLED,
         }
     }
-    #[doc = "Checks if the value of the field is `DISABLE_`"]
+    #[doc = "Checks if the value of the field is `DISABLED`"]
     #[inline]
-    pub fn is_disable_(&self) -> bool {
-        *self == HYSR::DISABLE_
+    pub fn is_disabled(&self) -> bool {
+        *self == HYSR::DISABLED
     }
-    #[doc = "Checks if the value of the field is `ENABLE_`"]
+    #[doc = "Checks if the value of the field is `ENABLED`"]
     #[inline]
-    pub fn is_enable_(&self) -> bool {
-        *self == HYSR::ENABLE_
+    pub fn is_enabled(&self) -> bool {
+        *self == HYSR::ENABLED
     }
 }
 #[doc = "Possible values of the field `INV`"]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum INVR {
     #[doc = "Input not inverted (HIGH on pin reads as 1, LOW on pin reads as 0)."]
-    INPUT_NOT_INVERTED_,
+    NOT_INVERTED,
     #[doc = "Input inverted (HIGH on pin reads as 0, LOW on pin reads as 1)."]
-    INPUT_INVERTED_HIGH,
+    INVERTED,
 }
 impl INVR {
     #[doc = r" Returns `true` if the bit is clear (0)"]
@@ -209,8 +209,8 @@ impl INVR {
     #[inline]
     pub fn bit(&self) -> bool {
         match *self {
-            INVR::INPUT_NOT_INVERTED_ => false,
-            INVR::INPUT_INVERTED_HIGH => true,
+            INVR::NOT_INVERTED => false,
+            INVR::INVERTED => true,
         }
     }
     #[allow(missing_docs)]
@@ -218,28 +218,28 @@ impl INVR {
     #[inline]
     pub fn _from(value: bool) -> INVR {
         match value {
-            false => INVR::INPUT_NOT_INVERTED_,
-            true => INVR::INPUT_INVERTED_HIGH,
+            false => INVR::NOT_INVERTED,
+            true => INVR::INVERTED,
         }
     }
-    #[doc = "Checks if the value of the field is `INPUT_NOT_INVERTED_`"]
+    #[doc = "Checks if the value of the field is `NOT_INVERTED`"]
     #[inline]
-    pub fn is_input_not_inverted_(&self) -> bool {
-        *self == INVR::INPUT_NOT_INVERTED_
+    pub fn is_not_inverted(&self) -> bool {
+        *self == INVR::NOT_INVERTED
     }
-    #[doc = "Checks if the value of the field is `INPUT_INVERTED_HIGH`"]
+    #[doc = "Checks if the value of the field is `INVERTED`"]
     #[inline]
-    pub fn is_input_inverted_high(&self) -> bool {
-        *self == INVR::INPUT_INVERTED_HIGH
+    pub fn is_inverted(&self) -> bool {
+        *self == INVR::INVERTED
     }
 }
 #[doc = "Possible values of the field `OD`"]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum ODR {
     #[doc = "Disable."]
-    DISABLE_,
+    DISABLED,
     #[doc = "Open-drain mode enabled. This is not a true open-drain mode. Input cannot be pulled up above VDD."]
-    OPEN_DRAIN_MODE_ENAB,
+    OPEN_DRAIN,
 }
 impl ODR {
     #[doc = r" Returns `true` if the bit is clear (0)"]
@@ -256,8 +256,8 @@ impl ODR {
     #[inline]
     pub fn bit(&self) -> bool {
         match *self {
-            ODR::DISABLE_ => false,
-            ODR::OPEN_DRAIN_MODE_ENAB => true,
+            ODR::DISABLED => false,
+            ODR::OPEN_DRAIN => true,
         }
     }
     #[allow(missing_docs)]
@@ -265,27 +265,27 @@ impl ODR {
     #[inline]
     pub fn _from(value: bool) -> ODR {
         match value {
-            false => ODR::DISABLE_,
-            true => ODR::OPEN_DRAIN_MODE_ENAB,
+            false => ODR::DISABLED,
+            true => ODR::OPEN_DRAIN,
         }
     }
-    #[doc = "Checks if the value of the field is `DISABLE_`"]
+    #[doc = "Checks if the value of the field is `DISABLED`"]
     #[inline]
-    pub fn is_disable_(&self) -> bool {
-        *self == ODR::DISABLE_
+    pub fn is_disabled(&self) -> bool {
+        *self == ODR::DISABLED
     }
-    #[doc = "Checks if the value of the field is `OPEN_DRAIN_MODE_ENAB`"]
+    #[doc = "Checks if the value of the field is `OPEN_DRAIN`"]
     #[inline]
-    pub fn is_open_drain_mode_enab(&self) -> bool {
-        *self == ODR::OPEN_DRAIN_MODE_ENAB
+    pub fn is_open_drain(&self) -> bool {
+        *self == ODR::OPEN_DRAIN
     }
 }
 #[doc = "Values that can be written to the field `FUNC`"]
 pub enum FUNCW {
     #[doc = "PIO1_4."]
-    PIO1_4_,
+    PIO1_4,
     #[doc = "CT32B1_CAP0."]
-    CT32B1_CAP0_,
+    CT32B1_CAP0,
 }
 impl FUNCW {
     #[allow(missing_docs)]
@@ -293,8 +293,8 @@ impl FUNCW {
     #[inline]
     pub fn _bits(&self) -> u8 {
         match *self {
-            FUNCW::PIO1_4_ => 0,
-            FUNCW::CT32B1_CAP0_ => 1,
+            FUNCW::PIO1_4 => 0,
+            FUNCW::CT32B1_CAP0 => 1,
         }
     }
 }
@@ -310,13 +310,13 @@ impl<'a> _FUNCW<'a> {
     }
     #[doc = "PIO1_4."]
     #[inline]
-    pub fn pio1_4_(self) -> &'a mut W {
-        self.variant(FUNCW::PIO1_4_)
+    pub fn pio1_4(self) -> &'a mut W {
+        self.variant(FUNCW::PIO1_4)
     }
     #[doc = "CT32B1_CAP0."]
     #[inline]
-    pub fn ct32b1_cap0_(self) -> &'a mut W {
-        self.variant(FUNCW::CT32B1_CAP0_)
+    pub fn ct32b1_cap0(self) -> &'a mut W {
+        self.variant(FUNCW::CT32B1_CAP0)
     }
     #[doc = r" Writes raw bits to the field"]
     #[inline]
@@ -331,13 +331,13 @@ impl<'a> _FUNCW<'a> {
 #[doc = "Values that can be written to the field `MODE`"]
 pub enum MODEW {
     #[doc = "Inactive (no pull-down/pull-up resistor enabled)."]
-    INACTIVE_NO_PULL_DO,
+    INACTIVE,
     #[doc = "Pull-down resistor enabled."]
-    PULL_DOWN_RESISTOR_E,
+    PULL_DOWN,
     #[doc = "Pull-up resistor enabled."]
-    PULL_UP_RESISTOR_ENA,
+    PULL_UP,
     #[doc = "Repeater mode."]
-    REPEATER_MODE_,
+    REPEATER,
 }
 impl MODEW {
     #[allow(missing_docs)]
@@ -345,10 +345,10 @@ impl MODEW {
     #[inline]
     pub fn _bits(&self) -> u8 {
         match *self {
-            MODEW::INACTIVE_NO_PULL_DO => 0,
-            MODEW::PULL_DOWN_RESISTOR_E => 1,
-            MODEW::PULL_UP_RESISTOR_ENA => 2,
-            MODEW::REPEATER_MODE_ => 3,
+            MODEW::INACTIVE => 0,
+            MODEW::PULL_DOWN => 1,
+            MODEW::PULL_UP => 2,
+            MODEW::REPEATER => 3,
         }
     }
 }
@@ -366,23 +366,23 @@ impl<'a> _MODEW<'a> {
     }
     #[doc = "Inactive (no pull-down/pull-up resistor enabled)."]
     #[inline]
-    pub fn inactive_no_pull_do(self) -> &'a mut W {
-        self.variant(MODEW::INACTIVE_NO_PULL_DO)
+    pub fn inactive(self) -> &'a mut W {
+        self.variant(MODEW::INACTIVE)
     }
     #[doc = "Pull-down resistor enabled."]
     #[inline]
-    pub fn pull_down_resistor_e(self) -> &'a mut W {
-        self.variant(MODEW::PULL_DOWN_RESISTOR_E)
+    pub fn pull_down(self) -> &'a mut W {
+        self.variant(MODEW::PULL_DOWN)
     }
     #[doc = "Pull-up resistor enabled."]
     #[inline]
-    pub fn pull_up_resistor_ena(self) -> &'a mut W {
-        self.variant(MODEW::PULL_UP_RESISTOR_ENA)
+    pub fn pull_up(self) -> &'a mut W {
+        self.variant(MODEW::PULL_UP)
     }
     #[doc = "Repeater mode."]
     #[inline]
-    pub fn repeater_mode_(self) -> &'a mut W {
-        self.variant(MODEW::REPEATER_MODE_)
+    pub fn repeater(self) -> &'a mut W {
+        self.variant(MODEW::REPEATER)
     }
     #[doc = r" Writes raw bits to the field"]
     #[inline]
@@ -397,9 +397,9 @@ impl<'a> _MODEW<'a> {
 #[doc = "Values that can be written to the field `HYS`"]
 pub enum HYSW {
     #[doc = "Disable."]
-    DISABLE_,
+    DISABLED,
     #[doc = "Enable."]
-    ENABLE_,
+    ENABLED,
 }
 impl HYSW {
     #[allow(missing_docs)]
@@ -407,8 +407,8 @@ impl HYSW {
     #[inline]
     pub fn _bits(&self) -> bool {
         match *self {
-            HYSW::DISABLE_ => false,
-            HYSW::ENABLE_ => true,
+            HYSW::DISABLED => false,
+            HYSW::ENABLED => true,
         }
     }
 }
@@ -426,13 +426,13 @@ impl<'a> _HYSW<'a> {
     }
     #[doc = "Disable."]
     #[inline]
-    pub fn disable_(self) -> &'a mut W {
-        self.variant(HYSW::DISABLE_)
+    pub fn disabled(self) -> &'a mut W {
+        self.variant(HYSW::DISABLED)
     }
     #[doc = "Enable."]
     #[inline]
-    pub fn enable_(self) -> &'a mut W {
-        self.variant(HYSW::ENABLE_)
+    pub fn enabled(self) -> &'a mut W {
+        self.variant(HYSW::ENABLED)
     }
     #[doc = r" Sets the field bit"]
     pub fn set_bit(self) -> &'a mut W {
@@ -455,9 +455,9 @@ impl<'a> _HYSW<'a> {
 #[doc = "Values that can be written to the field `INV`"]
 pub enum INVW {
     #[doc = "Input not inverted (HIGH on pin reads as 1, LOW on pin reads as 0)."]
-    INPUT_NOT_INVERTED_,
+    NOT_INVERTED,
     #[doc = "Input inverted (HIGH on pin reads as 0, LOW on pin reads as 1)."]
-    INPUT_INVERTED_HIGH,
+    INVERTED,
 }
 impl INVW {
     #[allow(missing_docs)]
@@ -465,8 +465,8 @@ impl INVW {
     #[inline]
     pub fn _bits(&self) -> bool {
         match *self {
-            INVW::INPUT_NOT_INVERTED_ => false,
-            INVW::INPUT_INVERTED_HIGH => true,
+            INVW::NOT_INVERTED => false,
+            INVW::INVERTED => true,
         }
     }
 }
@@ -484,13 +484,13 @@ impl<'a> _INVW<'a> {
     }
     #[doc = "Input not inverted (HIGH on pin reads as 1, LOW on pin reads as 0)."]
     #[inline]
-    pub fn input_not_inverted_(self) -> &'a mut W {
-        self.variant(INVW::INPUT_NOT_INVERTED_)
+    pub fn not_inverted(self) -> &'a mut W {
+        self.variant(INVW::NOT_INVERTED)
     }
     #[doc = "Input inverted (HIGH on pin reads as 0, LOW on pin reads as 1)."]
     #[inline]
-    pub fn input_inverted_high(self) -> &'a mut W {
-        self.variant(INVW::INPUT_INVERTED_HIGH)
+    pub fn inverted(self) -> &'a mut W {
+        self.variant(INVW::INVERTED)
     }
     #[doc = r" Sets the field bit"]
     pub fn set_bit(self) -> &'a mut W {
@@ -513,9 +513,9 @@ impl<'a> _INVW<'a> {
 #[doc = "Values that can be written to the field `OD`"]
 pub enum ODW {
     #[doc = "Disable."]
-    DISABLE_,
+    DISABLED,
     #[doc = "Open-drain mode enabled. This is not a true open-drain mode. Input cannot be pulled up above VDD."]
-    OPEN_DRAIN_MODE_ENAB,
+    OPEN_DRAIN,
 }
 impl ODW {
     #[allow(missing_docs)]
@@ -523,8 +523,8 @@ impl ODW {
     #[inline]
     pub fn _bits(&self) -> bool {
         match *self {
-            ODW::DISABLE_ => false,
-            ODW::OPEN_DRAIN_MODE_ENAB => true,
+            ODW::DISABLED => false,
+            ODW::OPEN_DRAIN => true,
         }
     }
 }
@@ -542,13 +542,13 @@ impl<'a> _ODW<'a> {
     }
     #[doc = "Disable."]
     #[inline]
-    pub fn disable_(self) -> &'a mut W {
-        self.variant(ODW::DISABLE_)
+    pub fn disabled(self) -> &'a mut W {
+        self.variant(ODW::DISABLED)
     }
     #[doc = "Open-drain mode enabled. This is not a true open-drain mode. Input cannot be pulled up above VDD."]
     #[inline]
-    pub fn open_drain_mode_enab(self) -> &'a mut W {
-        self.variant(ODW::OPEN_DRAIN_MODE_ENAB)
+    pub fn open_drain(self) -> &'a mut W {
+        self.variant(ODW::OPEN_DRAIN)
     }
     #[doc = r" Sets the field bit"]
     pub fn set_bit(self) -> &'a mut W {

--- a/lpc11uxx/src/iocon/pio1_5.rs
+++ b/lpc11uxx/src/iocon/pio1_5.rs
@@ -46,9 +46,9 @@ impl super::PIO1_5 {
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum FUNCR {
     #[doc = "PIO1_5."]
-    PIO1_5_,
+    PIO1_5,
     #[doc = "CT32B1_CAP1."]
-    CT32B1_CAP1_,
+    CT32B1_CAP1,
     #[doc = r" Reserved"]
     _Reserved(u8),
 }
@@ -57,8 +57,8 @@ impl FUNCR {
     #[inline]
     pub fn bits(&self) -> u8 {
         match *self {
-            FUNCR::PIO1_5_ => 0,
-            FUNCR::CT32B1_CAP1_ => 1,
+            FUNCR::PIO1_5 => 0,
+            FUNCR::CT32B1_CAP1 => 1,
             FUNCR::_Reserved(bits) => bits,
         }
     }
@@ -67,43 +67,43 @@ impl FUNCR {
     #[inline]
     pub fn _from(value: u8) -> FUNCR {
         match value {
-            0 => FUNCR::PIO1_5_,
-            1 => FUNCR::CT32B1_CAP1_,
+            0 => FUNCR::PIO1_5,
+            1 => FUNCR::CT32B1_CAP1,
             i => FUNCR::_Reserved(i),
         }
     }
-    #[doc = "Checks if the value of the field is `PIO1_5_`"]
+    #[doc = "Checks if the value of the field is `PIO1_5`"]
     #[inline]
-    pub fn is_pio1_5_(&self) -> bool {
-        *self == FUNCR::PIO1_5_
+    pub fn is_pio1_5(&self) -> bool {
+        *self == FUNCR::PIO1_5
     }
-    #[doc = "Checks if the value of the field is `CT32B1_CAP1_`"]
+    #[doc = "Checks if the value of the field is `CT32B1_CAP1`"]
     #[inline]
-    pub fn is_ct32b1_cap1_(&self) -> bool {
-        *self == FUNCR::CT32B1_CAP1_
+    pub fn is_ct32b1_cap1(&self) -> bool {
+        *self == FUNCR::CT32B1_CAP1
     }
 }
 #[doc = "Possible values of the field `MODE`"]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum MODER {
     #[doc = "Inactive (no pull-down/pull-up resistor enabled)."]
-    INACTIVE_NO_PULL_DO,
+    INACTIVE,
     #[doc = "Pull-down resistor enabled."]
-    PULL_DOWN_RESISTOR_E,
+    PULL_DOWN,
     #[doc = "Pull-up resistor enabled."]
-    PULL_UP_RESISTOR_ENA,
+    PULL_UP,
     #[doc = "Repeater mode."]
-    REPEATER_MODE_,
+    REPEATER,
 }
 impl MODER {
     #[doc = r" Value of the field as raw bits"]
     #[inline]
     pub fn bits(&self) -> u8 {
         match *self {
-            MODER::INACTIVE_NO_PULL_DO => 0,
-            MODER::PULL_DOWN_RESISTOR_E => 1,
-            MODER::PULL_UP_RESISTOR_ENA => 2,
-            MODER::REPEATER_MODE_ => 3,
+            MODER::INACTIVE => 0,
+            MODER::PULL_DOWN => 1,
+            MODER::PULL_UP => 2,
+            MODER::REPEATER => 3,
         }
     }
     #[allow(missing_docs)]
@@ -111,41 +111,41 @@ impl MODER {
     #[inline]
     pub fn _from(value: u8) -> MODER {
         match value {
-            0 => MODER::INACTIVE_NO_PULL_DO,
-            1 => MODER::PULL_DOWN_RESISTOR_E,
-            2 => MODER::PULL_UP_RESISTOR_ENA,
-            3 => MODER::REPEATER_MODE_,
+            0 => MODER::INACTIVE,
+            1 => MODER::PULL_DOWN,
+            2 => MODER::PULL_UP,
+            3 => MODER::REPEATER,
             _ => unreachable!(),
         }
     }
-    #[doc = "Checks if the value of the field is `INACTIVE_NO_PULL_DO`"]
+    #[doc = "Checks if the value of the field is `INACTIVE`"]
     #[inline]
-    pub fn is_inactive_no_pull_do(&self) -> bool {
-        *self == MODER::INACTIVE_NO_PULL_DO
+    pub fn is_inactive(&self) -> bool {
+        *self == MODER::INACTIVE
     }
-    #[doc = "Checks if the value of the field is `PULL_DOWN_RESISTOR_E`"]
+    #[doc = "Checks if the value of the field is `PULL_DOWN`"]
     #[inline]
-    pub fn is_pull_down_resistor_e(&self) -> bool {
-        *self == MODER::PULL_DOWN_RESISTOR_E
+    pub fn is_pull_down(&self) -> bool {
+        *self == MODER::PULL_DOWN
     }
-    #[doc = "Checks if the value of the field is `PULL_UP_RESISTOR_ENA`"]
+    #[doc = "Checks if the value of the field is `PULL_UP`"]
     #[inline]
-    pub fn is_pull_up_resistor_ena(&self) -> bool {
-        *self == MODER::PULL_UP_RESISTOR_ENA
+    pub fn is_pull_up(&self) -> bool {
+        *self == MODER::PULL_UP
     }
-    #[doc = "Checks if the value of the field is `REPEATER_MODE_`"]
+    #[doc = "Checks if the value of the field is `REPEATER`"]
     #[inline]
-    pub fn is_repeater_mode_(&self) -> bool {
-        *self == MODER::REPEATER_MODE_
+    pub fn is_repeater(&self) -> bool {
+        *self == MODER::REPEATER
     }
 }
 #[doc = "Possible values of the field `HYS`"]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum HYSR {
     #[doc = "Disable."]
-    DISABLE_,
+    DISABLED,
     #[doc = "Enable."]
-    ENABLE_,
+    ENABLED,
 }
 impl HYSR {
     #[doc = r" Returns `true` if the bit is clear (0)"]
@@ -162,8 +162,8 @@ impl HYSR {
     #[inline]
     pub fn bit(&self) -> bool {
         match *self {
-            HYSR::DISABLE_ => false,
-            HYSR::ENABLE_ => true,
+            HYSR::DISABLED => false,
+            HYSR::ENABLED => true,
         }
     }
     #[allow(missing_docs)]
@@ -171,28 +171,28 @@ impl HYSR {
     #[inline]
     pub fn _from(value: bool) -> HYSR {
         match value {
-            false => HYSR::DISABLE_,
-            true => HYSR::ENABLE_,
+            false => HYSR::DISABLED,
+            true => HYSR::ENABLED,
         }
     }
-    #[doc = "Checks if the value of the field is `DISABLE_`"]
+    #[doc = "Checks if the value of the field is `DISABLED`"]
     #[inline]
-    pub fn is_disable_(&self) -> bool {
-        *self == HYSR::DISABLE_
+    pub fn is_disabled(&self) -> bool {
+        *self == HYSR::DISABLED
     }
-    #[doc = "Checks if the value of the field is `ENABLE_`"]
+    #[doc = "Checks if the value of the field is `ENABLED`"]
     #[inline]
-    pub fn is_enable_(&self) -> bool {
-        *self == HYSR::ENABLE_
+    pub fn is_enabled(&self) -> bool {
+        *self == HYSR::ENABLED
     }
 }
 #[doc = "Possible values of the field `INV`"]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum INVR {
     #[doc = "Input not inverted (HIGH on pin reads as 1, LOW on pin reads as 0)."]
-    INPUT_NOT_INVERTED_,
+    NOT_INVERTED,
     #[doc = "Input inverted (HIGH on pin reads as 0, LOW on pin reads as 1)."]
-    INPUT_INVERTED_HIGH,
+    INVERTED,
 }
 impl INVR {
     #[doc = r" Returns `true` if the bit is clear (0)"]
@@ -209,8 +209,8 @@ impl INVR {
     #[inline]
     pub fn bit(&self) -> bool {
         match *self {
-            INVR::INPUT_NOT_INVERTED_ => false,
-            INVR::INPUT_INVERTED_HIGH => true,
+            INVR::NOT_INVERTED => false,
+            INVR::INVERTED => true,
         }
     }
     #[allow(missing_docs)]
@@ -218,28 +218,28 @@ impl INVR {
     #[inline]
     pub fn _from(value: bool) -> INVR {
         match value {
-            false => INVR::INPUT_NOT_INVERTED_,
-            true => INVR::INPUT_INVERTED_HIGH,
+            false => INVR::NOT_INVERTED,
+            true => INVR::INVERTED,
         }
     }
-    #[doc = "Checks if the value of the field is `INPUT_NOT_INVERTED_`"]
+    #[doc = "Checks if the value of the field is `NOT_INVERTED`"]
     #[inline]
-    pub fn is_input_not_inverted_(&self) -> bool {
-        *self == INVR::INPUT_NOT_INVERTED_
+    pub fn is_not_inverted(&self) -> bool {
+        *self == INVR::NOT_INVERTED
     }
-    #[doc = "Checks if the value of the field is `INPUT_INVERTED_HIGH`"]
+    #[doc = "Checks if the value of the field is `INVERTED`"]
     #[inline]
-    pub fn is_input_inverted_high(&self) -> bool {
-        *self == INVR::INPUT_INVERTED_HIGH
+    pub fn is_inverted(&self) -> bool {
+        *self == INVR::INVERTED
     }
 }
 #[doc = "Possible values of the field `OD`"]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum ODR {
     #[doc = "Disable."]
-    DISABLE_,
+    DISABLED,
     #[doc = "Open-drain mode enabled.  This is not a true open-drain mode."]
-    OPEN_DRAIN_MODE_ENAB,
+    OPEN_DRAIN,
 }
 impl ODR {
     #[doc = r" Returns `true` if the bit is clear (0)"]
@@ -256,8 +256,8 @@ impl ODR {
     #[inline]
     pub fn bit(&self) -> bool {
         match *self {
-            ODR::DISABLE_ => false,
-            ODR::OPEN_DRAIN_MODE_ENAB => true,
+            ODR::DISABLED => false,
+            ODR::OPEN_DRAIN => true,
         }
     }
     #[allow(missing_docs)]
@@ -265,27 +265,27 @@ impl ODR {
     #[inline]
     pub fn _from(value: bool) -> ODR {
         match value {
-            false => ODR::DISABLE_,
-            true => ODR::OPEN_DRAIN_MODE_ENAB,
+            false => ODR::DISABLED,
+            true => ODR::OPEN_DRAIN,
         }
     }
-    #[doc = "Checks if the value of the field is `DISABLE_`"]
+    #[doc = "Checks if the value of the field is `DISABLED`"]
     #[inline]
-    pub fn is_disable_(&self) -> bool {
-        *self == ODR::DISABLE_
+    pub fn is_disabled(&self) -> bool {
+        *self == ODR::DISABLED
     }
-    #[doc = "Checks if the value of the field is `OPEN_DRAIN_MODE_ENAB`"]
+    #[doc = "Checks if the value of the field is `OPEN_DRAIN`"]
     #[inline]
-    pub fn is_open_drain_mode_enab(&self) -> bool {
-        *self == ODR::OPEN_DRAIN_MODE_ENAB
+    pub fn is_open_drain(&self) -> bool {
+        *self == ODR::OPEN_DRAIN
     }
 }
 #[doc = "Values that can be written to the field `FUNC`"]
 pub enum FUNCW {
     #[doc = "PIO1_5."]
-    PIO1_5_,
+    PIO1_5,
     #[doc = "CT32B1_CAP1."]
-    CT32B1_CAP1_,
+    CT32B1_CAP1,
 }
 impl FUNCW {
     #[allow(missing_docs)]
@@ -293,8 +293,8 @@ impl FUNCW {
     #[inline]
     pub fn _bits(&self) -> u8 {
         match *self {
-            FUNCW::PIO1_5_ => 0,
-            FUNCW::CT32B1_CAP1_ => 1,
+            FUNCW::PIO1_5 => 0,
+            FUNCW::CT32B1_CAP1 => 1,
         }
     }
 }
@@ -310,13 +310,13 @@ impl<'a> _FUNCW<'a> {
     }
     #[doc = "PIO1_5."]
     #[inline]
-    pub fn pio1_5_(self) -> &'a mut W {
-        self.variant(FUNCW::PIO1_5_)
+    pub fn pio1_5(self) -> &'a mut W {
+        self.variant(FUNCW::PIO1_5)
     }
     #[doc = "CT32B1_CAP1."]
     #[inline]
-    pub fn ct32b1_cap1_(self) -> &'a mut W {
-        self.variant(FUNCW::CT32B1_CAP1_)
+    pub fn ct32b1_cap1(self) -> &'a mut W {
+        self.variant(FUNCW::CT32B1_CAP1)
     }
     #[doc = r" Writes raw bits to the field"]
     #[inline]
@@ -331,13 +331,13 @@ impl<'a> _FUNCW<'a> {
 #[doc = "Values that can be written to the field `MODE`"]
 pub enum MODEW {
     #[doc = "Inactive (no pull-down/pull-up resistor enabled)."]
-    INACTIVE_NO_PULL_DO,
+    INACTIVE,
     #[doc = "Pull-down resistor enabled."]
-    PULL_DOWN_RESISTOR_E,
+    PULL_DOWN,
     #[doc = "Pull-up resistor enabled."]
-    PULL_UP_RESISTOR_ENA,
+    PULL_UP,
     #[doc = "Repeater mode."]
-    REPEATER_MODE_,
+    REPEATER,
 }
 impl MODEW {
     #[allow(missing_docs)]
@@ -345,10 +345,10 @@ impl MODEW {
     #[inline]
     pub fn _bits(&self) -> u8 {
         match *self {
-            MODEW::INACTIVE_NO_PULL_DO => 0,
-            MODEW::PULL_DOWN_RESISTOR_E => 1,
-            MODEW::PULL_UP_RESISTOR_ENA => 2,
-            MODEW::REPEATER_MODE_ => 3,
+            MODEW::INACTIVE => 0,
+            MODEW::PULL_DOWN => 1,
+            MODEW::PULL_UP => 2,
+            MODEW::REPEATER => 3,
         }
     }
 }
@@ -366,23 +366,23 @@ impl<'a> _MODEW<'a> {
     }
     #[doc = "Inactive (no pull-down/pull-up resistor enabled)."]
     #[inline]
-    pub fn inactive_no_pull_do(self) -> &'a mut W {
-        self.variant(MODEW::INACTIVE_NO_PULL_DO)
+    pub fn inactive(self) -> &'a mut W {
+        self.variant(MODEW::INACTIVE)
     }
     #[doc = "Pull-down resistor enabled."]
     #[inline]
-    pub fn pull_down_resistor_e(self) -> &'a mut W {
-        self.variant(MODEW::PULL_DOWN_RESISTOR_E)
+    pub fn pull_down(self) -> &'a mut W {
+        self.variant(MODEW::PULL_DOWN)
     }
     #[doc = "Pull-up resistor enabled."]
     #[inline]
-    pub fn pull_up_resistor_ena(self) -> &'a mut W {
-        self.variant(MODEW::PULL_UP_RESISTOR_ENA)
+    pub fn pull_up(self) -> &'a mut W {
+        self.variant(MODEW::PULL_UP)
     }
     #[doc = "Repeater mode."]
     #[inline]
-    pub fn repeater_mode_(self) -> &'a mut W {
-        self.variant(MODEW::REPEATER_MODE_)
+    pub fn repeater(self) -> &'a mut W {
+        self.variant(MODEW::REPEATER)
     }
     #[doc = r" Writes raw bits to the field"]
     #[inline]
@@ -397,9 +397,9 @@ impl<'a> _MODEW<'a> {
 #[doc = "Values that can be written to the field `HYS`"]
 pub enum HYSW {
     #[doc = "Disable."]
-    DISABLE_,
+    DISABLED,
     #[doc = "Enable."]
-    ENABLE_,
+    ENABLED,
 }
 impl HYSW {
     #[allow(missing_docs)]
@@ -407,8 +407,8 @@ impl HYSW {
     #[inline]
     pub fn _bits(&self) -> bool {
         match *self {
-            HYSW::DISABLE_ => false,
-            HYSW::ENABLE_ => true,
+            HYSW::DISABLED => false,
+            HYSW::ENABLED => true,
         }
     }
 }
@@ -426,13 +426,13 @@ impl<'a> _HYSW<'a> {
     }
     #[doc = "Disable."]
     #[inline]
-    pub fn disable_(self) -> &'a mut W {
-        self.variant(HYSW::DISABLE_)
+    pub fn disabled(self) -> &'a mut W {
+        self.variant(HYSW::DISABLED)
     }
     #[doc = "Enable."]
     #[inline]
-    pub fn enable_(self) -> &'a mut W {
-        self.variant(HYSW::ENABLE_)
+    pub fn enabled(self) -> &'a mut W {
+        self.variant(HYSW::ENABLED)
     }
     #[doc = r" Sets the field bit"]
     pub fn set_bit(self) -> &'a mut W {
@@ -455,9 +455,9 @@ impl<'a> _HYSW<'a> {
 #[doc = "Values that can be written to the field `INV`"]
 pub enum INVW {
     #[doc = "Input not inverted (HIGH on pin reads as 1, LOW on pin reads as 0)."]
-    INPUT_NOT_INVERTED_,
+    NOT_INVERTED,
     #[doc = "Input inverted (HIGH on pin reads as 0, LOW on pin reads as 1)."]
-    INPUT_INVERTED_HIGH,
+    INVERTED,
 }
 impl INVW {
     #[allow(missing_docs)]
@@ -465,8 +465,8 @@ impl INVW {
     #[inline]
     pub fn _bits(&self) -> bool {
         match *self {
-            INVW::INPUT_NOT_INVERTED_ => false,
-            INVW::INPUT_INVERTED_HIGH => true,
+            INVW::NOT_INVERTED => false,
+            INVW::INVERTED => true,
         }
     }
 }
@@ -484,13 +484,13 @@ impl<'a> _INVW<'a> {
     }
     #[doc = "Input not inverted (HIGH on pin reads as 1, LOW on pin reads as 0)."]
     #[inline]
-    pub fn input_not_inverted_(self) -> &'a mut W {
-        self.variant(INVW::INPUT_NOT_INVERTED_)
+    pub fn not_inverted(self) -> &'a mut W {
+        self.variant(INVW::NOT_INVERTED)
     }
     #[doc = "Input inverted (HIGH on pin reads as 0, LOW on pin reads as 1)."]
     #[inline]
-    pub fn input_inverted_high(self) -> &'a mut W {
-        self.variant(INVW::INPUT_INVERTED_HIGH)
+    pub fn inverted(self) -> &'a mut W {
+        self.variant(INVW::INVERTED)
     }
     #[doc = r" Sets the field bit"]
     pub fn set_bit(self) -> &'a mut W {
@@ -513,9 +513,9 @@ impl<'a> _INVW<'a> {
 #[doc = "Values that can be written to the field `OD`"]
 pub enum ODW {
     #[doc = "Disable."]
-    DISABLE_,
+    DISABLED,
     #[doc = "Open-drain mode enabled.  This is not a true open-drain mode."]
-    OPEN_DRAIN_MODE_ENAB,
+    OPEN_DRAIN,
 }
 impl ODW {
     #[allow(missing_docs)]
@@ -523,8 +523,8 @@ impl ODW {
     #[inline]
     pub fn _bits(&self) -> bool {
         match *self {
-            ODW::DISABLE_ => false,
-            ODW::OPEN_DRAIN_MODE_ENAB => true,
+            ODW::DISABLED => false,
+            ODW::OPEN_DRAIN => true,
         }
     }
 }
@@ -542,13 +542,13 @@ impl<'a> _ODW<'a> {
     }
     #[doc = "Disable."]
     #[inline]
-    pub fn disable_(self) -> &'a mut W {
-        self.variant(ODW::DISABLE_)
+    pub fn disabled(self) -> &'a mut W {
+        self.variant(ODW::DISABLED)
     }
     #[doc = "Open-drain mode enabled. This is not a true open-drain mode."]
     #[inline]
-    pub fn open_drain_mode_enab(self) -> &'a mut W {
-        self.variant(ODW::OPEN_DRAIN_MODE_ENAB)
+    pub fn open_drain(self) -> &'a mut W {
+        self.variant(ODW::OPEN_DRAIN)
     }
     #[doc = r" Sets the field bit"]
     pub fn set_bit(self) -> &'a mut W {

--- a/lpc11uxx/src/iocon/pio1_6.rs
+++ b/lpc11uxx/src/iocon/pio1_6.rs
@@ -46,7 +46,7 @@ impl super::PIO1_6 {
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum FUNCR {
     #[doc = "PIO1_6."]
-    PIO1_6_,
+    PIO1_6,
     #[doc = r" Reserved"]
     _Reserved(u8),
 }
@@ -55,7 +55,7 @@ impl FUNCR {
     #[inline]
     pub fn bits(&self) -> u8 {
         match *self {
-            FUNCR::PIO1_6_ => 0,
+            FUNCR::PIO1_6 => 0,
             FUNCR::_Reserved(bits) => bits,
         }
     }
@@ -64,37 +64,37 @@ impl FUNCR {
     #[inline]
     pub fn _from(value: u8) -> FUNCR {
         match value {
-            0 => FUNCR::PIO1_6_,
+            0 => FUNCR::PIO1_6,
             i => FUNCR::_Reserved(i),
         }
     }
-    #[doc = "Checks if the value of the field is `PIO1_6_`"]
+    #[doc = "Checks if the value of the field is `PIO1_6`"]
     #[inline]
-    pub fn is_pio1_6_(&self) -> bool {
-        *self == FUNCR::PIO1_6_
+    pub fn is_pio1_6(&self) -> bool {
+        *self == FUNCR::PIO1_6
     }
 }
 #[doc = "Possible values of the field `MODE`"]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum MODER {
     #[doc = "Inactive (no pull-down/pull-up resistor enabled)."]
-    INACTIVE_NO_PULL_DO,
+    INACTIVE,
     #[doc = "Pull-down resistor enabled."]
-    PULL_DOWN_RESISTOR_E,
+    PULL_DOWN,
     #[doc = "Pull-up resistor enabled."]
-    PULL_UP_RESISTOR_ENA,
+    PULL_UP,
     #[doc = "Repeater mode."]
-    REPEATER_MODE_,
+    REPEATER,
 }
 impl MODER {
     #[doc = r" Value of the field as raw bits"]
     #[inline]
     pub fn bits(&self) -> u8 {
         match *self {
-            MODER::INACTIVE_NO_PULL_DO => 0,
-            MODER::PULL_DOWN_RESISTOR_E => 1,
-            MODER::PULL_UP_RESISTOR_ENA => 2,
-            MODER::REPEATER_MODE_ => 3,
+            MODER::INACTIVE => 0,
+            MODER::PULL_DOWN => 1,
+            MODER::PULL_UP => 2,
+            MODER::REPEATER => 3,
         }
     }
     #[allow(missing_docs)]
@@ -102,41 +102,41 @@ impl MODER {
     #[inline]
     pub fn _from(value: u8) -> MODER {
         match value {
-            0 => MODER::INACTIVE_NO_PULL_DO,
-            1 => MODER::PULL_DOWN_RESISTOR_E,
-            2 => MODER::PULL_UP_RESISTOR_ENA,
-            3 => MODER::REPEATER_MODE_,
+            0 => MODER::INACTIVE,
+            1 => MODER::PULL_DOWN,
+            2 => MODER::PULL_UP,
+            3 => MODER::REPEATER,
             _ => unreachable!(),
         }
     }
-    #[doc = "Checks if the value of the field is `INACTIVE_NO_PULL_DO`"]
+    #[doc = "Checks if the value of the field is `INACTIVE`"]
     #[inline]
-    pub fn is_inactive_no_pull_do(&self) -> bool {
-        *self == MODER::INACTIVE_NO_PULL_DO
+    pub fn is_inactive(&self) -> bool {
+        *self == MODER::INACTIVE
     }
-    #[doc = "Checks if the value of the field is `PULL_DOWN_RESISTOR_E`"]
+    #[doc = "Checks if the value of the field is `PULL_DOWN`"]
     #[inline]
-    pub fn is_pull_down_resistor_e(&self) -> bool {
-        *self == MODER::PULL_DOWN_RESISTOR_E
+    pub fn is_pull_down(&self) -> bool {
+        *self == MODER::PULL_DOWN
     }
-    #[doc = "Checks if the value of the field is `PULL_UP_RESISTOR_ENA`"]
+    #[doc = "Checks if the value of the field is `PULL_UP`"]
     #[inline]
-    pub fn is_pull_up_resistor_ena(&self) -> bool {
-        *self == MODER::PULL_UP_RESISTOR_ENA
+    pub fn is_pull_up(&self) -> bool {
+        *self == MODER::PULL_UP
     }
-    #[doc = "Checks if the value of the field is `REPEATER_MODE_`"]
+    #[doc = "Checks if the value of the field is `REPEATER`"]
     #[inline]
-    pub fn is_repeater_mode_(&self) -> bool {
-        *self == MODER::REPEATER_MODE_
+    pub fn is_repeater(&self) -> bool {
+        *self == MODER::REPEATER
     }
 }
 #[doc = "Possible values of the field `HYS`"]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum HYSR {
     #[doc = "Disable."]
-    DISABLE_,
+    DISABLED,
     #[doc = "Enable."]
-    ENABLE_,
+    ENABLED,
 }
 impl HYSR {
     #[doc = r" Returns `true` if the bit is clear (0)"]
@@ -153,8 +153,8 @@ impl HYSR {
     #[inline]
     pub fn bit(&self) -> bool {
         match *self {
-            HYSR::DISABLE_ => false,
-            HYSR::ENABLE_ => true,
+            HYSR::DISABLED => false,
+            HYSR::ENABLED => true,
         }
     }
     #[allow(missing_docs)]
@@ -162,28 +162,28 @@ impl HYSR {
     #[inline]
     pub fn _from(value: bool) -> HYSR {
         match value {
-            false => HYSR::DISABLE_,
-            true => HYSR::ENABLE_,
+            false => HYSR::DISABLED,
+            true => HYSR::ENABLED,
         }
     }
-    #[doc = "Checks if the value of the field is `DISABLE_`"]
+    #[doc = "Checks if the value of the field is `DISABLED`"]
     #[inline]
-    pub fn is_disable_(&self) -> bool {
-        *self == HYSR::DISABLE_
+    pub fn is_disabled(&self) -> bool {
+        *self == HYSR::DISABLED
     }
-    #[doc = "Checks if the value of the field is `ENABLE_`"]
+    #[doc = "Checks if the value of the field is `ENABLED`"]
     #[inline]
-    pub fn is_enable_(&self) -> bool {
-        *self == HYSR::ENABLE_
+    pub fn is_enabled(&self) -> bool {
+        *self == HYSR::ENABLED
     }
 }
 #[doc = "Possible values of the field `INV`"]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum INVR {
     #[doc = "Input not inverted (HIGH on pin reads as 1, LOW on pin reads as 0)."]
-    INPUT_NOT_INVERTED_,
+    NOT_INVERTED,
     #[doc = "Input inverted (HIGH on pin reads as 0, LOW on pin reads as 1)."]
-    INPUT_INVERTED_HIGH,
+    INVERTED,
 }
 impl INVR {
     #[doc = r" Returns `true` if the bit is clear (0)"]
@@ -200,8 +200,8 @@ impl INVR {
     #[inline]
     pub fn bit(&self) -> bool {
         match *self {
-            INVR::INPUT_NOT_INVERTED_ => false,
-            INVR::INPUT_INVERTED_HIGH => true,
+            INVR::NOT_INVERTED => false,
+            INVR::INVERTED => true,
         }
     }
     #[allow(missing_docs)]
@@ -209,28 +209,28 @@ impl INVR {
     #[inline]
     pub fn _from(value: bool) -> INVR {
         match value {
-            false => INVR::INPUT_NOT_INVERTED_,
-            true => INVR::INPUT_INVERTED_HIGH,
+            false => INVR::NOT_INVERTED,
+            true => INVR::INVERTED,
         }
     }
-    #[doc = "Checks if the value of the field is `INPUT_NOT_INVERTED_`"]
+    #[doc = "Checks if the value of the field is `NOT_INVERTED`"]
     #[inline]
-    pub fn is_input_not_inverted_(&self) -> bool {
-        *self == INVR::INPUT_NOT_INVERTED_
+    pub fn is_not_inverted(&self) -> bool {
+        *self == INVR::NOT_INVERTED
     }
-    #[doc = "Checks if the value of the field is `INPUT_INVERTED_HIGH`"]
+    #[doc = "Checks if the value of the field is `INVERTED`"]
     #[inline]
-    pub fn is_input_inverted_high(&self) -> bool {
-        *self == INVR::INPUT_INVERTED_HIGH
+    pub fn is_inverted(&self) -> bool {
+        *self == INVR::INVERTED
     }
 }
 #[doc = "Possible values of the field `OD`"]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum ODR {
     #[doc = "Disable."]
-    DISABLE_,
+    DISABLED,
     #[doc = "Open-drain mode enabled. This is not a true open-drain mode. Input cannot be pulled up above VDD."]
-    OPEN_DRAIN_MODE_ENAB,
+    OPEN_DRAIN,
 }
 impl ODR {
     #[doc = r" Returns `true` if the bit is clear (0)"]
@@ -247,8 +247,8 @@ impl ODR {
     #[inline]
     pub fn bit(&self) -> bool {
         match *self {
-            ODR::DISABLE_ => false,
-            ODR::OPEN_DRAIN_MODE_ENAB => true,
+            ODR::DISABLED => false,
+            ODR::OPEN_DRAIN => true,
         }
     }
     #[allow(missing_docs)]
@@ -256,25 +256,25 @@ impl ODR {
     #[inline]
     pub fn _from(value: bool) -> ODR {
         match value {
-            false => ODR::DISABLE_,
-            true => ODR::OPEN_DRAIN_MODE_ENAB,
+            false => ODR::DISABLED,
+            true => ODR::OPEN_DRAIN,
         }
     }
-    #[doc = "Checks if the value of the field is `DISABLE_`"]
+    #[doc = "Checks if the value of the field is `DISABLED`"]
     #[inline]
-    pub fn is_disable_(&self) -> bool {
-        *self == ODR::DISABLE_
+    pub fn is_disabled(&self) -> bool {
+        *self == ODR::DISABLED
     }
-    #[doc = "Checks if the value of the field is `OPEN_DRAIN_MODE_ENAB`"]
+    #[doc = "Checks if the value of the field is `OPEN_DRAIN`"]
     #[inline]
-    pub fn is_open_drain_mode_enab(&self) -> bool {
-        *self == ODR::OPEN_DRAIN_MODE_ENAB
+    pub fn is_open_drain(&self) -> bool {
+        *self == ODR::OPEN_DRAIN
     }
 }
 #[doc = "Values that can be written to the field `FUNC`"]
 pub enum FUNCW {
     #[doc = "PIO1_6."]
-    PIO1_6_,
+    PIO1_6,
 }
 impl FUNCW {
     #[allow(missing_docs)]
@@ -282,7 +282,7 @@ impl FUNCW {
     #[inline]
     pub fn _bits(&self) -> u8 {
         match *self {
-            FUNCW::PIO1_6_ => 0,
+            FUNCW::PIO1_6 => 0,
         }
     }
 }
@@ -298,8 +298,8 @@ impl<'a> _FUNCW<'a> {
     }
     #[doc = "PIO1_6."]
     #[inline]
-    pub fn pio1_6_(self) -> &'a mut W {
-        self.variant(FUNCW::PIO1_6_)
+    pub fn pio1_6(self) -> &'a mut W {
+        self.variant(FUNCW::PIO1_6)
     }
     #[doc = r" Writes raw bits to the field"]
     #[inline]
@@ -314,13 +314,13 @@ impl<'a> _FUNCW<'a> {
 #[doc = "Values that can be written to the field `MODE`"]
 pub enum MODEW {
     #[doc = "Inactive (no pull-down/pull-up resistor enabled)."]
-    INACTIVE_NO_PULL_DO,
+    INACTIVE,
     #[doc = "Pull-down resistor enabled."]
-    PULL_DOWN_RESISTOR_E,
+    PULL_DOWN,
     #[doc = "Pull-up resistor enabled."]
-    PULL_UP_RESISTOR_ENA,
+    PULL_UP,
     #[doc = "Repeater mode."]
-    REPEATER_MODE_,
+    REPEATER,
 }
 impl MODEW {
     #[allow(missing_docs)]
@@ -328,10 +328,10 @@ impl MODEW {
     #[inline]
     pub fn _bits(&self) -> u8 {
         match *self {
-            MODEW::INACTIVE_NO_PULL_DO => 0,
-            MODEW::PULL_DOWN_RESISTOR_E => 1,
-            MODEW::PULL_UP_RESISTOR_ENA => 2,
-            MODEW::REPEATER_MODE_ => 3,
+            MODEW::INACTIVE => 0,
+            MODEW::PULL_DOWN => 1,
+            MODEW::PULL_UP => 2,
+            MODEW::REPEATER => 3,
         }
     }
 }
@@ -349,23 +349,23 @@ impl<'a> _MODEW<'a> {
     }
     #[doc = "Inactive (no pull-down/pull-up resistor enabled)."]
     #[inline]
-    pub fn inactive_no_pull_do(self) -> &'a mut W {
-        self.variant(MODEW::INACTIVE_NO_PULL_DO)
+    pub fn inactive(self) -> &'a mut W {
+        self.variant(MODEW::INACTIVE)
     }
     #[doc = "Pull-down resistor enabled."]
     #[inline]
-    pub fn pull_down_resistor_e(self) -> &'a mut W {
-        self.variant(MODEW::PULL_DOWN_RESISTOR_E)
+    pub fn pull_down(self) -> &'a mut W {
+        self.variant(MODEW::PULL_DOWN)
     }
     #[doc = "Pull-up resistor enabled."]
     #[inline]
-    pub fn pull_up_resistor_ena(self) -> &'a mut W {
-        self.variant(MODEW::PULL_UP_RESISTOR_ENA)
+    pub fn pull_up(self) -> &'a mut W {
+        self.variant(MODEW::PULL_UP)
     }
     #[doc = "Repeater mode."]
     #[inline]
-    pub fn repeater_mode_(self) -> &'a mut W {
-        self.variant(MODEW::REPEATER_MODE_)
+    pub fn repeater(self) -> &'a mut W {
+        self.variant(MODEW::REPEATER)
     }
     #[doc = r" Writes raw bits to the field"]
     #[inline]
@@ -380,9 +380,9 @@ impl<'a> _MODEW<'a> {
 #[doc = "Values that can be written to the field `HYS`"]
 pub enum HYSW {
     #[doc = "Disable."]
-    DISABLE_,
+    DISABLED,
     #[doc = "Enable."]
-    ENABLE_,
+    ENABLED,
 }
 impl HYSW {
     #[allow(missing_docs)]
@@ -390,8 +390,8 @@ impl HYSW {
     #[inline]
     pub fn _bits(&self) -> bool {
         match *self {
-            HYSW::DISABLE_ => false,
-            HYSW::ENABLE_ => true,
+            HYSW::DISABLED => false,
+            HYSW::ENABLED => true,
         }
     }
 }
@@ -409,13 +409,13 @@ impl<'a> _HYSW<'a> {
     }
     #[doc = "Disable."]
     #[inline]
-    pub fn disable_(self) -> &'a mut W {
-        self.variant(HYSW::DISABLE_)
+    pub fn disabled(self) -> &'a mut W {
+        self.variant(HYSW::DISABLED)
     }
     #[doc = "Enable."]
     #[inline]
-    pub fn enable_(self) -> &'a mut W {
-        self.variant(HYSW::ENABLE_)
+    pub fn enabled(self) -> &'a mut W {
+        self.variant(HYSW::ENABLED)
     }
     #[doc = r" Sets the field bit"]
     pub fn set_bit(self) -> &'a mut W {
@@ -438,9 +438,9 @@ impl<'a> _HYSW<'a> {
 #[doc = "Values that can be written to the field `INV`"]
 pub enum INVW {
     #[doc = "Input not inverted (HIGH on pin reads as 1, LOW on pin reads as 0)."]
-    INPUT_NOT_INVERTED_,
+    NOT_INVERTED,
     #[doc = "Input inverted (HIGH on pin reads as 0, LOW on pin reads as 1)."]
-    INPUT_INVERTED_HIGH,
+    INVERTED,
 }
 impl INVW {
     #[allow(missing_docs)]
@@ -448,8 +448,8 @@ impl INVW {
     #[inline]
     pub fn _bits(&self) -> bool {
         match *self {
-            INVW::INPUT_NOT_INVERTED_ => false,
-            INVW::INPUT_INVERTED_HIGH => true,
+            INVW::NOT_INVERTED => false,
+            INVW::INVERTED => true,
         }
     }
 }
@@ -467,13 +467,13 @@ impl<'a> _INVW<'a> {
     }
     #[doc = "Input not inverted (HIGH on pin reads as 1, LOW on pin reads as 0)."]
     #[inline]
-    pub fn input_not_inverted_(self) -> &'a mut W {
-        self.variant(INVW::INPUT_NOT_INVERTED_)
+    pub fn not_inverted(self) -> &'a mut W {
+        self.variant(INVW::NOT_INVERTED)
     }
     #[doc = "Input inverted (HIGH on pin reads as 0, LOW on pin reads as 1)."]
     #[inline]
-    pub fn input_inverted_high(self) -> &'a mut W {
-        self.variant(INVW::INPUT_INVERTED_HIGH)
+    pub fn inverted(self) -> &'a mut W {
+        self.variant(INVW::INVERTED)
     }
     #[doc = r" Sets the field bit"]
     pub fn set_bit(self) -> &'a mut W {
@@ -496,9 +496,9 @@ impl<'a> _INVW<'a> {
 #[doc = "Values that can be written to the field `OD`"]
 pub enum ODW {
     #[doc = "Disable."]
-    DISABLE_,
+    DISABLED,
     #[doc = "Open-drain mode enabled. This is not a true open-drain mode. Input cannot be pulled up above VDD."]
-    OPEN_DRAIN_MODE_ENAB,
+    OPEN_DRAIN,
 }
 impl ODW {
     #[allow(missing_docs)]
@@ -506,8 +506,8 @@ impl ODW {
     #[inline]
     pub fn _bits(&self) -> bool {
         match *self {
-            ODW::DISABLE_ => false,
-            ODW::OPEN_DRAIN_MODE_ENAB => true,
+            ODW::DISABLED => false,
+            ODW::OPEN_DRAIN => true,
         }
     }
 }
@@ -525,13 +525,13 @@ impl<'a> _ODW<'a> {
     }
     #[doc = "Disable."]
     #[inline]
-    pub fn disable_(self) -> &'a mut W {
-        self.variant(ODW::DISABLE_)
+    pub fn disabled(self) -> &'a mut W {
+        self.variant(ODW::DISABLED)
     }
     #[doc = "Open-drain mode enabled. This is not a true open-drain mode. Input cannot be pulled up above VDD."]
     #[inline]
-    pub fn open_drain_mode_enab(self) -> &'a mut W {
-        self.variant(ODW::OPEN_DRAIN_MODE_ENAB)
+    pub fn open_drain(self) -> &'a mut W {
+        self.variant(ODW::OPEN_DRAIN)
     }
     #[doc = r" Sets the field bit"]
     pub fn set_bit(self) -> &'a mut W {

--- a/lpc11uxx/src/iocon/pio1_7.rs
+++ b/lpc11uxx/src/iocon/pio1_7.rs
@@ -46,7 +46,7 @@ impl super::PIO1_7 {
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum FUNCR {
     #[doc = "PIO1_7."]
-    PIO1_7_,
+    PIO1_7,
     #[doc = r" Reserved"]
     _Reserved(u8),
 }
@@ -55,7 +55,7 @@ impl FUNCR {
     #[inline]
     pub fn bits(&self) -> u8 {
         match *self {
-            FUNCR::PIO1_7_ => 0,
+            FUNCR::PIO1_7 => 0,
             FUNCR::_Reserved(bits) => bits,
         }
     }
@@ -64,37 +64,37 @@ impl FUNCR {
     #[inline]
     pub fn _from(value: u8) -> FUNCR {
         match value {
-            0 => FUNCR::PIO1_7_,
+            0 => FUNCR::PIO1_7,
             i => FUNCR::_Reserved(i),
         }
     }
-    #[doc = "Checks if the value of the field is `PIO1_7_`"]
+    #[doc = "Checks if the value of the field is `PIO1_7`"]
     #[inline]
-    pub fn is_pio1_7_(&self) -> bool {
-        *self == FUNCR::PIO1_7_
+    pub fn is_pio1_7(&self) -> bool {
+        *self == FUNCR::PIO1_7
     }
 }
 #[doc = "Possible values of the field `MODE`"]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum MODER {
     #[doc = "Inactive (no pull-down/pull-up resistor enabled)."]
-    INACTIVE_NO_PULL_DO,
+    INACTIVE,
     #[doc = "Pull-down resistor enabled."]
-    PULL_DOWN_RESISTOR_E,
+    PULL_DOWN,
     #[doc = "Pull-up resistor enabled."]
-    PULL_UP_RESISTOR_ENA,
+    PULL_UP,
     #[doc = "Repeater mode."]
-    REPEATER_MODE_,
+    REPEATER,
 }
 impl MODER {
     #[doc = r" Value of the field as raw bits"]
     #[inline]
     pub fn bits(&self) -> u8 {
         match *self {
-            MODER::INACTIVE_NO_PULL_DO => 0,
-            MODER::PULL_DOWN_RESISTOR_E => 1,
-            MODER::PULL_UP_RESISTOR_ENA => 2,
-            MODER::REPEATER_MODE_ => 3,
+            MODER::INACTIVE => 0,
+            MODER::PULL_DOWN => 1,
+            MODER::PULL_UP => 2,
+            MODER::REPEATER => 3,
         }
     }
     #[allow(missing_docs)]
@@ -102,41 +102,41 @@ impl MODER {
     #[inline]
     pub fn _from(value: u8) -> MODER {
         match value {
-            0 => MODER::INACTIVE_NO_PULL_DO,
-            1 => MODER::PULL_DOWN_RESISTOR_E,
-            2 => MODER::PULL_UP_RESISTOR_ENA,
-            3 => MODER::REPEATER_MODE_,
+            0 => MODER::INACTIVE,
+            1 => MODER::PULL_DOWN,
+            2 => MODER::PULL_UP,
+            3 => MODER::REPEATER,
             _ => unreachable!(),
         }
     }
-    #[doc = "Checks if the value of the field is `INACTIVE_NO_PULL_DO`"]
+    #[doc = "Checks if the value of the field is `INACTIVE`"]
     #[inline]
-    pub fn is_inactive_no_pull_do(&self) -> bool {
-        *self == MODER::INACTIVE_NO_PULL_DO
+    pub fn is_inactive(&self) -> bool {
+        *self == MODER::INACTIVE
     }
-    #[doc = "Checks if the value of the field is `PULL_DOWN_RESISTOR_E`"]
+    #[doc = "Checks if the value of the field is `PULL_DOWN`"]
     #[inline]
-    pub fn is_pull_down_resistor_e(&self) -> bool {
-        *self == MODER::PULL_DOWN_RESISTOR_E
+    pub fn is_pull_down(&self) -> bool {
+        *self == MODER::PULL_DOWN
     }
-    #[doc = "Checks if the value of the field is `PULL_UP_RESISTOR_ENA`"]
+    #[doc = "Checks if the value of the field is `PULL_UP`"]
     #[inline]
-    pub fn is_pull_up_resistor_ena(&self) -> bool {
-        *self == MODER::PULL_UP_RESISTOR_ENA
+    pub fn is_pull_up(&self) -> bool {
+        *self == MODER::PULL_UP
     }
-    #[doc = "Checks if the value of the field is `REPEATER_MODE_`"]
+    #[doc = "Checks if the value of the field is `REPEATER`"]
     #[inline]
-    pub fn is_repeater_mode_(&self) -> bool {
-        *self == MODER::REPEATER_MODE_
+    pub fn is_repeater(&self) -> bool {
+        *self == MODER::REPEATER
     }
 }
 #[doc = "Possible values of the field `HYS`"]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum HYSR {
     #[doc = "Disable."]
-    DISABLE_,
+    DISABLED,
     #[doc = "Enable."]
-    ENABLE_,
+    ENABLED,
 }
 impl HYSR {
     #[doc = r" Returns `true` if the bit is clear (0)"]
@@ -153,8 +153,8 @@ impl HYSR {
     #[inline]
     pub fn bit(&self) -> bool {
         match *self {
-            HYSR::DISABLE_ => false,
-            HYSR::ENABLE_ => true,
+            HYSR::DISABLED => false,
+            HYSR::ENABLED => true,
         }
     }
     #[allow(missing_docs)]
@@ -162,28 +162,28 @@ impl HYSR {
     #[inline]
     pub fn _from(value: bool) -> HYSR {
         match value {
-            false => HYSR::DISABLE_,
-            true => HYSR::ENABLE_,
+            false => HYSR::DISABLED,
+            true => HYSR::ENABLED,
         }
     }
-    #[doc = "Checks if the value of the field is `DISABLE_`"]
+    #[doc = "Checks if the value of the field is `DISABLED`"]
     #[inline]
-    pub fn is_disable_(&self) -> bool {
-        *self == HYSR::DISABLE_
+    pub fn is_disabled(&self) -> bool {
+        *self == HYSR::DISABLED
     }
-    #[doc = "Checks if the value of the field is `ENABLE_`"]
+    #[doc = "Checks if the value of the field is `ENABLED`"]
     #[inline]
-    pub fn is_enable_(&self) -> bool {
-        *self == HYSR::ENABLE_
+    pub fn is_enabled(&self) -> bool {
+        *self == HYSR::ENABLED
     }
 }
 #[doc = "Possible values of the field `INV`"]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum INVR {
     #[doc = "Input not inverted (HIGH on pin reads as 1, LOW on pin reads as 0)."]
-    INPUT_NOT_INVERTED_,
+    NOT_INVERTED,
     #[doc = "Input inverted (HIGH on pin reads as 0, LOW on pin reads as 1)."]
-    INPUT_INVERTED_HIGH,
+    INVERTED,
 }
 impl INVR {
     #[doc = r" Returns `true` if the bit is clear (0)"]
@@ -200,8 +200,8 @@ impl INVR {
     #[inline]
     pub fn bit(&self) -> bool {
         match *self {
-            INVR::INPUT_NOT_INVERTED_ => false,
-            INVR::INPUT_INVERTED_HIGH => true,
+            INVR::NOT_INVERTED => false,
+            INVR::INVERTED => true,
         }
     }
     #[allow(missing_docs)]
@@ -209,28 +209,28 @@ impl INVR {
     #[inline]
     pub fn _from(value: bool) -> INVR {
         match value {
-            false => INVR::INPUT_NOT_INVERTED_,
-            true => INVR::INPUT_INVERTED_HIGH,
+            false => INVR::NOT_INVERTED,
+            true => INVR::INVERTED,
         }
     }
-    #[doc = "Checks if the value of the field is `INPUT_NOT_INVERTED_`"]
+    #[doc = "Checks if the value of the field is `NOT_INVERTED`"]
     #[inline]
-    pub fn is_input_not_inverted_(&self) -> bool {
-        *self == INVR::INPUT_NOT_INVERTED_
+    pub fn is_not_inverted(&self) -> bool {
+        *self == INVR::NOT_INVERTED
     }
-    #[doc = "Checks if the value of the field is `INPUT_INVERTED_HIGH`"]
+    #[doc = "Checks if the value of the field is `INVERTED`"]
     #[inline]
-    pub fn is_input_inverted_high(&self) -> bool {
-        *self == INVR::INPUT_INVERTED_HIGH
+    pub fn is_inverted(&self) -> bool {
+        *self == INVR::INVERTED
     }
 }
 #[doc = "Possible values of the field `OD`"]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum ODR {
     #[doc = "Disable."]
-    DISABLE_,
+    DISABLED,
     #[doc = "Open-drain mode enabled. This is not a true open-drain mode. Input cannot be pulled up above VDD."]
-    OPEN_DRAIN_MODE_ENAB,
+    OPEN_DRAIN,
 }
 impl ODR {
     #[doc = r" Returns `true` if the bit is clear (0)"]
@@ -247,8 +247,8 @@ impl ODR {
     #[inline]
     pub fn bit(&self) -> bool {
         match *self {
-            ODR::DISABLE_ => false,
-            ODR::OPEN_DRAIN_MODE_ENAB => true,
+            ODR::DISABLED => false,
+            ODR::OPEN_DRAIN => true,
         }
     }
     #[allow(missing_docs)]
@@ -256,25 +256,25 @@ impl ODR {
     #[inline]
     pub fn _from(value: bool) -> ODR {
         match value {
-            false => ODR::DISABLE_,
-            true => ODR::OPEN_DRAIN_MODE_ENAB,
+            false => ODR::DISABLED,
+            true => ODR::OPEN_DRAIN,
         }
     }
-    #[doc = "Checks if the value of the field is `DISABLE_`"]
+    #[doc = "Checks if the value of the field is `DISABLED`"]
     #[inline]
-    pub fn is_disable_(&self) -> bool {
-        *self == ODR::DISABLE_
+    pub fn is_disabled(&self) -> bool {
+        *self == ODR::DISABLED
     }
-    #[doc = "Checks if the value of the field is `OPEN_DRAIN_MODE_ENAB`"]
+    #[doc = "Checks if the value of the field is `OPEN_DRAIN`"]
     #[inline]
-    pub fn is_open_drain_mode_enab(&self) -> bool {
-        *self == ODR::OPEN_DRAIN_MODE_ENAB
+    pub fn is_open_drain(&self) -> bool {
+        *self == ODR::OPEN_DRAIN
     }
 }
 #[doc = "Values that can be written to the field `FUNC`"]
 pub enum FUNCW {
     #[doc = "PIO1_7."]
-    PIO1_7_,
+    PIO1_7,
 }
 impl FUNCW {
     #[allow(missing_docs)]
@@ -282,7 +282,7 @@ impl FUNCW {
     #[inline]
     pub fn _bits(&self) -> u8 {
         match *self {
-            FUNCW::PIO1_7_ => 0,
+            FUNCW::PIO1_7 => 0,
         }
     }
 }
@@ -298,8 +298,8 @@ impl<'a> _FUNCW<'a> {
     }
     #[doc = "PIO1_7."]
     #[inline]
-    pub fn pio1_7_(self) -> &'a mut W {
-        self.variant(FUNCW::PIO1_7_)
+    pub fn pio1_7(self) -> &'a mut W {
+        self.variant(FUNCW::PIO1_7)
     }
     #[doc = r" Writes raw bits to the field"]
     #[inline]
@@ -314,13 +314,13 @@ impl<'a> _FUNCW<'a> {
 #[doc = "Values that can be written to the field `MODE`"]
 pub enum MODEW {
     #[doc = "Inactive (no pull-down/pull-up resistor enabled)."]
-    INACTIVE_NO_PULL_DO,
+    INACTIVE,
     #[doc = "Pull-down resistor enabled."]
-    PULL_DOWN_RESISTOR_E,
+    PULL_DOWN,
     #[doc = "Pull-up resistor enabled."]
-    PULL_UP_RESISTOR_ENA,
+    PULL_UP,
     #[doc = "Repeater mode."]
-    REPEATER_MODE_,
+    REPEATER,
 }
 impl MODEW {
     #[allow(missing_docs)]
@@ -328,10 +328,10 @@ impl MODEW {
     #[inline]
     pub fn _bits(&self) -> u8 {
         match *self {
-            MODEW::INACTIVE_NO_PULL_DO => 0,
-            MODEW::PULL_DOWN_RESISTOR_E => 1,
-            MODEW::PULL_UP_RESISTOR_ENA => 2,
-            MODEW::REPEATER_MODE_ => 3,
+            MODEW::INACTIVE => 0,
+            MODEW::PULL_DOWN => 1,
+            MODEW::PULL_UP => 2,
+            MODEW::REPEATER => 3,
         }
     }
 }
@@ -349,23 +349,23 @@ impl<'a> _MODEW<'a> {
     }
     #[doc = "Inactive (no pull-down/pull-up resistor enabled)."]
     #[inline]
-    pub fn inactive_no_pull_do(self) -> &'a mut W {
-        self.variant(MODEW::INACTIVE_NO_PULL_DO)
+    pub fn inactive(self) -> &'a mut W {
+        self.variant(MODEW::INACTIVE)
     }
     #[doc = "Pull-down resistor enabled."]
     #[inline]
-    pub fn pull_down_resistor_e(self) -> &'a mut W {
-        self.variant(MODEW::PULL_DOWN_RESISTOR_E)
+    pub fn pull_down(self) -> &'a mut W {
+        self.variant(MODEW::PULL_DOWN)
     }
     #[doc = "Pull-up resistor enabled."]
     #[inline]
-    pub fn pull_up_resistor_ena(self) -> &'a mut W {
-        self.variant(MODEW::PULL_UP_RESISTOR_ENA)
+    pub fn pull_up(self) -> &'a mut W {
+        self.variant(MODEW::PULL_UP)
     }
     #[doc = "Repeater mode."]
     #[inline]
-    pub fn repeater_mode_(self) -> &'a mut W {
-        self.variant(MODEW::REPEATER_MODE_)
+    pub fn repeater(self) -> &'a mut W {
+        self.variant(MODEW::REPEATER)
     }
     #[doc = r" Writes raw bits to the field"]
     #[inline]
@@ -380,9 +380,9 @@ impl<'a> _MODEW<'a> {
 #[doc = "Values that can be written to the field `HYS`"]
 pub enum HYSW {
     #[doc = "Disable."]
-    DISABLE_,
+    DISABLED,
     #[doc = "Enable."]
-    ENABLE_,
+    ENABLED,
 }
 impl HYSW {
     #[allow(missing_docs)]
@@ -390,8 +390,8 @@ impl HYSW {
     #[inline]
     pub fn _bits(&self) -> bool {
         match *self {
-            HYSW::DISABLE_ => false,
-            HYSW::ENABLE_ => true,
+            HYSW::DISABLED => false,
+            HYSW::ENABLED => true,
         }
     }
 }
@@ -409,13 +409,13 @@ impl<'a> _HYSW<'a> {
     }
     #[doc = "Disable."]
     #[inline]
-    pub fn disable_(self) -> &'a mut W {
-        self.variant(HYSW::DISABLE_)
+    pub fn disabled(self) -> &'a mut W {
+        self.variant(HYSW::DISABLED)
     }
     #[doc = "Enable."]
     #[inline]
-    pub fn enable_(self) -> &'a mut W {
-        self.variant(HYSW::ENABLE_)
+    pub fn enabled(self) -> &'a mut W {
+        self.variant(HYSW::ENABLED)
     }
     #[doc = r" Sets the field bit"]
     pub fn set_bit(self) -> &'a mut W {
@@ -438,9 +438,9 @@ impl<'a> _HYSW<'a> {
 #[doc = "Values that can be written to the field `INV`"]
 pub enum INVW {
     #[doc = "Input not inverted (HIGH on pin reads as 1, LOW on pin reads as 0)."]
-    INPUT_NOT_INVERTED_,
+    NOT_INVERTED,
     #[doc = "Input inverted (HIGH on pin reads as 0, LOW on pin reads as 1)."]
-    INPUT_INVERTED_HIGH,
+    INVERTED,
 }
 impl INVW {
     #[allow(missing_docs)]
@@ -448,8 +448,8 @@ impl INVW {
     #[inline]
     pub fn _bits(&self) -> bool {
         match *self {
-            INVW::INPUT_NOT_INVERTED_ => false,
-            INVW::INPUT_INVERTED_HIGH => true,
+            INVW::NOT_INVERTED => false,
+            INVW::INVERTED => true,
         }
     }
 }
@@ -467,13 +467,13 @@ impl<'a> _INVW<'a> {
     }
     #[doc = "Input not inverted (HIGH on pin reads as 1, LOW on pin reads as 0)."]
     #[inline]
-    pub fn input_not_inverted_(self) -> &'a mut W {
-        self.variant(INVW::INPUT_NOT_INVERTED_)
+    pub fn not_inverted(self) -> &'a mut W {
+        self.variant(INVW::NOT_INVERTED)
     }
     #[doc = "Input inverted (HIGH on pin reads as 0, LOW on pin reads as 1)."]
     #[inline]
-    pub fn input_inverted_high(self) -> &'a mut W {
-        self.variant(INVW::INPUT_INVERTED_HIGH)
+    pub fn inverted(self) -> &'a mut W {
+        self.variant(INVW::INVERTED)
     }
     #[doc = r" Sets the field bit"]
     pub fn set_bit(self) -> &'a mut W {
@@ -496,9 +496,9 @@ impl<'a> _INVW<'a> {
 #[doc = "Values that can be written to the field `OD`"]
 pub enum ODW {
     #[doc = "Disable."]
-    DISABLE_,
+    DISABLED,
     #[doc = "Open-drain mode enabled. This is not a true open-drain mode. Input cannot be pulled up above VDD."]
-    OPEN_DRAIN_MODE_ENAB,
+    OPEN_DRAIN,
 }
 impl ODW {
     #[allow(missing_docs)]
@@ -506,8 +506,8 @@ impl ODW {
     #[inline]
     pub fn _bits(&self) -> bool {
         match *self {
-            ODW::DISABLE_ => false,
-            ODW::OPEN_DRAIN_MODE_ENAB => true,
+            ODW::DISABLED => false,
+            ODW::OPEN_DRAIN => true,
         }
     }
 }
@@ -525,13 +525,13 @@ impl<'a> _ODW<'a> {
     }
     #[doc = "Disable."]
     #[inline]
-    pub fn disable_(self) -> &'a mut W {
-        self.variant(ODW::DISABLE_)
+    pub fn disabled(self) -> &'a mut W {
+        self.variant(ODW::DISABLED)
     }
     #[doc = "Open-drain mode enabled. This is not a true open-drain mode. Input cannot be pulled up above VDD."]
     #[inline]
-    pub fn open_drain_mode_enab(self) -> &'a mut W {
-        self.variant(ODW::OPEN_DRAIN_MODE_ENAB)
+    pub fn open_drain(self) -> &'a mut W {
+        self.variant(ODW::OPEN_DRAIN)
     }
     #[doc = r" Sets the field bit"]
     pub fn set_bit(self) -> &'a mut W {

--- a/lpc11uxx/src/iocon/pio1_8.rs
+++ b/lpc11uxx/src/iocon/pio1_8.rs
@@ -46,7 +46,7 @@ impl super::PIO1_8 {
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum FUNCR {
     #[doc = "PIO1_8."]
-    PIO1_8_,
+    PIO1_8,
     #[doc = r" Reserved"]
     _Reserved(u8),
 }
@@ -55,7 +55,7 @@ impl FUNCR {
     #[inline]
     pub fn bits(&self) -> u8 {
         match *self {
-            FUNCR::PIO1_8_ => 0,
+            FUNCR::PIO1_8 => 0,
             FUNCR::_Reserved(bits) => bits,
         }
     }
@@ -64,37 +64,37 @@ impl FUNCR {
     #[inline]
     pub fn _from(value: u8) -> FUNCR {
         match value {
-            0 => FUNCR::PIO1_8_,
+            0 => FUNCR::PIO1_8,
             i => FUNCR::_Reserved(i),
         }
     }
-    #[doc = "Checks if the value of the field is `PIO1_8_`"]
+    #[doc = "Checks if the value of the field is `PIO1_8`"]
     #[inline]
-    pub fn is_pio1_8_(&self) -> bool {
-        *self == FUNCR::PIO1_8_
+    pub fn is_pio1_8(&self) -> bool {
+        *self == FUNCR::PIO1_8
     }
 }
 #[doc = "Possible values of the field `MODE`"]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum MODER {
     #[doc = "Inactive (no pull-down/pull-up resistor enabled)."]
-    INACTIVE_NO_PULL_DO,
+    INACTIVE,
     #[doc = "Pull-down resistor enabled."]
-    PULL_DOWN_RESISTOR_E,
+    PULL_DOWN,
     #[doc = "Pull-up resistor enabled."]
-    PULL_UP_RESISTOR_ENA,
+    PULL_UP,
     #[doc = "Repeater mode."]
-    REPEATER_MODE_,
+    REPEATER,
 }
 impl MODER {
     #[doc = r" Value of the field as raw bits"]
     #[inline]
     pub fn bits(&self) -> u8 {
         match *self {
-            MODER::INACTIVE_NO_PULL_DO => 0,
-            MODER::PULL_DOWN_RESISTOR_E => 1,
-            MODER::PULL_UP_RESISTOR_ENA => 2,
-            MODER::REPEATER_MODE_ => 3,
+            MODER::INACTIVE => 0,
+            MODER::PULL_DOWN => 1,
+            MODER::PULL_UP => 2,
+            MODER::REPEATER => 3,
         }
     }
     #[allow(missing_docs)]
@@ -102,41 +102,41 @@ impl MODER {
     #[inline]
     pub fn _from(value: u8) -> MODER {
         match value {
-            0 => MODER::INACTIVE_NO_PULL_DO,
-            1 => MODER::PULL_DOWN_RESISTOR_E,
-            2 => MODER::PULL_UP_RESISTOR_ENA,
-            3 => MODER::REPEATER_MODE_,
+            0 => MODER::INACTIVE,
+            1 => MODER::PULL_DOWN,
+            2 => MODER::PULL_UP,
+            3 => MODER::REPEATER,
             _ => unreachable!(),
         }
     }
-    #[doc = "Checks if the value of the field is `INACTIVE_NO_PULL_DO`"]
+    #[doc = "Checks if the value of the field is `INACTIVE`"]
     #[inline]
-    pub fn is_inactive_no_pull_do(&self) -> bool {
-        *self == MODER::INACTIVE_NO_PULL_DO
+    pub fn is_inactive(&self) -> bool {
+        *self == MODER::INACTIVE
     }
-    #[doc = "Checks if the value of the field is `PULL_DOWN_RESISTOR_E`"]
+    #[doc = "Checks if the value of the field is `PULL_DOWN`"]
     #[inline]
-    pub fn is_pull_down_resistor_e(&self) -> bool {
-        *self == MODER::PULL_DOWN_RESISTOR_E
+    pub fn is_pull_down(&self) -> bool {
+        *self == MODER::PULL_DOWN
     }
-    #[doc = "Checks if the value of the field is `PULL_UP_RESISTOR_ENA`"]
+    #[doc = "Checks if the value of the field is `PULL_UP`"]
     #[inline]
-    pub fn is_pull_up_resistor_ena(&self) -> bool {
-        *self == MODER::PULL_UP_RESISTOR_ENA
+    pub fn is_pull_up(&self) -> bool {
+        *self == MODER::PULL_UP
     }
-    #[doc = "Checks if the value of the field is `REPEATER_MODE_`"]
+    #[doc = "Checks if the value of the field is `REPEATER`"]
     #[inline]
-    pub fn is_repeater_mode_(&self) -> bool {
-        *self == MODER::REPEATER_MODE_
+    pub fn is_repeater(&self) -> bool {
+        *self == MODER::REPEATER
     }
 }
 #[doc = "Possible values of the field `HYS`"]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum HYSR {
     #[doc = "Disable."]
-    DISABLE_,
+    DISABLED,
     #[doc = "Enable."]
-    ENABLE_,
+    ENABLED,
 }
 impl HYSR {
     #[doc = r" Returns `true` if the bit is clear (0)"]
@@ -153,8 +153,8 @@ impl HYSR {
     #[inline]
     pub fn bit(&self) -> bool {
         match *self {
-            HYSR::DISABLE_ => false,
-            HYSR::ENABLE_ => true,
+            HYSR::DISABLED => false,
+            HYSR::ENABLED => true,
         }
     }
     #[allow(missing_docs)]
@@ -162,28 +162,28 @@ impl HYSR {
     #[inline]
     pub fn _from(value: bool) -> HYSR {
         match value {
-            false => HYSR::DISABLE_,
-            true => HYSR::ENABLE_,
+            false => HYSR::DISABLED,
+            true => HYSR::ENABLED,
         }
     }
-    #[doc = "Checks if the value of the field is `DISABLE_`"]
+    #[doc = "Checks if the value of the field is `DISABLED`"]
     #[inline]
-    pub fn is_disable_(&self) -> bool {
-        *self == HYSR::DISABLE_
+    pub fn is_disabled(&self) -> bool {
+        *self == HYSR::DISABLED
     }
-    #[doc = "Checks if the value of the field is `ENABLE_`"]
+    #[doc = "Checks if the value of the field is `ENABLED`"]
     #[inline]
-    pub fn is_enable_(&self) -> bool {
-        *self == HYSR::ENABLE_
+    pub fn is_enabled(&self) -> bool {
+        *self == HYSR::ENABLED
     }
 }
 #[doc = "Possible values of the field `INV`"]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum INVR {
     #[doc = "Input not inverted (HIGH on pin reads as 1, LOW on pin reads as 0)."]
-    INPUT_NOT_INVERTED_,
+    NOT_INVERTED,
     #[doc = "Input inverted (HIGH on pin reads as 0, LOW on pin reads as 1)."]
-    INPUT_INVERTED_HIGH,
+    INVERTED,
 }
 impl INVR {
     #[doc = r" Returns `true` if the bit is clear (0)"]
@@ -200,8 +200,8 @@ impl INVR {
     #[inline]
     pub fn bit(&self) -> bool {
         match *self {
-            INVR::INPUT_NOT_INVERTED_ => false,
-            INVR::INPUT_INVERTED_HIGH => true,
+            INVR::NOT_INVERTED => false,
+            INVR::INVERTED => true,
         }
     }
     #[allow(missing_docs)]
@@ -209,28 +209,28 @@ impl INVR {
     #[inline]
     pub fn _from(value: bool) -> INVR {
         match value {
-            false => INVR::INPUT_NOT_INVERTED_,
-            true => INVR::INPUT_INVERTED_HIGH,
+            false => INVR::NOT_INVERTED,
+            true => INVR::INVERTED,
         }
     }
-    #[doc = "Checks if the value of the field is `INPUT_NOT_INVERTED_`"]
+    #[doc = "Checks if the value of the field is `NOT_INVERTED`"]
     #[inline]
-    pub fn is_input_not_inverted_(&self) -> bool {
-        *self == INVR::INPUT_NOT_INVERTED_
+    pub fn is_not_inverted(&self) -> bool {
+        *self == INVR::NOT_INVERTED
     }
-    #[doc = "Checks if the value of the field is `INPUT_INVERTED_HIGH`"]
+    #[doc = "Checks if the value of the field is `INVERTED`"]
     #[inline]
-    pub fn is_input_inverted_high(&self) -> bool {
-        *self == INVR::INPUT_INVERTED_HIGH
+    pub fn is_inverted(&self) -> bool {
+        *self == INVR::INVERTED
     }
 }
 #[doc = "Possible values of the field `OD`"]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum ODR {
     #[doc = "Disable."]
-    DISABLE_,
+    DISABLED,
     #[doc = "Open-drain mode enabled. This is not a true open-drain mode. Input cannot be pulled up above VDD."]
-    OPEN_DRAIN_MODE_ENAB,
+    OPEN_DRAIN,
 }
 impl ODR {
     #[doc = r" Returns `true` if the bit is clear (0)"]
@@ -247,8 +247,8 @@ impl ODR {
     #[inline]
     pub fn bit(&self) -> bool {
         match *self {
-            ODR::DISABLE_ => false,
-            ODR::OPEN_DRAIN_MODE_ENAB => true,
+            ODR::DISABLED => false,
+            ODR::OPEN_DRAIN => true,
         }
     }
     #[allow(missing_docs)]
@@ -256,25 +256,25 @@ impl ODR {
     #[inline]
     pub fn _from(value: bool) -> ODR {
         match value {
-            false => ODR::DISABLE_,
-            true => ODR::OPEN_DRAIN_MODE_ENAB,
+            false => ODR::DISABLED,
+            true => ODR::OPEN_DRAIN,
         }
     }
-    #[doc = "Checks if the value of the field is `DISABLE_`"]
+    #[doc = "Checks if the value of the field is `DISABLED`"]
     #[inline]
-    pub fn is_disable_(&self) -> bool {
-        *self == ODR::DISABLE_
+    pub fn is_disabled(&self) -> bool {
+        *self == ODR::DISABLED
     }
-    #[doc = "Checks if the value of the field is `OPEN_DRAIN_MODE_ENAB`"]
+    #[doc = "Checks if the value of the field is `OPEN_DRAIN`"]
     #[inline]
-    pub fn is_open_drain_mode_enab(&self) -> bool {
-        *self == ODR::OPEN_DRAIN_MODE_ENAB
+    pub fn is_open_drain(&self) -> bool {
+        *self == ODR::OPEN_DRAIN
     }
 }
 #[doc = "Values that can be written to the field `FUNC`"]
 pub enum FUNCW {
     #[doc = "PIO1_8."]
-    PIO1_8_,
+    PIO1_8,
 }
 impl FUNCW {
     #[allow(missing_docs)]
@@ -282,7 +282,7 @@ impl FUNCW {
     #[inline]
     pub fn _bits(&self) -> u8 {
         match *self {
-            FUNCW::PIO1_8_ => 0,
+            FUNCW::PIO1_8 => 0,
         }
     }
 }
@@ -298,8 +298,8 @@ impl<'a> _FUNCW<'a> {
     }
     #[doc = "PIO1_8."]
     #[inline]
-    pub fn pio1_8_(self) -> &'a mut W {
-        self.variant(FUNCW::PIO1_8_)
+    pub fn pio1_8(self) -> &'a mut W {
+        self.variant(FUNCW::PIO1_8)
     }
     #[doc = r" Writes raw bits to the field"]
     #[inline]
@@ -314,13 +314,13 @@ impl<'a> _FUNCW<'a> {
 #[doc = "Values that can be written to the field `MODE`"]
 pub enum MODEW {
     #[doc = "Inactive (no pull-down/pull-up resistor enabled)."]
-    INACTIVE_NO_PULL_DO,
+    INACTIVE,
     #[doc = "Pull-down resistor enabled."]
-    PULL_DOWN_RESISTOR_E,
+    PULL_DOWN,
     #[doc = "Pull-up resistor enabled."]
-    PULL_UP_RESISTOR_ENA,
+    PULL_UP,
     #[doc = "Repeater mode."]
-    REPEATER_MODE_,
+    REPEATER,
 }
 impl MODEW {
     #[allow(missing_docs)]
@@ -328,10 +328,10 @@ impl MODEW {
     #[inline]
     pub fn _bits(&self) -> u8 {
         match *self {
-            MODEW::INACTIVE_NO_PULL_DO => 0,
-            MODEW::PULL_DOWN_RESISTOR_E => 1,
-            MODEW::PULL_UP_RESISTOR_ENA => 2,
-            MODEW::REPEATER_MODE_ => 3,
+            MODEW::INACTIVE => 0,
+            MODEW::PULL_DOWN => 1,
+            MODEW::PULL_UP => 2,
+            MODEW::REPEATER => 3,
         }
     }
 }
@@ -349,23 +349,23 @@ impl<'a> _MODEW<'a> {
     }
     #[doc = "Inactive (no pull-down/pull-up resistor enabled)."]
     #[inline]
-    pub fn inactive_no_pull_do(self) -> &'a mut W {
-        self.variant(MODEW::INACTIVE_NO_PULL_DO)
+    pub fn inactive(self) -> &'a mut W {
+        self.variant(MODEW::INACTIVE)
     }
     #[doc = "Pull-down resistor enabled."]
     #[inline]
-    pub fn pull_down_resistor_e(self) -> &'a mut W {
-        self.variant(MODEW::PULL_DOWN_RESISTOR_E)
+    pub fn pull_down(self) -> &'a mut W {
+        self.variant(MODEW::PULL_DOWN)
     }
     #[doc = "Pull-up resistor enabled."]
     #[inline]
-    pub fn pull_up_resistor_ena(self) -> &'a mut W {
-        self.variant(MODEW::PULL_UP_RESISTOR_ENA)
+    pub fn pull_up(self) -> &'a mut W {
+        self.variant(MODEW::PULL_UP)
     }
     #[doc = "Repeater mode."]
     #[inline]
-    pub fn repeater_mode_(self) -> &'a mut W {
-        self.variant(MODEW::REPEATER_MODE_)
+    pub fn repeater(self) -> &'a mut W {
+        self.variant(MODEW::REPEATER)
     }
     #[doc = r" Writes raw bits to the field"]
     #[inline]
@@ -380,9 +380,9 @@ impl<'a> _MODEW<'a> {
 #[doc = "Values that can be written to the field `HYS`"]
 pub enum HYSW {
     #[doc = "Disable."]
-    DISABLE_,
+    DISABLED,
     #[doc = "Enable."]
-    ENABLE_,
+    ENABLED,
 }
 impl HYSW {
     #[allow(missing_docs)]
@@ -390,8 +390,8 @@ impl HYSW {
     #[inline]
     pub fn _bits(&self) -> bool {
         match *self {
-            HYSW::DISABLE_ => false,
-            HYSW::ENABLE_ => true,
+            HYSW::DISABLED => false,
+            HYSW::ENABLED => true,
         }
     }
 }
@@ -409,13 +409,13 @@ impl<'a> _HYSW<'a> {
     }
     #[doc = "Disable."]
     #[inline]
-    pub fn disable_(self) -> &'a mut W {
-        self.variant(HYSW::DISABLE_)
+    pub fn disabled(self) -> &'a mut W {
+        self.variant(HYSW::DISABLED)
     }
     #[doc = "Enable."]
     #[inline]
-    pub fn enable_(self) -> &'a mut W {
-        self.variant(HYSW::ENABLE_)
+    pub fn enabled(self) -> &'a mut W {
+        self.variant(HYSW::ENABLED)
     }
     #[doc = r" Sets the field bit"]
     pub fn set_bit(self) -> &'a mut W {
@@ -438,9 +438,9 @@ impl<'a> _HYSW<'a> {
 #[doc = "Values that can be written to the field `INV`"]
 pub enum INVW {
     #[doc = "Input not inverted (HIGH on pin reads as 1, LOW on pin reads as 0)."]
-    INPUT_NOT_INVERTED_,
+    NOT_INVERTED,
     #[doc = "Input inverted (HIGH on pin reads as 0, LOW on pin reads as 1)."]
-    INPUT_INVERTED_HIGH,
+    INVERTED,
 }
 impl INVW {
     #[allow(missing_docs)]
@@ -448,8 +448,8 @@ impl INVW {
     #[inline]
     pub fn _bits(&self) -> bool {
         match *self {
-            INVW::INPUT_NOT_INVERTED_ => false,
-            INVW::INPUT_INVERTED_HIGH => true,
+            INVW::NOT_INVERTED => false,
+            INVW::INVERTED => true,
         }
     }
 }
@@ -467,13 +467,13 @@ impl<'a> _INVW<'a> {
     }
     #[doc = "Input not inverted (HIGH on pin reads as 1, LOW on pin reads as 0)."]
     #[inline]
-    pub fn input_not_inverted_(self) -> &'a mut W {
-        self.variant(INVW::INPUT_NOT_INVERTED_)
+    pub fn not_inverted(self) -> &'a mut W {
+        self.variant(INVW::NOT_INVERTED)
     }
     #[doc = "Input inverted (HIGH on pin reads as 0, LOW on pin reads as 1)."]
     #[inline]
-    pub fn input_inverted_high(self) -> &'a mut W {
-        self.variant(INVW::INPUT_INVERTED_HIGH)
+    pub fn inverted(self) -> &'a mut W {
+        self.variant(INVW::INVERTED)
     }
     #[doc = r" Sets the field bit"]
     pub fn set_bit(self) -> &'a mut W {
@@ -496,9 +496,9 @@ impl<'a> _INVW<'a> {
 #[doc = "Values that can be written to the field `OD`"]
 pub enum ODW {
     #[doc = "Disable."]
-    DISABLE_,
+    DISABLED,
     #[doc = "Open-drain mode enabled. This is not a true open-drain mode. Input cannot be pulled up above VDD."]
-    OPEN_DRAIN_MODE_ENAB,
+    OPEN_DRAIN,
 }
 impl ODW {
     #[allow(missing_docs)]
@@ -506,8 +506,8 @@ impl ODW {
     #[inline]
     pub fn _bits(&self) -> bool {
         match *self {
-            ODW::DISABLE_ => false,
-            ODW::OPEN_DRAIN_MODE_ENAB => true,
+            ODW::DISABLED => false,
+            ODW::OPEN_DRAIN => true,
         }
     }
 }
@@ -525,13 +525,13 @@ impl<'a> _ODW<'a> {
     }
     #[doc = "Disable."]
     #[inline]
-    pub fn disable_(self) -> &'a mut W {
-        self.variant(ODW::DISABLE_)
+    pub fn disabled(self) -> &'a mut W {
+        self.variant(ODW::DISABLED)
     }
     #[doc = "Open-drain mode enabled. This is not a true open-drain mode. Input cannot be pulled up above VDD."]
     #[inline]
-    pub fn open_drain_mode_enab(self) -> &'a mut W {
-        self.variant(ODW::OPEN_DRAIN_MODE_ENAB)
+    pub fn open_drain(self) -> &'a mut W {
+        self.variant(ODW::OPEN_DRAIN)
     }
     #[doc = r" Sets the field bit"]
     pub fn set_bit(self) -> &'a mut W {

--- a/lpc11uxx/src/iocon/pio1_9.rs
+++ b/lpc11uxx/src/iocon/pio1_9.rs
@@ -46,7 +46,7 @@ impl super::PIO1_9 {
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum FUNCR {
     #[doc = "PIO1_9."]
-    PIO1_9_,
+    PIO1_9,
     #[doc = r" Reserved"]
     _Reserved(u8),
 }
@@ -55,7 +55,7 @@ impl FUNCR {
     #[inline]
     pub fn bits(&self) -> u8 {
         match *self {
-            FUNCR::PIO1_9_ => 0,
+            FUNCR::PIO1_9 => 0,
             FUNCR::_Reserved(bits) => bits,
         }
     }
@@ -64,37 +64,37 @@ impl FUNCR {
     #[inline]
     pub fn _from(value: u8) -> FUNCR {
         match value {
-            0 => FUNCR::PIO1_9_,
+            0 => FUNCR::PIO1_9,
             i => FUNCR::_Reserved(i),
         }
     }
-    #[doc = "Checks if the value of the field is `PIO1_9_`"]
+    #[doc = "Checks if the value of the field is `PIO1_9`"]
     #[inline]
-    pub fn is_pio1_9_(&self) -> bool {
-        *self == FUNCR::PIO1_9_
+    pub fn is_pio1_9(&self) -> bool {
+        *self == FUNCR::PIO1_9
     }
 }
 #[doc = "Possible values of the field `MODE`"]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum MODER {
     #[doc = "Inactive (no pull-down/pull-up resistor enabled)."]
-    INACTIVE_NO_PULL_DO,
+    INACTIVE,
     #[doc = "Pull-down resistor enabled."]
-    PULL_DOWN_RESISTOR_E,
+    PULL_DOWN,
     #[doc = "Pull-up resistor enabled."]
-    PULL_UP_RESISTOR_ENA,
+    PULL_UP,
     #[doc = "Repeater mode."]
-    REPEATER_MODE_,
+    REPEATER,
 }
 impl MODER {
     #[doc = r" Value of the field as raw bits"]
     #[inline]
     pub fn bits(&self) -> u8 {
         match *self {
-            MODER::INACTIVE_NO_PULL_DO => 0,
-            MODER::PULL_DOWN_RESISTOR_E => 1,
-            MODER::PULL_UP_RESISTOR_ENA => 2,
-            MODER::REPEATER_MODE_ => 3,
+            MODER::INACTIVE => 0,
+            MODER::PULL_DOWN => 1,
+            MODER::PULL_UP => 2,
+            MODER::REPEATER => 3,
         }
     }
     #[allow(missing_docs)]
@@ -102,41 +102,41 @@ impl MODER {
     #[inline]
     pub fn _from(value: u8) -> MODER {
         match value {
-            0 => MODER::INACTIVE_NO_PULL_DO,
-            1 => MODER::PULL_DOWN_RESISTOR_E,
-            2 => MODER::PULL_UP_RESISTOR_ENA,
-            3 => MODER::REPEATER_MODE_,
+            0 => MODER::INACTIVE,
+            1 => MODER::PULL_DOWN,
+            2 => MODER::PULL_UP,
+            3 => MODER::REPEATER,
             _ => unreachable!(),
         }
     }
-    #[doc = "Checks if the value of the field is `INACTIVE_NO_PULL_DO`"]
+    #[doc = "Checks if the value of the field is `INACTIVE`"]
     #[inline]
-    pub fn is_inactive_no_pull_do(&self) -> bool {
-        *self == MODER::INACTIVE_NO_PULL_DO
+    pub fn is_inactive(&self) -> bool {
+        *self == MODER::INACTIVE
     }
-    #[doc = "Checks if the value of the field is `PULL_DOWN_RESISTOR_E`"]
+    #[doc = "Checks if the value of the field is `PULL_DOWN`"]
     #[inline]
-    pub fn is_pull_down_resistor_e(&self) -> bool {
-        *self == MODER::PULL_DOWN_RESISTOR_E
+    pub fn is_pull_down(&self) -> bool {
+        *self == MODER::PULL_DOWN
     }
-    #[doc = "Checks if the value of the field is `PULL_UP_RESISTOR_ENA`"]
+    #[doc = "Checks if the value of the field is `PULL_UP`"]
     #[inline]
-    pub fn is_pull_up_resistor_ena(&self) -> bool {
-        *self == MODER::PULL_UP_RESISTOR_ENA
+    pub fn is_pull_up(&self) -> bool {
+        *self == MODER::PULL_UP
     }
-    #[doc = "Checks if the value of the field is `REPEATER_MODE_`"]
+    #[doc = "Checks if the value of the field is `REPEATER`"]
     #[inline]
-    pub fn is_repeater_mode_(&self) -> bool {
-        *self == MODER::REPEATER_MODE_
+    pub fn is_repeater(&self) -> bool {
+        *self == MODER::REPEATER
     }
 }
 #[doc = "Possible values of the field `HYS`"]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum HYSR {
     #[doc = "Disable."]
-    DISABLE_,
+    DISABLED,
     #[doc = "Enable."]
-    ENABLE_,
+    ENABLED,
 }
 impl HYSR {
     #[doc = r" Returns `true` if the bit is clear (0)"]
@@ -153,8 +153,8 @@ impl HYSR {
     #[inline]
     pub fn bit(&self) -> bool {
         match *self {
-            HYSR::DISABLE_ => false,
-            HYSR::ENABLE_ => true,
+            HYSR::DISABLED => false,
+            HYSR::ENABLED => true,
         }
     }
     #[allow(missing_docs)]
@@ -162,28 +162,28 @@ impl HYSR {
     #[inline]
     pub fn _from(value: bool) -> HYSR {
         match value {
-            false => HYSR::DISABLE_,
-            true => HYSR::ENABLE_,
+            false => HYSR::DISABLED,
+            true => HYSR::ENABLED,
         }
     }
-    #[doc = "Checks if the value of the field is `DISABLE_`"]
+    #[doc = "Checks if the value of the field is `DISABLED`"]
     #[inline]
-    pub fn is_disable_(&self) -> bool {
-        *self == HYSR::DISABLE_
+    pub fn is_disabled(&self) -> bool {
+        *self == HYSR::DISABLED
     }
-    #[doc = "Checks if the value of the field is `ENABLE_`"]
+    #[doc = "Checks if the value of the field is `ENABLED`"]
     #[inline]
-    pub fn is_enable_(&self) -> bool {
-        *self == HYSR::ENABLE_
+    pub fn is_enabled(&self) -> bool {
+        *self == HYSR::ENABLED
     }
 }
 #[doc = "Possible values of the field `INV`"]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum INVR {
     #[doc = "Input not inverted (HIGH on pin reads as 1, LOW on pin reads as 0)."]
-    INPUT_NOT_INVERTED_,
+    NOT_INVERTED,
     #[doc = "Input inverted (HIGH on pin reads as 0, LOW on pin reads as 1)."]
-    INPUT_INVERTED_HIGH,
+    INVERTED,
 }
 impl INVR {
     #[doc = r" Returns `true` if the bit is clear (0)"]
@@ -200,8 +200,8 @@ impl INVR {
     #[inline]
     pub fn bit(&self) -> bool {
         match *self {
-            INVR::INPUT_NOT_INVERTED_ => false,
-            INVR::INPUT_INVERTED_HIGH => true,
+            INVR::NOT_INVERTED => false,
+            INVR::INVERTED => true,
         }
     }
     #[allow(missing_docs)]
@@ -209,28 +209,28 @@ impl INVR {
     #[inline]
     pub fn _from(value: bool) -> INVR {
         match value {
-            false => INVR::INPUT_NOT_INVERTED_,
-            true => INVR::INPUT_INVERTED_HIGH,
+            false => INVR::NOT_INVERTED,
+            true => INVR::INVERTED,
         }
     }
-    #[doc = "Checks if the value of the field is `INPUT_NOT_INVERTED_`"]
+    #[doc = "Checks if the value of the field is `NOT_INVERTED`"]
     #[inline]
-    pub fn is_input_not_inverted_(&self) -> bool {
-        *self == INVR::INPUT_NOT_INVERTED_
+    pub fn is_not_inverted(&self) -> bool {
+        *self == INVR::NOT_INVERTED
     }
-    #[doc = "Checks if the value of the field is `INPUT_INVERTED_HIGH`"]
+    #[doc = "Checks if the value of the field is `INVERTED`"]
     #[inline]
-    pub fn is_input_inverted_high(&self) -> bool {
-        *self == INVR::INPUT_INVERTED_HIGH
+    pub fn is_inverted(&self) -> bool {
+        *self == INVR::INVERTED
     }
 }
 #[doc = "Possible values of the field `OD`"]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum ODR {
     #[doc = "Disable."]
-    DISABLE_,
+    DISABLED,
     #[doc = "Open-drain mode enabled. This is not a true open-drain mode. Input cannot be pulled up above VDD."]
-    OPEN_DRAIN_MODE_ENAB,
+    OPEN_DRAIN,
 }
 impl ODR {
     #[doc = r" Returns `true` if the bit is clear (0)"]
@@ -247,8 +247,8 @@ impl ODR {
     #[inline]
     pub fn bit(&self) -> bool {
         match *self {
-            ODR::DISABLE_ => false,
-            ODR::OPEN_DRAIN_MODE_ENAB => true,
+            ODR::DISABLED => false,
+            ODR::OPEN_DRAIN => true,
         }
     }
     #[allow(missing_docs)]
@@ -256,25 +256,25 @@ impl ODR {
     #[inline]
     pub fn _from(value: bool) -> ODR {
         match value {
-            false => ODR::DISABLE_,
-            true => ODR::OPEN_DRAIN_MODE_ENAB,
+            false => ODR::DISABLED,
+            true => ODR::OPEN_DRAIN,
         }
     }
-    #[doc = "Checks if the value of the field is `DISABLE_`"]
+    #[doc = "Checks if the value of the field is `DISABLED`"]
     #[inline]
-    pub fn is_disable_(&self) -> bool {
-        *self == ODR::DISABLE_
+    pub fn is_disabled(&self) -> bool {
+        *self == ODR::DISABLED
     }
-    #[doc = "Checks if the value of the field is `OPEN_DRAIN_MODE_ENAB`"]
+    #[doc = "Checks if the value of the field is `OPEN_DRAIN`"]
     #[inline]
-    pub fn is_open_drain_mode_enab(&self) -> bool {
-        *self == ODR::OPEN_DRAIN_MODE_ENAB
+    pub fn is_open_drain(&self) -> bool {
+        *self == ODR::OPEN_DRAIN
     }
 }
 #[doc = "Values that can be written to the field `FUNC`"]
 pub enum FUNCW {
     #[doc = "PIO1_9."]
-    PIO1_9_,
+    PIO1_9,
 }
 impl FUNCW {
     #[allow(missing_docs)]
@@ -282,7 +282,7 @@ impl FUNCW {
     #[inline]
     pub fn _bits(&self) -> u8 {
         match *self {
-            FUNCW::PIO1_9_ => 0,
+            FUNCW::PIO1_9 => 0,
         }
     }
 }
@@ -298,8 +298,8 @@ impl<'a> _FUNCW<'a> {
     }
     #[doc = "PIO1_9."]
     #[inline]
-    pub fn pio1_9_(self) -> &'a mut W {
-        self.variant(FUNCW::PIO1_9_)
+    pub fn pio1_9(self) -> &'a mut W {
+        self.variant(FUNCW::PIO1_9)
     }
     #[doc = r" Writes raw bits to the field"]
     #[inline]
@@ -314,13 +314,13 @@ impl<'a> _FUNCW<'a> {
 #[doc = "Values that can be written to the field `MODE`"]
 pub enum MODEW {
     #[doc = "Inactive (no pull-down/pull-up resistor enabled)."]
-    INACTIVE_NO_PULL_DO,
+    INACTIVE,
     #[doc = "Pull-down resistor enabled."]
-    PULL_DOWN_RESISTOR_E,
+    PULL_DOWN,
     #[doc = "Pull-up resistor enabled."]
-    PULL_UP_RESISTOR_ENA,
+    PULL_UP,
     #[doc = "Repeater mode."]
-    REPEATER_MODE_,
+    REPEATER,
 }
 impl MODEW {
     #[allow(missing_docs)]
@@ -328,10 +328,10 @@ impl MODEW {
     #[inline]
     pub fn _bits(&self) -> u8 {
         match *self {
-            MODEW::INACTIVE_NO_PULL_DO => 0,
-            MODEW::PULL_DOWN_RESISTOR_E => 1,
-            MODEW::PULL_UP_RESISTOR_ENA => 2,
-            MODEW::REPEATER_MODE_ => 3,
+            MODEW::INACTIVE => 0,
+            MODEW::PULL_DOWN => 1,
+            MODEW::PULL_UP => 2,
+            MODEW::REPEATER => 3,
         }
     }
 }
@@ -349,23 +349,23 @@ impl<'a> _MODEW<'a> {
     }
     #[doc = "Inactive (no pull-down/pull-up resistor enabled)."]
     #[inline]
-    pub fn inactive_no_pull_do(self) -> &'a mut W {
-        self.variant(MODEW::INACTIVE_NO_PULL_DO)
+    pub fn inactive(self) -> &'a mut W {
+        self.variant(MODEW::INACTIVE)
     }
     #[doc = "Pull-down resistor enabled."]
     #[inline]
-    pub fn pull_down_resistor_e(self) -> &'a mut W {
-        self.variant(MODEW::PULL_DOWN_RESISTOR_E)
+    pub fn pull_down(self) -> &'a mut W {
+        self.variant(MODEW::PULL_DOWN)
     }
     #[doc = "Pull-up resistor enabled."]
     #[inline]
-    pub fn pull_up_resistor_ena(self) -> &'a mut W {
-        self.variant(MODEW::PULL_UP_RESISTOR_ENA)
+    pub fn pull_up(self) -> &'a mut W {
+        self.variant(MODEW::PULL_UP)
     }
     #[doc = "Repeater mode."]
     #[inline]
-    pub fn repeater_mode_(self) -> &'a mut W {
-        self.variant(MODEW::REPEATER_MODE_)
+    pub fn repeater(self) -> &'a mut W {
+        self.variant(MODEW::REPEATER)
     }
     #[doc = r" Writes raw bits to the field"]
     #[inline]
@@ -380,9 +380,9 @@ impl<'a> _MODEW<'a> {
 #[doc = "Values that can be written to the field `HYS`"]
 pub enum HYSW {
     #[doc = "Disable."]
-    DISABLE_,
+    DISABLED,
     #[doc = "Enable."]
-    ENABLE_,
+    ENABLED,
 }
 impl HYSW {
     #[allow(missing_docs)]
@@ -390,8 +390,8 @@ impl HYSW {
     #[inline]
     pub fn _bits(&self) -> bool {
         match *self {
-            HYSW::DISABLE_ => false,
-            HYSW::ENABLE_ => true,
+            HYSW::DISABLED => false,
+            HYSW::ENABLED => true,
         }
     }
 }
@@ -409,13 +409,13 @@ impl<'a> _HYSW<'a> {
     }
     #[doc = "Disable."]
     #[inline]
-    pub fn disable_(self) -> &'a mut W {
-        self.variant(HYSW::DISABLE_)
+    pub fn disabled(self) -> &'a mut W {
+        self.variant(HYSW::DISABLED)
     }
     #[doc = "Enable."]
     #[inline]
-    pub fn enable_(self) -> &'a mut W {
-        self.variant(HYSW::ENABLE_)
+    pub fn enabled(self) -> &'a mut W {
+        self.variant(HYSW::ENABLED)
     }
     #[doc = r" Sets the field bit"]
     pub fn set_bit(self) -> &'a mut W {
@@ -438,9 +438,9 @@ impl<'a> _HYSW<'a> {
 #[doc = "Values that can be written to the field `INV`"]
 pub enum INVW {
     #[doc = "Input not inverted (HIGH on pin reads as 1, LOW on pin reads as 0)."]
-    INPUT_NOT_INVERTED_,
+    NOT_INVERTED,
     #[doc = "Input inverted (HIGH on pin reads as 0, LOW on pin reads as 1)."]
-    INPUT_INVERTED_HIGH,
+    INVERTED,
 }
 impl INVW {
     #[allow(missing_docs)]
@@ -448,8 +448,8 @@ impl INVW {
     #[inline]
     pub fn _bits(&self) -> bool {
         match *self {
-            INVW::INPUT_NOT_INVERTED_ => false,
-            INVW::INPUT_INVERTED_HIGH => true,
+            INVW::NOT_INVERTED => false,
+            INVW::INVERTED => true,
         }
     }
 }
@@ -467,13 +467,13 @@ impl<'a> _INVW<'a> {
     }
     #[doc = "Input not inverted (HIGH on pin reads as 1, LOW on pin reads as 0)."]
     #[inline]
-    pub fn input_not_inverted_(self) -> &'a mut W {
-        self.variant(INVW::INPUT_NOT_INVERTED_)
+    pub fn not_inverted(self) -> &'a mut W {
+        self.variant(INVW::NOT_INVERTED)
     }
     #[doc = "Input inverted (HIGH on pin reads as 0, LOW on pin reads as 1)."]
     #[inline]
-    pub fn input_inverted_high(self) -> &'a mut W {
-        self.variant(INVW::INPUT_INVERTED_HIGH)
+    pub fn inverted(self) -> &'a mut W {
+        self.variant(INVW::INVERTED)
     }
     #[doc = r" Sets the field bit"]
     pub fn set_bit(self) -> &'a mut W {
@@ -496,9 +496,9 @@ impl<'a> _INVW<'a> {
 #[doc = "Values that can be written to the field `OD`"]
 pub enum ODW {
     #[doc = "Disable."]
-    DISABLE_,
+    DISABLED,
     #[doc = "Open-drain mode enabled. This is not a true open-drain mode. Input cannot be pulled up above VDD."]
-    OPEN_DRAIN_MODE_ENAB,
+    OPEN_DRAIN,
 }
 impl ODW {
     #[allow(missing_docs)]
@@ -506,8 +506,8 @@ impl ODW {
     #[inline]
     pub fn _bits(&self) -> bool {
         match *self {
-            ODW::DISABLE_ => false,
-            ODW::OPEN_DRAIN_MODE_ENAB => true,
+            ODW::DISABLED => false,
+            ODW::OPEN_DRAIN => true,
         }
     }
 }
@@ -525,13 +525,13 @@ impl<'a> _ODW<'a> {
     }
     #[doc = "Disable."]
     #[inline]
-    pub fn disable_(self) -> &'a mut W {
-        self.variant(ODW::DISABLE_)
+    pub fn disabled(self) -> &'a mut W {
+        self.variant(ODW::DISABLED)
     }
     #[doc = "Open-drain mode enabled. This is not a true open-drain mode. Input cannot be pulled up above VDD."]
     #[inline]
-    pub fn open_drain_mode_enab(self) -> &'a mut W {
-        self.variant(ODW::OPEN_DRAIN_MODE_ENAB)
+    pub fn open_drain(self) -> &'a mut W {
+        self.variant(ODW::OPEN_DRAIN)
     }
     #[doc = r" Sets the field bit"]
     pub fn set_bit(self) -> &'a mut W {

--- a/lpc11uxx/src/iocon/reset_pio0_0.rs
+++ b/lpc11uxx/src/iocon/reset_pio0_0.rs
@@ -46,9 +46,9 @@ impl super::RESET_PIO0_0 {
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum FUNCR {
     #[doc = "RESET."]
-    RESET_,
+    RESET,
     #[doc = "PIO0_0."]
-    PIO0_0_,
+    PIO0_0,
     #[doc = r" Reserved"]
     _Reserved(u8),
 }
@@ -57,8 +57,8 @@ impl FUNCR {
     #[inline]
     pub fn bits(&self) -> u8 {
         match *self {
-            FUNCR::RESET_ => 0,
-            FUNCR::PIO0_0_ => 1,
+            FUNCR::RESET => 0,
+            FUNCR::PIO0_0 => 1,
             FUNCR::_Reserved(bits) => bits,
         }
     }
@@ -67,43 +67,43 @@ impl FUNCR {
     #[inline]
     pub fn _from(value: u8) -> FUNCR {
         match value {
-            0 => FUNCR::RESET_,
-            1 => FUNCR::PIO0_0_,
+            0 => FUNCR::RESET,
+            1 => FUNCR::PIO0_0,
             i => FUNCR::_Reserved(i),
         }
     }
-    #[doc = "Checks if the value of the field is `RESET_`"]
+    #[doc = "Checks if the value of the field is `RESET`"]
     #[inline]
-    pub fn is_reset_(&self) -> bool {
-        *self == FUNCR::RESET_
+    pub fn is_reset(&self) -> bool {
+        *self == FUNCR::RESET
     }
-    #[doc = "Checks if the value of the field is `PIO0_0_`"]
+    #[doc = "Checks if the value of the field is `PIO0_0`"]
     #[inline]
-    pub fn is_pio0_0_(&self) -> bool {
-        *self == FUNCR::PIO0_0_
+    pub fn is_pio0_0(&self) -> bool {
+        *self == FUNCR::PIO0_0
     }
 }
 #[doc = "Possible values of the field `MODE`"]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum MODER {
     #[doc = "Inactive (no pull-down/pull-up resistor enabled)."]
-    INACTIVE_NO_PULL_DO,
+    INACTIVE,
     #[doc = "Pull-down resistor enabled."]
-    PULL_DOWN_RESISTOR_E,
+    PULL_DOWN,
     #[doc = "Pull-up resistor enabled."]
-    PULL_UP_RESISTOR_ENA,
+    PULL_UP,
     #[doc = "Repeater mode."]
-    REPEATER_MODE_,
+    REPEATER,
 }
 impl MODER {
     #[doc = r" Value of the field as raw bits"]
     #[inline]
     pub fn bits(&self) -> u8 {
         match *self {
-            MODER::INACTIVE_NO_PULL_DO => 0,
-            MODER::PULL_DOWN_RESISTOR_E => 1,
-            MODER::PULL_UP_RESISTOR_ENA => 2,
-            MODER::REPEATER_MODE_ => 3,
+            MODER::INACTIVE => 0,
+            MODER::PULL_DOWN => 1,
+            MODER::PULL_UP => 2,
+            MODER::REPEATER => 3,
         }
     }
     #[allow(missing_docs)]
@@ -111,41 +111,41 @@ impl MODER {
     #[inline]
     pub fn _from(value: u8) -> MODER {
         match value {
-            0 => MODER::INACTIVE_NO_PULL_DO,
-            1 => MODER::PULL_DOWN_RESISTOR_E,
-            2 => MODER::PULL_UP_RESISTOR_ENA,
-            3 => MODER::REPEATER_MODE_,
+            0 => MODER::INACTIVE,
+            1 => MODER::PULL_DOWN,
+            2 => MODER::PULL_UP,
+            3 => MODER::REPEATER,
             _ => unreachable!(),
         }
     }
-    #[doc = "Checks if the value of the field is `INACTIVE_NO_PULL_DO`"]
+    #[doc = "Checks if the value of the field is `INACTIVE`"]
     #[inline]
-    pub fn is_inactive_no_pull_do(&self) -> bool {
-        *self == MODER::INACTIVE_NO_PULL_DO
+    pub fn is_inactive(&self) -> bool {
+        *self == MODER::INACTIVE
     }
-    #[doc = "Checks if the value of the field is `PULL_DOWN_RESISTOR_E`"]
+    #[doc = "Checks if the value of the field is `PULL_DOWN`"]
     #[inline]
-    pub fn is_pull_down_resistor_e(&self) -> bool {
-        *self == MODER::PULL_DOWN_RESISTOR_E
+    pub fn is_pull_down(&self) -> bool {
+        *self == MODER::PULL_DOWN
     }
-    #[doc = "Checks if the value of the field is `PULL_UP_RESISTOR_ENA`"]
+    #[doc = "Checks if the value of the field is `PULL_UP`"]
     #[inline]
-    pub fn is_pull_up_resistor_ena(&self) -> bool {
-        *self == MODER::PULL_UP_RESISTOR_ENA
+    pub fn is_pull_up(&self) -> bool {
+        *self == MODER::PULL_UP
     }
-    #[doc = "Checks if the value of the field is `REPEATER_MODE_`"]
+    #[doc = "Checks if the value of the field is `REPEATER`"]
     #[inline]
-    pub fn is_repeater_mode_(&self) -> bool {
-        *self == MODER::REPEATER_MODE_
+    pub fn is_repeater(&self) -> bool {
+        *self == MODER::REPEATER
     }
 }
 #[doc = "Possible values of the field `HYS`"]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum HYSR {
     #[doc = "Disable."]
-    DISABLE_,
+    DISABLED,
     #[doc = "Enable."]
-    ENABLE_,
+    ENABLED,
 }
 impl HYSR {
     #[doc = r" Returns `true` if the bit is clear (0)"]
@@ -162,8 +162,8 @@ impl HYSR {
     #[inline]
     pub fn bit(&self) -> bool {
         match *self {
-            HYSR::DISABLE_ => false,
-            HYSR::ENABLE_ => true,
+            HYSR::DISABLED => false,
+            HYSR::ENABLED => true,
         }
     }
     #[allow(missing_docs)]
@@ -171,28 +171,28 @@ impl HYSR {
     #[inline]
     pub fn _from(value: bool) -> HYSR {
         match value {
-            false => HYSR::DISABLE_,
-            true => HYSR::ENABLE_,
+            false => HYSR::DISABLED,
+            true => HYSR::ENABLED,
         }
     }
-    #[doc = "Checks if the value of the field is `DISABLE_`"]
+    #[doc = "Checks if the value of the field is `DISABLED`"]
     #[inline]
-    pub fn is_disable_(&self) -> bool {
-        *self == HYSR::DISABLE_
+    pub fn is_disabled(&self) -> bool {
+        *self == HYSR::DISABLED
     }
-    #[doc = "Checks if the value of the field is `ENABLE_`"]
+    #[doc = "Checks if the value of the field is `ENABLED`"]
     #[inline]
-    pub fn is_enable_(&self) -> bool {
-        *self == HYSR::ENABLE_
+    pub fn is_enabled(&self) -> bool {
+        *self == HYSR::ENABLED
     }
 }
 #[doc = "Possible values of the field `INV`"]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum INVR {
     #[doc = "Input not inverted (HIGH on pin reads as 1, LOW on pin reads as 0)."]
-    INPUT_NOT_INVERTED_,
+    NOT_INVERTED,
     #[doc = "Input inverted (HIGH on pin reads as 0, LOW on pin reads as 1)."]
-    INPUT_INVERTED_HIGH,
+    INVERTED,
 }
 impl INVR {
     #[doc = r" Returns `true` if the bit is clear (0)"]
@@ -209,8 +209,8 @@ impl INVR {
     #[inline]
     pub fn bit(&self) -> bool {
         match *self {
-            INVR::INPUT_NOT_INVERTED_ => false,
-            INVR::INPUT_INVERTED_HIGH => true,
+            INVR::NOT_INVERTED => false,
+            INVR::INVERTED => true,
         }
     }
     #[allow(missing_docs)]
@@ -218,28 +218,28 @@ impl INVR {
     #[inline]
     pub fn _from(value: bool) -> INVR {
         match value {
-            false => INVR::INPUT_NOT_INVERTED_,
-            true => INVR::INPUT_INVERTED_HIGH,
+            false => INVR::NOT_INVERTED,
+            true => INVR::INVERTED,
         }
     }
-    #[doc = "Checks if the value of the field is `INPUT_NOT_INVERTED_`"]
+    #[doc = "Checks if the value of the field is `NOT_INVERTED`"]
     #[inline]
-    pub fn is_input_not_inverted_(&self) -> bool {
-        *self == INVR::INPUT_NOT_INVERTED_
+    pub fn is_not_inverted(&self) -> bool {
+        *self == INVR::NOT_INVERTED
     }
-    #[doc = "Checks if the value of the field is `INPUT_INVERTED_HIGH`"]
+    #[doc = "Checks if the value of the field is `INVERTED`"]
     #[inline]
-    pub fn is_input_inverted_high(&self) -> bool {
-        *self == INVR::INPUT_INVERTED_HIGH
+    pub fn is_inverted(&self) -> bool {
+        *self == INVR::INVERTED
     }
 }
 #[doc = "Possible values of the field `OD`"]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum ODR {
     #[doc = "Disable."]
-    DISABLE_,
+    DISABLED,
     #[doc = "Open-drain mode enabled.  This is not a true open-drain mode."]
-    OPEN_DRAIN_MODE_ENAB,
+    OPEN_DRAIN,
 }
 impl ODR {
     #[doc = r" Returns `true` if the bit is clear (0)"]
@@ -256,8 +256,8 @@ impl ODR {
     #[inline]
     pub fn bit(&self) -> bool {
         match *self {
-            ODR::DISABLE_ => false,
-            ODR::OPEN_DRAIN_MODE_ENAB => true,
+            ODR::DISABLED => false,
+            ODR::OPEN_DRAIN => true,
         }
     }
     #[allow(missing_docs)]
@@ -265,27 +265,27 @@ impl ODR {
     #[inline]
     pub fn _from(value: bool) -> ODR {
         match value {
-            false => ODR::DISABLE_,
-            true => ODR::OPEN_DRAIN_MODE_ENAB,
+            false => ODR::DISABLED,
+            true => ODR::OPEN_DRAIN,
         }
     }
-    #[doc = "Checks if the value of the field is `DISABLE_`"]
+    #[doc = "Checks if the value of the field is `DISABLED`"]
     #[inline]
-    pub fn is_disable_(&self) -> bool {
-        *self == ODR::DISABLE_
+    pub fn is_disabled(&self) -> bool {
+        *self == ODR::DISABLED
     }
-    #[doc = "Checks if the value of the field is `OPEN_DRAIN_MODE_ENAB`"]
+    #[doc = "Checks if the value of the field is `OPEN_DRAIN`"]
     #[inline]
-    pub fn is_open_drain_mode_enab(&self) -> bool {
-        *self == ODR::OPEN_DRAIN_MODE_ENAB
+    pub fn is_open_drain(&self) -> bool {
+        *self == ODR::OPEN_DRAIN
     }
 }
 #[doc = "Values that can be written to the field `FUNC`"]
 pub enum FUNCW {
     #[doc = "RESET."]
-    RESET_,
+    RESET,
     #[doc = "PIO0_0."]
-    PIO0_0_,
+    PIO0_0,
 }
 impl FUNCW {
     #[allow(missing_docs)]
@@ -293,8 +293,8 @@ impl FUNCW {
     #[inline]
     pub fn _bits(&self) -> u8 {
         match *self {
-            FUNCW::RESET_ => 0,
-            FUNCW::PIO0_0_ => 1,
+            FUNCW::RESET => 0,
+            FUNCW::PIO0_0 => 1,
         }
     }
 }
@@ -310,13 +310,13 @@ impl<'a> _FUNCW<'a> {
     }
     #[doc = "RESET."]
     #[inline]
-    pub fn reset_(self) -> &'a mut W {
-        self.variant(FUNCW::RESET_)
+    pub fn reset(self) -> &'a mut W {
+        self.variant(FUNCW::RESET)
     }
     #[doc = "PIO0_0."]
     #[inline]
-    pub fn pio0_0_(self) -> &'a mut W {
-        self.variant(FUNCW::PIO0_0_)
+    pub fn pio0_0(self) -> &'a mut W {
+        self.variant(FUNCW::PIO0_0)
     }
     #[doc = r" Writes raw bits to the field"]
     #[inline]
@@ -331,13 +331,13 @@ impl<'a> _FUNCW<'a> {
 #[doc = "Values that can be written to the field `MODE`"]
 pub enum MODEW {
     #[doc = "Inactive (no pull-down/pull-up resistor enabled)."]
-    INACTIVE_NO_PULL_DO,
+    INACTIVE,
     #[doc = "Pull-down resistor enabled."]
-    PULL_DOWN_RESISTOR_E,
+    PULL_DOWN,
     #[doc = "Pull-up resistor enabled."]
-    PULL_UP_RESISTOR_ENA,
+    PULL_UP,
     #[doc = "Repeater mode."]
-    REPEATER_MODE_,
+    REPEATER,
 }
 impl MODEW {
     #[allow(missing_docs)]
@@ -345,10 +345,10 @@ impl MODEW {
     #[inline]
     pub fn _bits(&self) -> u8 {
         match *self {
-            MODEW::INACTIVE_NO_PULL_DO => 0,
-            MODEW::PULL_DOWN_RESISTOR_E => 1,
-            MODEW::PULL_UP_RESISTOR_ENA => 2,
-            MODEW::REPEATER_MODE_ => 3,
+            MODEW::INACTIVE => 0,
+            MODEW::PULL_DOWN => 1,
+            MODEW::PULL_UP => 2,
+            MODEW::REPEATER => 3,
         }
     }
 }
@@ -366,23 +366,23 @@ impl<'a> _MODEW<'a> {
     }
     #[doc = "Inactive (no pull-down/pull-up resistor enabled)."]
     #[inline]
-    pub fn inactive_no_pull_do(self) -> &'a mut W {
-        self.variant(MODEW::INACTIVE_NO_PULL_DO)
+    pub fn inactive(self) -> &'a mut W {
+        self.variant(MODEW::INACTIVE)
     }
     #[doc = "Pull-down resistor enabled."]
     #[inline]
-    pub fn pull_down_resistor_e(self) -> &'a mut W {
-        self.variant(MODEW::PULL_DOWN_RESISTOR_E)
+    pub fn pull_down(self) -> &'a mut W {
+        self.variant(MODEW::PULL_DOWN)
     }
     #[doc = "Pull-up resistor enabled."]
     #[inline]
-    pub fn pull_up_resistor_ena(self) -> &'a mut W {
-        self.variant(MODEW::PULL_UP_RESISTOR_ENA)
+    pub fn pull_up(self) -> &'a mut W {
+        self.variant(MODEW::PULL_UP)
     }
     #[doc = "Repeater mode."]
     #[inline]
-    pub fn repeater_mode_(self) -> &'a mut W {
-        self.variant(MODEW::REPEATER_MODE_)
+    pub fn repeater(self) -> &'a mut W {
+        self.variant(MODEW::REPEATER)
     }
     #[doc = r" Writes raw bits to the field"]
     #[inline]
@@ -397,9 +397,9 @@ impl<'a> _MODEW<'a> {
 #[doc = "Values that can be written to the field `HYS`"]
 pub enum HYSW {
     #[doc = "Disable."]
-    DISABLE_,
+    DISABLED,
     #[doc = "Enable."]
-    ENABLE_,
+    ENABLED,
 }
 impl HYSW {
     #[allow(missing_docs)]
@@ -407,8 +407,8 @@ impl HYSW {
     #[inline]
     pub fn _bits(&self) -> bool {
         match *self {
-            HYSW::DISABLE_ => false,
-            HYSW::ENABLE_ => true,
+            HYSW::DISABLED => false,
+            HYSW::ENABLED => true,
         }
     }
 }
@@ -426,13 +426,13 @@ impl<'a> _HYSW<'a> {
     }
     #[doc = "Disable."]
     #[inline]
-    pub fn disable_(self) -> &'a mut W {
-        self.variant(HYSW::DISABLE_)
+    pub fn disabled(self) -> &'a mut W {
+        self.variant(HYSW::DISABLED)
     }
     #[doc = "Enable."]
     #[inline]
-    pub fn enable_(self) -> &'a mut W {
-        self.variant(HYSW::ENABLE_)
+    pub fn enabled(self) -> &'a mut W {
+        self.variant(HYSW::ENABLED)
     }
     #[doc = r" Sets the field bit"]
     pub fn set_bit(self) -> &'a mut W {
@@ -455,9 +455,9 @@ impl<'a> _HYSW<'a> {
 #[doc = "Values that can be written to the field `INV`"]
 pub enum INVW {
     #[doc = "Input not inverted (HIGH on pin reads as 1, LOW on pin reads as 0)."]
-    INPUT_NOT_INVERTED_,
+    NOT_INVERTED,
     #[doc = "Input inverted (HIGH on pin reads as 0, LOW on pin reads as 1)."]
-    INPUT_INVERTED_HIGH,
+    INVERTED,
 }
 impl INVW {
     #[allow(missing_docs)]
@@ -465,8 +465,8 @@ impl INVW {
     #[inline]
     pub fn _bits(&self) -> bool {
         match *self {
-            INVW::INPUT_NOT_INVERTED_ => false,
-            INVW::INPUT_INVERTED_HIGH => true,
+            INVW::NOT_INVERTED => false,
+            INVW::INVERTED => true,
         }
     }
 }
@@ -484,13 +484,13 @@ impl<'a> _INVW<'a> {
     }
     #[doc = "Input not inverted (HIGH on pin reads as 1, LOW on pin reads as 0)."]
     #[inline]
-    pub fn input_not_inverted_(self) -> &'a mut W {
-        self.variant(INVW::INPUT_NOT_INVERTED_)
+    pub fn not_inverted(self) -> &'a mut W {
+        self.variant(INVW::NOT_INVERTED)
     }
     #[doc = "Input inverted (HIGH on pin reads as 0, LOW on pin reads as 1)."]
     #[inline]
-    pub fn input_inverted_high(self) -> &'a mut W {
-        self.variant(INVW::INPUT_INVERTED_HIGH)
+    pub fn inverted(self) -> &'a mut W {
+        self.variant(INVW::INVERTED)
     }
     #[doc = r" Sets the field bit"]
     pub fn set_bit(self) -> &'a mut W {
@@ -513,9 +513,9 @@ impl<'a> _INVW<'a> {
 #[doc = "Values that can be written to the field `OD`"]
 pub enum ODW {
     #[doc = "Disable."]
-    DISABLE_,
+    DISABLED,
     #[doc = "Open-drain mode enabled.  This is not a true open-drain mode."]
-    OPEN_DRAIN_MODE_ENAB,
+    OPEN_DRAIN,
 }
 impl ODW {
     #[allow(missing_docs)]
@@ -523,8 +523,8 @@ impl ODW {
     #[inline]
     pub fn _bits(&self) -> bool {
         match *self {
-            ODW::DISABLE_ => false,
-            ODW::OPEN_DRAIN_MODE_ENAB => true,
+            ODW::DISABLED => false,
+            ODW::OPEN_DRAIN => true,
         }
     }
 }
@@ -542,13 +542,13 @@ impl<'a> _ODW<'a> {
     }
     #[doc = "Disable."]
     #[inline]
-    pub fn disable_(self) -> &'a mut W {
-        self.variant(ODW::DISABLE_)
+    pub fn disabled(self) -> &'a mut W {
+        self.variant(ODW::DISABLED)
     }
     #[doc = "Open-drain mode enabled. This is not a true open-drain mode."]
     #[inline]
-    pub fn open_drain_mode_enab(self) -> &'a mut W {
-        self.variant(ODW::OPEN_DRAIN_MODE_ENAB)
+    pub fn open_drain(self) -> &'a mut W {
+        self.variant(ODW::OPEN_DRAIN)
     }
     #[doc = r" Sets the field bit"]
     pub fn set_bit(self) -> &'a mut W {

--- a/lpc11uxx/src/iocon/swclk_pio0_10.rs
+++ b/lpc11uxx/src/iocon/swclk_pio0_10.rs
@@ -46,13 +46,13 @@ impl super::SWCLK_PIO0_10 {
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum FUNCR {
     #[doc = "SWCLK."]
-    SWCLK_,
+    SWCLK,
     #[doc = "PIO0_10."]
-    PIO0_10_,
+    PIO0_10,
     #[doc = "SCK0."]
-    SCK0_,
+    SCK0,
     #[doc = "CT16B0_MAT2."]
-    CT16B0_MAT2_,
+    CT16B0_MAT2,
     #[doc = r" Reserved"]
     _Reserved(u8),
 }
@@ -61,10 +61,10 @@ impl FUNCR {
     #[inline]
     pub fn bits(&self) -> u8 {
         match *self {
-            FUNCR::SWCLK_ => 0,
-            FUNCR::PIO0_10_ => 1,
-            FUNCR::SCK0_ => 2,
-            FUNCR::CT16B0_MAT2_ => 3,
+            FUNCR::SWCLK => 0,
+            FUNCR::PIO0_10 => 1,
+            FUNCR::SCK0 => 2,
+            FUNCR::CT16B0_MAT2 => 3,
             FUNCR::_Reserved(bits) => bits,
         }
     }
@@ -73,55 +73,55 @@ impl FUNCR {
     #[inline]
     pub fn _from(value: u8) -> FUNCR {
         match value {
-            0 => FUNCR::SWCLK_,
-            1 => FUNCR::PIO0_10_,
-            2 => FUNCR::SCK0_,
-            3 => FUNCR::CT16B0_MAT2_,
+            0 => FUNCR::SWCLK,
+            1 => FUNCR::PIO0_10,
+            2 => FUNCR::SCK0,
+            3 => FUNCR::CT16B0_MAT2,
             i => FUNCR::_Reserved(i),
         }
     }
-    #[doc = "Checks if the value of the field is `SWCLK_`"]
+    #[doc = "Checks if the value of the field is `SWCLK`"]
     #[inline]
-    pub fn is_swclk_(&self) -> bool {
-        *self == FUNCR::SWCLK_
+    pub fn is_swclk(&self) -> bool {
+        *self == FUNCR::SWCLK
     }
-    #[doc = "Checks if the value of the field is `PIO0_10_`"]
+    #[doc = "Checks if the value of the field is `PIO0_10`"]
     #[inline]
-    pub fn is_pio0_10_(&self) -> bool {
-        *self == FUNCR::PIO0_10_
+    pub fn is_pio0_10(&self) -> bool {
+        *self == FUNCR::PIO0_10
     }
-    #[doc = "Checks if the value of the field is `SCK0_`"]
+    #[doc = "Checks if the value of the field is `SCK0`"]
     #[inline]
-    pub fn is_sck0_(&self) -> bool {
-        *self == FUNCR::SCK0_
+    pub fn is_sck0(&self) -> bool {
+        *self == FUNCR::SCK0
     }
-    #[doc = "Checks if the value of the field is `CT16B0_MAT2_`"]
+    #[doc = "Checks if the value of the field is `CT16B0_MAT2`"]
     #[inline]
-    pub fn is_ct16b0_mat2_(&self) -> bool {
-        *self == FUNCR::CT16B0_MAT2_
+    pub fn is_ct16b0_mat2(&self) -> bool {
+        *self == FUNCR::CT16B0_MAT2
     }
 }
 #[doc = "Possible values of the field `MODE`"]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum MODER {
     #[doc = "Inactive (no pull-down/pull-up resistor enabled)."]
-    INACTIVE_NO_PULL_DO,
+    INACTIVE,
     #[doc = "Pull-down resistor enabled."]
-    PULL_DOWN_RESISTOR_E,
+    PULL_DOWN,
     #[doc = "Pull-up resistor enabled."]
-    PULL_UP_RESISTOR_ENA,
+    PULL_UP,
     #[doc = "Repeater mode."]
-    REPEATER_MODE_,
+    REPEATER,
 }
 impl MODER {
     #[doc = r" Value of the field as raw bits"]
     #[inline]
     pub fn bits(&self) -> u8 {
         match *self {
-            MODER::INACTIVE_NO_PULL_DO => 0,
-            MODER::PULL_DOWN_RESISTOR_E => 1,
-            MODER::PULL_UP_RESISTOR_ENA => 2,
-            MODER::REPEATER_MODE_ => 3,
+            MODER::INACTIVE => 0,
+            MODER::PULL_DOWN => 1,
+            MODER::PULL_UP => 2,
+            MODER::REPEATER => 3,
         }
     }
     #[allow(missing_docs)]
@@ -129,41 +129,41 @@ impl MODER {
     #[inline]
     pub fn _from(value: u8) -> MODER {
         match value {
-            0 => MODER::INACTIVE_NO_PULL_DO,
-            1 => MODER::PULL_DOWN_RESISTOR_E,
-            2 => MODER::PULL_UP_RESISTOR_ENA,
-            3 => MODER::REPEATER_MODE_,
+            0 => MODER::INACTIVE,
+            1 => MODER::PULL_DOWN,
+            2 => MODER::PULL_UP,
+            3 => MODER::REPEATER,
             _ => unreachable!(),
         }
     }
-    #[doc = "Checks if the value of the field is `INACTIVE_NO_PULL_DO`"]
+    #[doc = "Checks if the value of the field is `INACTIVE`"]
     #[inline]
-    pub fn is_inactive_no_pull_do(&self) -> bool {
-        *self == MODER::INACTIVE_NO_PULL_DO
+    pub fn is_inactive(&self) -> bool {
+        *self == MODER::INACTIVE
     }
-    #[doc = "Checks if the value of the field is `PULL_DOWN_RESISTOR_E`"]
+    #[doc = "Checks if the value of the field is `PULL_DOWN`"]
     #[inline]
-    pub fn is_pull_down_resistor_e(&self) -> bool {
-        *self == MODER::PULL_DOWN_RESISTOR_E
+    pub fn is_pull_down(&self) -> bool {
+        *self == MODER::PULL_DOWN
     }
-    #[doc = "Checks if the value of the field is `PULL_UP_RESISTOR_ENA`"]
+    #[doc = "Checks if the value of the field is `PULL_UP`"]
     #[inline]
-    pub fn is_pull_up_resistor_ena(&self) -> bool {
-        *self == MODER::PULL_UP_RESISTOR_ENA
+    pub fn is_pull_up(&self) -> bool {
+        *self == MODER::PULL_UP
     }
-    #[doc = "Checks if the value of the field is `REPEATER_MODE_`"]
+    #[doc = "Checks if the value of the field is `REPEATER`"]
     #[inline]
-    pub fn is_repeater_mode_(&self) -> bool {
-        *self == MODER::REPEATER_MODE_
+    pub fn is_repeater(&self) -> bool {
+        *self == MODER::REPEATER
     }
 }
 #[doc = "Possible values of the field `HYS`"]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum HYSR {
     #[doc = "Disable."]
-    DISABLE_,
+    DISABLED,
     #[doc = "Enable."]
-    ENABLE_,
+    ENABLED,
 }
 impl HYSR {
     #[doc = r" Returns `true` if the bit is clear (0)"]
@@ -180,8 +180,8 @@ impl HYSR {
     #[inline]
     pub fn bit(&self) -> bool {
         match *self {
-            HYSR::DISABLE_ => false,
-            HYSR::ENABLE_ => true,
+            HYSR::DISABLED => false,
+            HYSR::ENABLED => true,
         }
     }
     #[allow(missing_docs)]
@@ -189,28 +189,28 @@ impl HYSR {
     #[inline]
     pub fn _from(value: bool) -> HYSR {
         match value {
-            false => HYSR::DISABLE_,
-            true => HYSR::ENABLE_,
+            false => HYSR::DISABLED,
+            true => HYSR::ENABLED,
         }
     }
-    #[doc = "Checks if the value of the field is `DISABLE_`"]
+    #[doc = "Checks if the value of the field is `DISABLED`"]
     #[inline]
-    pub fn is_disable_(&self) -> bool {
-        *self == HYSR::DISABLE_
+    pub fn is_disabled(&self) -> bool {
+        *self == HYSR::DISABLED
     }
-    #[doc = "Checks if the value of the field is `ENABLE_`"]
+    #[doc = "Checks if the value of the field is `ENABLED`"]
     #[inline]
-    pub fn is_enable_(&self) -> bool {
-        *self == HYSR::ENABLE_
+    pub fn is_enabled(&self) -> bool {
+        *self == HYSR::ENABLED
     }
 }
 #[doc = "Possible values of the field `INV`"]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum INVR {
     #[doc = "Input not inverted (HIGH on pin reads as 1, LOW on pin reads as 0)."]
-    INPUT_NOT_INVERTED_,
+    NOT_INVERTED,
     #[doc = "Input inverted (HIGH on pin reads as 0, LOW on pin reads as 1)."]
-    INPUT_INVERTED_HIGH,
+    INVERTED,
 }
 impl INVR {
     #[doc = r" Returns `true` if the bit is clear (0)"]
@@ -227,8 +227,8 @@ impl INVR {
     #[inline]
     pub fn bit(&self) -> bool {
         match *self {
-            INVR::INPUT_NOT_INVERTED_ => false,
-            INVR::INPUT_INVERTED_HIGH => true,
+            INVR::NOT_INVERTED => false,
+            INVR::INVERTED => true,
         }
     }
     #[allow(missing_docs)]
@@ -236,28 +236,28 @@ impl INVR {
     #[inline]
     pub fn _from(value: bool) -> INVR {
         match value {
-            false => INVR::INPUT_NOT_INVERTED_,
-            true => INVR::INPUT_INVERTED_HIGH,
+            false => INVR::NOT_INVERTED,
+            true => INVR::INVERTED,
         }
     }
-    #[doc = "Checks if the value of the field is `INPUT_NOT_INVERTED_`"]
+    #[doc = "Checks if the value of the field is `NOT_INVERTED`"]
     #[inline]
-    pub fn is_input_not_inverted_(&self) -> bool {
-        *self == INVR::INPUT_NOT_INVERTED_
+    pub fn is_not_inverted(&self) -> bool {
+        *self == INVR::NOT_INVERTED
     }
-    #[doc = "Checks if the value of the field is `INPUT_INVERTED_HIGH`"]
+    #[doc = "Checks if the value of the field is `INVERTED`"]
     #[inline]
-    pub fn is_input_inverted_high(&self) -> bool {
-        *self == INVR::INPUT_INVERTED_HIGH
+    pub fn is_inverted(&self) -> bool {
+        *self == INVR::INVERTED
     }
 }
 #[doc = "Possible values of the field `OD`"]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum ODR {
     #[doc = "Disable."]
-    DISABLE_,
+    DISABLED,
     #[doc = "Open-drain mode enabled.  This is not a true open-drain mode."]
-    OPEN_DRAIN_MODE_ENAB,
+    OPEN_DRAIN,
 }
 impl ODR {
     #[doc = r" Returns `true` if the bit is clear (0)"]
@@ -274,8 +274,8 @@ impl ODR {
     #[inline]
     pub fn bit(&self) -> bool {
         match *self {
-            ODR::DISABLE_ => false,
-            ODR::OPEN_DRAIN_MODE_ENAB => true,
+            ODR::DISABLED => false,
+            ODR::OPEN_DRAIN => true,
         }
     }
     #[allow(missing_docs)]
@@ -283,31 +283,31 @@ impl ODR {
     #[inline]
     pub fn _from(value: bool) -> ODR {
         match value {
-            false => ODR::DISABLE_,
-            true => ODR::OPEN_DRAIN_MODE_ENAB,
+            false => ODR::DISABLED,
+            true => ODR::OPEN_DRAIN,
         }
     }
-    #[doc = "Checks if the value of the field is `DISABLE_`"]
+    #[doc = "Checks if the value of the field is `DISABLED`"]
     #[inline]
-    pub fn is_disable_(&self) -> bool {
-        *self == ODR::DISABLE_
+    pub fn is_disabled(&self) -> bool {
+        *self == ODR::DISABLED
     }
-    #[doc = "Checks if the value of the field is `OPEN_DRAIN_MODE_ENAB`"]
+    #[doc = "Checks if the value of the field is `OPEN_DRAIN`"]
     #[inline]
-    pub fn is_open_drain_mode_enab(&self) -> bool {
-        *self == ODR::OPEN_DRAIN_MODE_ENAB
+    pub fn is_open_drain(&self) -> bool {
+        *self == ODR::OPEN_DRAIN
     }
 }
 #[doc = "Values that can be written to the field `FUNC`"]
 pub enum FUNCW {
     #[doc = "SWCLK."]
-    SWCLK_,
+    SWCLK,
     #[doc = "PIO0_10."]
-    PIO0_10_,
+    PIO0_10,
     #[doc = "SCK0."]
-    SCK0_,
+    SCK0,
     #[doc = "CT16B0_MAT2."]
-    CT16B0_MAT2_,
+    CT16B0_MAT2,
 }
 impl FUNCW {
     #[allow(missing_docs)]
@@ -315,10 +315,10 @@ impl FUNCW {
     #[inline]
     pub fn _bits(&self) -> u8 {
         match *self {
-            FUNCW::SWCLK_ => 0,
-            FUNCW::PIO0_10_ => 1,
-            FUNCW::SCK0_ => 2,
-            FUNCW::CT16B0_MAT2_ => 3,
+            FUNCW::SWCLK => 0,
+            FUNCW::PIO0_10 => 1,
+            FUNCW::SCK0 => 2,
+            FUNCW::CT16B0_MAT2 => 3,
         }
     }
 }
@@ -334,23 +334,23 @@ impl<'a> _FUNCW<'a> {
     }
     #[doc = "SWCLK."]
     #[inline]
-    pub fn swclk_(self) -> &'a mut W {
-        self.variant(FUNCW::SWCLK_)
+    pub fn swclk(self) -> &'a mut W {
+        self.variant(FUNCW::SWCLK)
     }
     #[doc = "PIO0_10."]
     #[inline]
-    pub fn pio0_10_(self) -> &'a mut W {
-        self.variant(FUNCW::PIO0_10_)
+    pub fn pio0_10(self) -> &'a mut W {
+        self.variant(FUNCW::PIO0_10)
     }
     #[doc = "SCK0."]
     #[inline]
-    pub fn sck0_(self) -> &'a mut W {
-        self.variant(FUNCW::SCK0_)
+    pub fn sck0(self) -> &'a mut W {
+        self.variant(FUNCW::SCK0)
     }
     #[doc = "CT16B0_MAT2."]
     #[inline]
-    pub fn ct16b0_mat2_(self) -> &'a mut W {
-        self.variant(FUNCW::CT16B0_MAT2_)
+    pub fn ct16b0_mat2(self) -> &'a mut W {
+        self.variant(FUNCW::CT16B0_MAT2)
     }
     #[doc = r" Writes raw bits to the field"]
     #[inline]
@@ -365,13 +365,13 @@ impl<'a> _FUNCW<'a> {
 #[doc = "Values that can be written to the field `MODE`"]
 pub enum MODEW {
     #[doc = "Inactive (no pull-down/pull-up resistor enabled)."]
-    INACTIVE_NO_PULL_DO,
+    INACTIVE,
     #[doc = "Pull-down resistor enabled."]
-    PULL_DOWN_RESISTOR_E,
+    PULL_DOWN,
     #[doc = "Pull-up resistor enabled."]
-    PULL_UP_RESISTOR_ENA,
+    PULL_UP,
     #[doc = "Repeater mode."]
-    REPEATER_MODE_,
+    REPEATER,
 }
 impl MODEW {
     #[allow(missing_docs)]
@@ -379,10 +379,10 @@ impl MODEW {
     #[inline]
     pub fn _bits(&self) -> u8 {
         match *self {
-            MODEW::INACTIVE_NO_PULL_DO => 0,
-            MODEW::PULL_DOWN_RESISTOR_E => 1,
-            MODEW::PULL_UP_RESISTOR_ENA => 2,
-            MODEW::REPEATER_MODE_ => 3,
+            MODEW::INACTIVE => 0,
+            MODEW::PULL_DOWN => 1,
+            MODEW::PULL_UP => 2,
+            MODEW::REPEATER => 3,
         }
     }
 }
@@ -400,23 +400,23 @@ impl<'a> _MODEW<'a> {
     }
     #[doc = "Inactive (no pull-down/pull-up resistor enabled)."]
     #[inline]
-    pub fn inactive_no_pull_do(self) -> &'a mut W {
-        self.variant(MODEW::INACTIVE_NO_PULL_DO)
+    pub fn inactive(self) -> &'a mut W {
+        self.variant(MODEW::INACTIVE)
     }
     #[doc = "Pull-down resistor enabled."]
     #[inline]
-    pub fn pull_down_resistor_e(self) -> &'a mut W {
-        self.variant(MODEW::PULL_DOWN_RESISTOR_E)
+    pub fn pull_down(self) -> &'a mut W {
+        self.variant(MODEW::PULL_DOWN)
     }
     #[doc = "Pull-up resistor enabled."]
     #[inline]
-    pub fn pull_up_resistor_ena(self) -> &'a mut W {
-        self.variant(MODEW::PULL_UP_RESISTOR_ENA)
+    pub fn pull_up(self) -> &'a mut W {
+        self.variant(MODEW::PULL_UP)
     }
     #[doc = "Repeater mode."]
     #[inline]
-    pub fn repeater_mode_(self) -> &'a mut W {
-        self.variant(MODEW::REPEATER_MODE_)
+    pub fn repeater(self) -> &'a mut W {
+        self.variant(MODEW::REPEATER)
     }
     #[doc = r" Writes raw bits to the field"]
     #[inline]
@@ -431,9 +431,9 @@ impl<'a> _MODEW<'a> {
 #[doc = "Values that can be written to the field `HYS`"]
 pub enum HYSW {
     #[doc = "Disable."]
-    DISABLE_,
+    DISABLED,
     #[doc = "Enable."]
-    ENABLE_,
+    ENABLED,
 }
 impl HYSW {
     #[allow(missing_docs)]
@@ -441,8 +441,8 @@ impl HYSW {
     #[inline]
     pub fn _bits(&self) -> bool {
         match *self {
-            HYSW::DISABLE_ => false,
-            HYSW::ENABLE_ => true,
+            HYSW::DISABLED => false,
+            HYSW::ENABLED => true,
         }
     }
 }
@@ -460,13 +460,13 @@ impl<'a> _HYSW<'a> {
     }
     #[doc = "Disable."]
     #[inline]
-    pub fn disable_(self) -> &'a mut W {
-        self.variant(HYSW::DISABLE_)
+    pub fn disabled(self) -> &'a mut W {
+        self.variant(HYSW::DISABLED)
     }
     #[doc = "Enable."]
     #[inline]
-    pub fn enable_(self) -> &'a mut W {
-        self.variant(HYSW::ENABLE_)
+    pub fn enabled(self) -> &'a mut W {
+        self.variant(HYSW::ENABLED)
     }
     #[doc = r" Sets the field bit"]
     pub fn set_bit(self) -> &'a mut W {
@@ -489,9 +489,9 @@ impl<'a> _HYSW<'a> {
 #[doc = "Values that can be written to the field `INV`"]
 pub enum INVW {
     #[doc = "Input not inverted (HIGH on pin reads as 1, LOW on pin reads as 0)."]
-    INPUT_NOT_INVERTED_,
+    NOT_INVERTED,
     #[doc = "Input inverted (HIGH on pin reads as 0, LOW on pin reads as 1)."]
-    INPUT_INVERTED_HIGH,
+    INVERTED,
 }
 impl INVW {
     #[allow(missing_docs)]
@@ -499,8 +499,8 @@ impl INVW {
     #[inline]
     pub fn _bits(&self) -> bool {
         match *self {
-            INVW::INPUT_NOT_INVERTED_ => false,
-            INVW::INPUT_INVERTED_HIGH => true,
+            INVW::NOT_INVERTED => false,
+            INVW::INVERTED => true,
         }
     }
 }
@@ -518,13 +518,13 @@ impl<'a> _INVW<'a> {
     }
     #[doc = "Input not inverted (HIGH on pin reads as 1, LOW on pin reads as 0)."]
     #[inline]
-    pub fn input_not_inverted_(self) -> &'a mut W {
-        self.variant(INVW::INPUT_NOT_INVERTED_)
+    pub fn not_inverted(self) -> &'a mut W {
+        self.variant(INVW::NOT_INVERTED)
     }
     #[doc = "Input inverted (HIGH on pin reads as 0, LOW on pin reads as 1)."]
     #[inline]
-    pub fn input_inverted_high(self) -> &'a mut W {
-        self.variant(INVW::INPUT_INVERTED_HIGH)
+    pub fn inverted(self) -> &'a mut W {
+        self.variant(INVW::INVERTED)
     }
     #[doc = r" Sets the field bit"]
     pub fn set_bit(self) -> &'a mut W {
@@ -547,9 +547,9 @@ impl<'a> _INVW<'a> {
 #[doc = "Values that can be written to the field `OD`"]
 pub enum ODW {
     #[doc = "Disable."]
-    DISABLE_,
+    DISABLED,
     #[doc = "Open-drain mode enabled.  This is not a true open-drain mode."]
-    OPEN_DRAIN_MODE_ENAB,
+    OPEN_DRAIN,
 }
 impl ODW {
     #[allow(missing_docs)]
@@ -557,8 +557,8 @@ impl ODW {
     #[inline]
     pub fn _bits(&self) -> bool {
         match *self {
-            ODW::DISABLE_ => false,
-            ODW::OPEN_DRAIN_MODE_ENAB => true,
+            ODW::DISABLED => false,
+            ODW::OPEN_DRAIN => true,
         }
     }
 }
@@ -576,13 +576,13 @@ impl<'a> _ODW<'a> {
     }
     #[doc = "Disable."]
     #[inline]
-    pub fn disable_(self) -> &'a mut W {
-        self.variant(ODW::DISABLE_)
+    pub fn disabled(self) -> &'a mut W {
+        self.variant(ODW::DISABLED)
     }
     #[doc = "Open-drain mode enabled. This is not a true open-drain mode."]
     #[inline]
-    pub fn open_drain_mode_enab(self) -> &'a mut W {
-        self.variant(ODW::OPEN_DRAIN_MODE_ENAB)
+    pub fn open_drain(self) -> &'a mut W {
+        self.variant(ODW::OPEN_DRAIN)
     }
     #[doc = r" Sets the field bit"]
     pub fn set_bit(self) -> &'a mut W {

--- a/lpc11uxx/src/iocon/swdio_pio0_15.rs
+++ b/lpc11uxx/src/iocon/swdio_pio0_15.rs
@@ -46,13 +46,13 @@ impl super::SWDIO_PIO0_15 {
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum FUNCR {
     #[doc = "SWDIO."]
-    SWDIO_,
+    SWDIO,
     #[doc = "PIO0_15."]
-    PIO0_15_,
+    PIO0_15,
     #[doc = "AD4."]
-    AD4_,
+    AD4,
     #[doc = "CT32B1_MAT2."]
-    CT32B1_MAT2_,
+    CT32B1_MAT2,
     #[doc = r" Reserved"]
     _Reserved(u8),
 }
@@ -61,10 +61,10 @@ impl FUNCR {
     #[inline]
     pub fn bits(&self) -> u8 {
         match *self {
-            FUNCR::SWDIO_ => 0,
-            FUNCR::PIO0_15_ => 1,
-            FUNCR::AD4_ => 2,
-            FUNCR::CT32B1_MAT2_ => 3,
+            FUNCR::SWDIO => 0,
+            FUNCR::PIO0_15 => 1,
+            FUNCR::AD4 => 2,
+            FUNCR::CT32B1_MAT2 => 3,
             FUNCR::_Reserved(bits) => bits,
         }
     }
@@ -73,55 +73,55 @@ impl FUNCR {
     #[inline]
     pub fn _from(value: u8) -> FUNCR {
         match value {
-            0 => FUNCR::SWDIO_,
-            1 => FUNCR::PIO0_15_,
-            2 => FUNCR::AD4_,
-            3 => FUNCR::CT32B1_MAT2_,
+            0 => FUNCR::SWDIO,
+            1 => FUNCR::PIO0_15,
+            2 => FUNCR::AD4,
+            3 => FUNCR::CT32B1_MAT2,
             i => FUNCR::_Reserved(i),
         }
     }
-    #[doc = "Checks if the value of the field is `SWDIO_`"]
+    #[doc = "Checks if the value of the field is `SWDIO`"]
     #[inline]
-    pub fn is_swdio_(&self) -> bool {
-        *self == FUNCR::SWDIO_
+    pub fn is_swdio(&self) -> bool {
+        *self == FUNCR::SWDIO
     }
-    #[doc = "Checks if the value of the field is `PIO0_15_`"]
+    #[doc = "Checks if the value of the field is `PIO0_15`"]
     #[inline]
-    pub fn is_pio0_15_(&self) -> bool {
-        *self == FUNCR::PIO0_15_
+    pub fn is_pio0_15(&self) -> bool {
+        *self == FUNCR::PIO0_15
     }
-    #[doc = "Checks if the value of the field is `AD4_`"]
+    #[doc = "Checks if the value of the field is `AD4`"]
     #[inline]
-    pub fn is_ad4_(&self) -> bool {
-        *self == FUNCR::AD4_
+    pub fn is_ad4(&self) -> bool {
+        *self == FUNCR::AD4
     }
-    #[doc = "Checks if the value of the field is `CT32B1_MAT2_`"]
+    #[doc = "Checks if the value of the field is `CT32B1_MAT2`"]
     #[inline]
-    pub fn is_ct32b1_mat2_(&self) -> bool {
-        *self == FUNCR::CT32B1_MAT2_
+    pub fn is_ct32b1_mat2(&self) -> bool {
+        *self == FUNCR::CT32B1_MAT2
     }
 }
 #[doc = "Possible values of the field `MODE`"]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum MODER {
     #[doc = "Inactive (no pull-down/pull-up resistor enabled)."]
-    INACTIVE_NO_PULL_DO,
+    INACTIVE,
     #[doc = "Pull-down resistor enabled."]
-    PULL_DOWN_RESISTOR_E,
+    PULL_DOWN,
     #[doc = "Pull-up resistor enabled."]
-    PULL_UP_RESISTOR_ENA,
+    PULL_UP,
     #[doc = "Repeater mode."]
-    REPEATER_MODE_,
+    REPEATER,
 }
 impl MODER {
     #[doc = r" Value of the field as raw bits"]
     #[inline]
     pub fn bits(&self) -> u8 {
         match *self {
-            MODER::INACTIVE_NO_PULL_DO => 0,
-            MODER::PULL_DOWN_RESISTOR_E => 1,
-            MODER::PULL_UP_RESISTOR_ENA => 2,
-            MODER::REPEATER_MODE_ => 3,
+            MODER::INACTIVE => 0,
+            MODER::PULL_DOWN => 1,
+            MODER::PULL_UP => 2,
+            MODER::REPEATER => 3,
         }
     }
     #[allow(missing_docs)]
@@ -129,41 +129,41 @@ impl MODER {
     #[inline]
     pub fn _from(value: u8) -> MODER {
         match value {
-            0 => MODER::INACTIVE_NO_PULL_DO,
-            1 => MODER::PULL_DOWN_RESISTOR_E,
-            2 => MODER::PULL_UP_RESISTOR_ENA,
-            3 => MODER::REPEATER_MODE_,
+            0 => MODER::INACTIVE,
+            1 => MODER::PULL_DOWN,
+            2 => MODER::PULL_UP,
+            3 => MODER::REPEATER,
             _ => unreachable!(),
         }
     }
-    #[doc = "Checks if the value of the field is `INACTIVE_NO_PULL_DO`"]
+    #[doc = "Checks if the value of the field is `INACTIVE`"]
     #[inline]
-    pub fn is_inactive_no_pull_do(&self) -> bool {
-        *self == MODER::INACTIVE_NO_PULL_DO
+    pub fn is_inactive(&self) -> bool {
+        *self == MODER::INACTIVE
     }
-    #[doc = "Checks if the value of the field is `PULL_DOWN_RESISTOR_E`"]
+    #[doc = "Checks if the value of the field is `PULL_DOWN`"]
     #[inline]
-    pub fn is_pull_down_resistor_e(&self) -> bool {
-        *self == MODER::PULL_DOWN_RESISTOR_E
+    pub fn is_pull_down(&self) -> bool {
+        *self == MODER::PULL_DOWN
     }
-    #[doc = "Checks if the value of the field is `PULL_UP_RESISTOR_ENA`"]
+    #[doc = "Checks if the value of the field is `PULL_UP`"]
     #[inline]
-    pub fn is_pull_up_resistor_ena(&self) -> bool {
-        *self == MODER::PULL_UP_RESISTOR_ENA
+    pub fn is_pull_up(&self) -> bool {
+        *self == MODER::PULL_UP
     }
-    #[doc = "Checks if the value of the field is `REPEATER_MODE_`"]
+    #[doc = "Checks if the value of the field is `REPEATER`"]
     #[inline]
-    pub fn is_repeater_mode_(&self) -> bool {
-        *self == MODER::REPEATER_MODE_
+    pub fn is_repeater(&self) -> bool {
+        *self == MODER::REPEATER
     }
 }
 #[doc = "Possible values of the field `HYS`"]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum HYSR {
     #[doc = "Disable."]
-    DISABLE_,
+    DISABLED,
     #[doc = "Enable."]
-    ENABLE_,
+    ENABLED,
 }
 impl HYSR {
     #[doc = r" Returns `true` if the bit is clear (0)"]
@@ -180,8 +180,8 @@ impl HYSR {
     #[inline]
     pub fn bit(&self) -> bool {
         match *self {
-            HYSR::DISABLE_ => false,
-            HYSR::ENABLE_ => true,
+            HYSR::DISABLED => false,
+            HYSR::ENABLED => true,
         }
     }
     #[allow(missing_docs)]
@@ -189,28 +189,28 @@ impl HYSR {
     #[inline]
     pub fn _from(value: bool) -> HYSR {
         match value {
-            false => HYSR::DISABLE_,
-            true => HYSR::ENABLE_,
+            false => HYSR::DISABLED,
+            true => HYSR::ENABLED,
         }
     }
-    #[doc = "Checks if the value of the field is `DISABLE_`"]
+    #[doc = "Checks if the value of the field is `DISABLED`"]
     #[inline]
-    pub fn is_disable_(&self) -> bool {
-        *self == HYSR::DISABLE_
+    pub fn is_disabled(&self) -> bool {
+        *self == HYSR::DISABLED
     }
-    #[doc = "Checks if the value of the field is `ENABLE_`"]
+    #[doc = "Checks if the value of the field is `ENABLED`"]
     #[inline]
-    pub fn is_enable_(&self) -> bool {
-        *self == HYSR::ENABLE_
+    pub fn is_enabled(&self) -> bool {
+        *self == HYSR::ENABLED
     }
 }
 #[doc = "Possible values of the field `INV`"]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum INVR {
     #[doc = "Input not inverted (HIGH on pin reads as 1, LOW on pin reads as 0)."]
-    INPUT_NOT_INVERTED_,
+    NOT_INVERTED,
     #[doc = "Input inverted (HIGH on pin reads as 0, LOW on pin reads as 1)."]
-    INPUT_INVERTED_HIGH,
+    INVERTED,
 }
 impl INVR {
     #[doc = r" Returns `true` if the bit is clear (0)"]
@@ -227,8 +227,8 @@ impl INVR {
     #[inline]
     pub fn bit(&self) -> bool {
         match *self {
-            INVR::INPUT_NOT_INVERTED_ => false,
-            INVR::INPUT_INVERTED_HIGH => true,
+            INVR::NOT_INVERTED => false,
+            INVR::INVERTED => true,
         }
     }
     #[allow(missing_docs)]
@@ -236,28 +236,28 @@ impl INVR {
     #[inline]
     pub fn _from(value: bool) -> INVR {
         match value {
-            false => INVR::INPUT_NOT_INVERTED_,
-            true => INVR::INPUT_INVERTED_HIGH,
+            false => INVR::NOT_INVERTED,
+            true => INVR::INVERTED,
         }
     }
-    #[doc = "Checks if the value of the field is `INPUT_NOT_INVERTED_`"]
+    #[doc = "Checks if the value of the field is `NOT_INVERTED`"]
     #[inline]
-    pub fn is_input_not_inverted_(&self) -> bool {
-        *self == INVR::INPUT_NOT_INVERTED_
+    pub fn is_not_inverted(&self) -> bool {
+        *self == INVR::NOT_INVERTED
     }
-    #[doc = "Checks if the value of the field is `INPUT_INVERTED_HIGH`"]
+    #[doc = "Checks if the value of the field is `INVERTED`"]
     #[inline]
-    pub fn is_input_inverted_high(&self) -> bool {
-        *self == INVR::INPUT_INVERTED_HIGH
+    pub fn is_inverted(&self) -> bool {
+        *self == INVR::INVERTED
     }
 }
 #[doc = "Possible values of the field `ADMODE`"]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum ADMODER {
     #[doc = "Analog input mode."]
-    ANALOG_INPUT_MODE_,
+    ANALOG,
     #[doc = "Digital functional mode."]
-    DIGITAL_FUNCTIONAL_M,
+    DIGITAL,
 }
 impl ADMODER {
     #[doc = r" Returns `true` if the bit is clear (0)"]
@@ -274,8 +274,8 @@ impl ADMODER {
     #[inline]
     pub fn bit(&self) -> bool {
         match *self {
-            ADMODER::ANALOG_INPUT_MODE_ => false,
-            ADMODER::DIGITAL_FUNCTIONAL_M => true,
+            ADMODER::ANALOG => false,
+            ADMODER::DIGITAL => true,
         }
     }
     #[allow(missing_docs)]
@@ -283,28 +283,28 @@ impl ADMODER {
     #[inline]
     pub fn _from(value: bool) -> ADMODER {
         match value {
-            false => ADMODER::ANALOG_INPUT_MODE_,
-            true => ADMODER::DIGITAL_FUNCTIONAL_M,
+            false => ADMODER::ANALOG,
+            true => ADMODER::DIGITAL,
         }
     }
-    #[doc = "Checks if the value of the field is `ANALOG_INPUT_MODE_`"]
+    #[doc = "Checks if the value of the field is `ANALOG`"]
     #[inline]
-    pub fn is_analog_input_mode_(&self) -> bool {
-        *self == ADMODER::ANALOG_INPUT_MODE_
+    pub fn is_analog(&self) -> bool {
+        *self == ADMODER::ANALOG
     }
-    #[doc = "Checks if the value of the field is `DIGITAL_FUNCTIONAL_M`"]
+    #[doc = "Checks if the value of the field is `DIGITAL`"]
     #[inline]
-    pub fn is_digital_functional_m(&self) -> bool {
-        *self == ADMODER::DIGITAL_FUNCTIONAL_M
+    pub fn is_digital(&self) -> bool {
+        *self == ADMODER::DIGITAL
     }
 }
 #[doc = "Possible values of the field `FILTR`"]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum FILTRR {
     #[doc = "Filter enabled."]
-    FILTER_ENABLED_,
+    ENABLED,
     #[doc = "Filter disabled."]
-    FILTER_DISABLED_,
+    DISABLED,
 }
 impl FILTRR {
     #[doc = r" Returns `true` if the bit is clear (0)"]
@@ -321,8 +321,8 @@ impl FILTRR {
     #[inline]
     pub fn bit(&self) -> bool {
         match *self {
-            FILTRR::FILTER_ENABLED_ => false,
-            FILTRR::FILTER_DISABLED_ => true,
+            FILTRR::ENABLED => false,
+            FILTRR::DISABLED => true,
         }
     }
     #[allow(missing_docs)]
@@ -330,28 +330,28 @@ impl FILTRR {
     #[inline]
     pub fn _from(value: bool) -> FILTRR {
         match value {
-            false => FILTRR::FILTER_ENABLED_,
-            true => FILTRR::FILTER_DISABLED_,
+            false => FILTRR::ENABLED,
+            true => FILTRR::DISABLED,
         }
     }
-    #[doc = "Checks if the value of the field is `FILTER_ENABLED_`"]
+    #[doc = "Checks if the value of the field is `ENABLED`"]
     #[inline]
-    pub fn is_filter_enabled_(&self) -> bool {
-        *self == FILTRR::FILTER_ENABLED_
+    pub fn is_enabled(&self) -> bool {
+        *self == FILTRR::ENABLED
     }
-    #[doc = "Checks if the value of the field is `FILTER_DISABLED_`"]
+    #[doc = "Checks if the value of the field is `DISABLED`"]
     #[inline]
-    pub fn is_filter_disabled_(&self) -> bool {
-        *self == FILTRR::FILTER_DISABLED_
+    pub fn is_disabled(&self) -> bool {
+        *self == FILTRR::DISABLED
     }
 }
 #[doc = "Possible values of the field `OD`"]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum ODR {
     #[doc = "Disable."]
-    DISABLE_,
+    DISABLED,
     #[doc = "Open-drain mode enabled.  This is not a true open-drain mode."]
-    OPEN_DRAIN_MODE_ENAB,
+    OPEN_DRAIN,
 }
 impl ODR {
     #[doc = r" Returns `true` if the bit is clear (0)"]
@@ -368,8 +368,8 @@ impl ODR {
     #[inline]
     pub fn bit(&self) -> bool {
         match *self {
-            ODR::DISABLE_ => false,
-            ODR::OPEN_DRAIN_MODE_ENAB => true,
+            ODR::DISABLED => false,
+            ODR::OPEN_DRAIN => true,
         }
     }
     #[allow(missing_docs)]
@@ -377,31 +377,31 @@ impl ODR {
     #[inline]
     pub fn _from(value: bool) -> ODR {
         match value {
-            false => ODR::DISABLE_,
-            true => ODR::OPEN_DRAIN_MODE_ENAB,
+            false => ODR::DISABLED,
+            true => ODR::OPEN_DRAIN,
         }
     }
-    #[doc = "Checks if the value of the field is `DISABLE_`"]
+    #[doc = "Checks if the value of the field is `DISABLED`"]
     #[inline]
-    pub fn is_disable_(&self) -> bool {
-        *self == ODR::DISABLE_
+    pub fn is_disabled(&self) -> bool {
+        *self == ODR::DISABLED
     }
-    #[doc = "Checks if the value of the field is `OPEN_DRAIN_MODE_ENAB`"]
+    #[doc = "Checks if the value of the field is `OPEN_DRAIN`"]
     #[inline]
-    pub fn is_open_drain_mode_enab(&self) -> bool {
-        *self == ODR::OPEN_DRAIN_MODE_ENAB
+    pub fn is_open_drain(&self) -> bool {
+        *self == ODR::OPEN_DRAIN
     }
 }
 #[doc = "Values that can be written to the field `FUNC`"]
 pub enum FUNCW {
     #[doc = "SWDIO."]
-    SWDIO_,
+    SWDIO,
     #[doc = "PIO0_15."]
-    PIO0_15_,
+    PIO0_15,
     #[doc = "AD4."]
-    AD4_,
+    AD4,
     #[doc = "CT32B1_MAT2."]
-    CT32B1_MAT2_,
+    CT32B1_MAT2,
 }
 impl FUNCW {
     #[allow(missing_docs)]
@@ -409,10 +409,10 @@ impl FUNCW {
     #[inline]
     pub fn _bits(&self) -> u8 {
         match *self {
-            FUNCW::SWDIO_ => 0,
-            FUNCW::PIO0_15_ => 1,
-            FUNCW::AD4_ => 2,
-            FUNCW::CT32B1_MAT2_ => 3,
+            FUNCW::SWDIO => 0,
+            FUNCW::PIO0_15 => 1,
+            FUNCW::AD4 => 2,
+            FUNCW::CT32B1_MAT2 => 3,
         }
     }
 }
@@ -428,23 +428,23 @@ impl<'a> _FUNCW<'a> {
     }
     #[doc = "SWDIO."]
     #[inline]
-    pub fn swdio_(self) -> &'a mut W {
-        self.variant(FUNCW::SWDIO_)
+    pub fn swdio(self) -> &'a mut W {
+        self.variant(FUNCW::SWDIO)
     }
     #[doc = "PIO0_15."]
     #[inline]
-    pub fn pio0_15_(self) -> &'a mut W {
-        self.variant(FUNCW::PIO0_15_)
+    pub fn pio0_15(self) -> &'a mut W {
+        self.variant(FUNCW::PIO0_15)
     }
     #[doc = "AD4."]
     #[inline]
-    pub fn ad4_(self) -> &'a mut W {
-        self.variant(FUNCW::AD4_)
+    pub fn ad4(self) -> &'a mut W {
+        self.variant(FUNCW::AD4)
     }
     #[doc = "CT32B1_MAT2."]
     #[inline]
-    pub fn ct32b1_mat2_(self) -> &'a mut W {
-        self.variant(FUNCW::CT32B1_MAT2_)
+    pub fn ct32b1_mat2(self) -> &'a mut W {
+        self.variant(FUNCW::CT32B1_MAT2)
     }
     #[doc = r" Writes raw bits to the field"]
     #[inline]
@@ -459,13 +459,13 @@ impl<'a> _FUNCW<'a> {
 #[doc = "Values that can be written to the field `MODE`"]
 pub enum MODEW {
     #[doc = "Inactive (no pull-down/pull-up resistor enabled)."]
-    INACTIVE_NO_PULL_DO,
+    INACTIVE,
     #[doc = "Pull-down resistor enabled."]
-    PULL_DOWN_RESISTOR_E,
+    PULL_DOWN,
     #[doc = "Pull-up resistor enabled."]
-    PULL_UP_RESISTOR_ENA,
+    PULL_UP,
     #[doc = "Repeater mode."]
-    REPEATER_MODE_,
+    REPEATER,
 }
 impl MODEW {
     #[allow(missing_docs)]
@@ -473,10 +473,10 @@ impl MODEW {
     #[inline]
     pub fn _bits(&self) -> u8 {
         match *self {
-            MODEW::INACTIVE_NO_PULL_DO => 0,
-            MODEW::PULL_DOWN_RESISTOR_E => 1,
-            MODEW::PULL_UP_RESISTOR_ENA => 2,
-            MODEW::REPEATER_MODE_ => 3,
+            MODEW::INACTIVE => 0,
+            MODEW::PULL_DOWN => 1,
+            MODEW::PULL_UP => 2,
+            MODEW::REPEATER => 3,
         }
     }
 }
@@ -494,23 +494,23 @@ impl<'a> _MODEW<'a> {
     }
     #[doc = "Inactive (no pull-down/pull-up resistor enabled)."]
     #[inline]
-    pub fn inactive_no_pull_do(self) -> &'a mut W {
-        self.variant(MODEW::INACTIVE_NO_PULL_DO)
+    pub fn inactive(self) -> &'a mut W {
+        self.variant(MODEW::INACTIVE)
     }
     #[doc = "Pull-down resistor enabled."]
     #[inline]
-    pub fn pull_down_resistor_e(self) -> &'a mut W {
-        self.variant(MODEW::PULL_DOWN_RESISTOR_E)
+    pub fn pull_down(self) -> &'a mut W {
+        self.variant(MODEW::PULL_DOWN)
     }
     #[doc = "Pull-up resistor enabled."]
     #[inline]
-    pub fn pull_up_resistor_ena(self) -> &'a mut W {
-        self.variant(MODEW::PULL_UP_RESISTOR_ENA)
+    pub fn pull_up(self) -> &'a mut W {
+        self.variant(MODEW::PULL_UP)
     }
     #[doc = "Repeater mode."]
     #[inline]
-    pub fn repeater_mode_(self) -> &'a mut W {
-        self.variant(MODEW::REPEATER_MODE_)
+    pub fn repeater(self) -> &'a mut W {
+        self.variant(MODEW::REPEATER)
     }
     #[doc = r" Writes raw bits to the field"]
     #[inline]
@@ -525,9 +525,9 @@ impl<'a> _MODEW<'a> {
 #[doc = "Values that can be written to the field `HYS`"]
 pub enum HYSW {
     #[doc = "Disable."]
-    DISABLE_,
+    DISABLED,
     #[doc = "Enable."]
-    ENABLE_,
+    ENABLED,
 }
 impl HYSW {
     #[allow(missing_docs)]
@@ -535,8 +535,8 @@ impl HYSW {
     #[inline]
     pub fn _bits(&self) -> bool {
         match *self {
-            HYSW::DISABLE_ => false,
-            HYSW::ENABLE_ => true,
+            HYSW::DISABLED => false,
+            HYSW::ENABLED => true,
         }
     }
 }
@@ -554,13 +554,13 @@ impl<'a> _HYSW<'a> {
     }
     #[doc = "Disable."]
     #[inline]
-    pub fn disable_(self) -> &'a mut W {
-        self.variant(HYSW::DISABLE_)
+    pub fn disabled(self) -> &'a mut W {
+        self.variant(HYSW::DISABLED)
     }
     #[doc = "Enable."]
     #[inline]
-    pub fn enable_(self) -> &'a mut W {
-        self.variant(HYSW::ENABLE_)
+    pub fn enabled(self) -> &'a mut W {
+        self.variant(HYSW::ENABLED)
     }
     #[doc = r" Sets the field bit"]
     pub fn set_bit(self) -> &'a mut W {
@@ -583,9 +583,9 @@ impl<'a> _HYSW<'a> {
 #[doc = "Values that can be written to the field `INV`"]
 pub enum INVW {
     #[doc = "Input not inverted (HIGH on pin reads as 1, LOW on pin reads as 0)."]
-    INPUT_NOT_INVERTED_,
+    NOT_INVERTED,
     #[doc = "Input inverted (HIGH on pin reads as 0, LOW on pin reads as 1)."]
-    INPUT_INVERTED_HIGH,
+    INVERTED,
 }
 impl INVW {
     #[allow(missing_docs)]
@@ -593,8 +593,8 @@ impl INVW {
     #[inline]
     pub fn _bits(&self) -> bool {
         match *self {
-            INVW::INPUT_NOT_INVERTED_ => false,
-            INVW::INPUT_INVERTED_HIGH => true,
+            INVW::NOT_INVERTED => false,
+            INVW::INVERTED => true,
         }
     }
 }
@@ -612,13 +612,13 @@ impl<'a> _INVW<'a> {
     }
     #[doc = "Input not inverted (HIGH on pin reads as 1, LOW on pin reads as 0)."]
     #[inline]
-    pub fn input_not_inverted_(self) -> &'a mut W {
-        self.variant(INVW::INPUT_NOT_INVERTED_)
+    pub fn not_inverted(self) -> &'a mut W {
+        self.variant(INVW::NOT_INVERTED)
     }
     #[doc = "Input inverted (HIGH on pin reads as 0, LOW on pin reads as 1)."]
     #[inline]
-    pub fn input_inverted_high(self) -> &'a mut W {
-        self.variant(INVW::INPUT_INVERTED_HIGH)
+    pub fn inverted(self) -> &'a mut W {
+        self.variant(INVW::INVERTED)
     }
     #[doc = r" Sets the field bit"]
     pub fn set_bit(self) -> &'a mut W {
@@ -641,9 +641,9 @@ impl<'a> _INVW<'a> {
 #[doc = "Values that can be written to the field `ADMODE`"]
 pub enum ADMODEW {
     #[doc = "Analog input mode."]
-    ANALOG_INPUT_MODE_,
+    ANALOG,
     #[doc = "Digital functional mode."]
-    DIGITAL_FUNCTIONAL_M,
+    DIGITAL,
 }
 impl ADMODEW {
     #[allow(missing_docs)]
@@ -651,8 +651,8 @@ impl ADMODEW {
     #[inline]
     pub fn _bits(&self) -> bool {
         match *self {
-            ADMODEW::ANALOG_INPUT_MODE_ => false,
-            ADMODEW::DIGITAL_FUNCTIONAL_M => true,
+            ADMODEW::ANALOG => false,
+            ADMODEW::DIGITAL => true,
         }
     }
 }
@@ -670,13 +670,13 @@ impl<'a> _ADMODEW<'a> {
     }
     #[doc = "Analog input mode."]
     #[inline]
-    pub fn analog_input_mode_(self) -> &'a mut W {
-        self.variant(ADMODEW::ANALOG_INPUT_MODE_)
+    pub fn analog(self) -> &'a mut W {
+        self.variant(ADMODEW::ANALOG)
     }
     #[doc = "Digital functional mode."]
     #[inline]
-    pub fn digital_functional_m(self) -> &'a mut W {
-        self.variant(ADMODEW::DIGITAL_FUNCTIONAL_M)
+    pub fn digital(self) -> &'a mut W {
+        self.variant(ADMODEW::DIGITAL)
     }
     #[doc = r" Sets the field bit"]
     pub fn set_bit(self) -> &'a mut W {
@@ -699,9 +699,9 @@ impl<'a> _ADMODEW<'a> {
 #[doc = "Values that can be written to the field `FILTR`"]
 pub enum FILTRW {
     #[doc = "Filter enabled."]
-    FILTER_ENABLED_,
+    ENABLED,
     #[doc = "Filter disabled."]
-    FILTER_DISABLED_,
+    DISABLED,
 }
 impl FILTRW {
     #[allow(missing_docs)]
@@ -709,8 +709,8 @@ impl FILTRW {
     #[inline]
     pub fn _bits(&self) -> bool {
         match *self {
-            FILTRW::FILTER_ENABLED_ => false,
-            FILTRW::FILTER_DISABLED_ => true,
+            FILTRW::ENABLED => false,
+            FILTRW::DISABLED => true,
         }
     }
 }
@@ -728,13 +728,13 @@ impl<'a> _FILTRW<'a> {
     }
     #[doc = "Filter enabled."]
     #[inline]
-    pub fn filter_enabled_(self) -> &'a mut W {
-        self.variant(FILTRW::FILTER_ENABLED_)
+    pub fn enabled(self) -> &'a mut W {
+        self.variant(FILTRW::ENABLED)
     }
     #[doc = "Filter disabled."]
     #[inline]
-    pub fn filter_disabled_(self) -> &'a mut W {
-        self.variant(FILTRW::FILTER_DISABLED_)
+    pub fn disabled(self) -> &'a mut W {
+        self.variant(FILTRW::DISABLED)
     }
     #[doc = r" Sets the field bit"]
     pub fn set_bit(self) -> &'a mut W {
@@ -757,9 +757,9 @@ impl<'a> _FILTRW<'a> {
 #[doc = "Values that can be written to the field `OD`"]
 pub enum ODW {
     #[doc = "Disable."]
-    DISABLE_,
+    DISABLED,
     #[doc = "Open-drain mode enabled.  This is not a true open-drain mode."]
-    OPEN_DRAIN_MODE_ENAB,
+    OPEN_DRAIN,
 }
 impl ODW {
     #[allow(missing_docs)]
@@ -767,8 +767,8 @@ impl ODW {
     #[inline]
     pub fn _bits(&self) -> bool {
         match *self {
-            ODW::DISABLE_ => false,
-            ODW::OPEN_DRAIN_MODE_ENAB => true,
+            ODW::DISABLED => false,
+            ODW::OPEN_DRAIN => true,
         }
     }
 }
@@ -786,13 +786,13 @@ impl<'a> _ODW<'a> {
     }
     #[doc = "Disable."]
     #[inline]
-    pub fn disable_(self) -> &'a mut W {
-        self.variant(ODW::DISABLE_)
+    pub fn disabled(self) -> &'a mut W {
+        self.variant(ODW::DISABLED)
     }
     #[doc = "Open-drain mode enabled. This is not a true open-drain mode."]
     #[inline]
-    pub fn open_drain_mode_enab(self) -> &'a mut W {
-        self.variant(ODW::OPEN_DRAIN_MODE_ENAB)
+    pub fn open_drain(self) -> &'a mut W {
+        self.variant(ODW::OPEN_DRAIN)
     }
     #[doc = r" Sets the field bit"]
     pub fn set_bit(self) -> &'a mut W {

--- a/lpc11uxx/src/iocon/tdi_pio0_11.rs
+++ b/lpc11uxx/src/iocon/tdi_pio0_11.rs
@@ -46,13 +46,13 @@ impl super::TDI_PIO0_11 {
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum FUNCR {
     #[doc = "TDI."]
-    TDI_,
+    TDI,
     #[doc = "PIO0_11."]
-    PIO0_11_,
+    PIO0_11,
     #[doc = "AD0."]
-    AD0_,
+    AD0,
     #[doc = "CT32B0_MAT3."]
-    CT32B0_MAT3_,
+    CT32B0_MAT3,
     #[doc = r" Reserved"]
     _Reserved(u8),
 }
@@ -61,10 +61,10 @@ impl FUNCR {
     #[inline]
     pub fn bits(&self) -> u8 {
         match *self {
-            FUNCR::TDI_ => 0,
-            FUNCR::PIO0_11_ => 1,
-            FUNCR::AD0_ => 2,
-            FUNCR::CT32B0_MAT3_ => 3,
+            FUNCR::TDI => 0,
+            FUNCR::PIO0_11 => 1,
+            FUNCR::AD0 => 2,
+            FUNCR::CT32B0_MAT3 => 3,
             FUNCR::_Reserved(bits) => bits,
         }
     }
@@ -73,55 +73,55 @@ impl FUNCR {
     #[inline]
     pub fn _from(value: u8) -> FUNCR {
         match value {
-            0 => FUNCR::TDI_,
-            1 => FUNCR::PIO0_11_,
-            2 => FUNCR::AD0_,
-            3 => FUNCR::CT32B0_MAT3_,
+            0 => FUNCR::TDI,
+            1 => FUNCR::PIO0_11,
+            2 => FUNCR::AD0,
+            3 => FUNCR::CT32B0_MAT3,
             i => FUNCR::_Reserved(i),
         }
     }
-    #[doc = "Checks if the value of the field is `TDI_`"]
+    #[doc = "Checks if the value of the field is `TDI`"]
     #[inline]
-    pub fn is_tdi_(&self) -> bool {
-        *self == FUNCR::TDI_
+    pub fn is_tdi(&self) -> bool {
+        *self == FUNCR::TDI
     }
-    #[doc = "Checks if the value of the field is `PIO0_11_`"]
+    #[doc = "Checks if the value of the field is `PIO0_11`"]
     #[inline]
-    pub fn is_pio0_11_(&self) -> bool {
-        *self == FUNCR::PIO0_11_
+    pub fn is_pio0_11(&self) -> bool {
+        *self == FUNCR::PIO0_11
     }
-    #[doc = "Checks if the value of the field is `AD0_`"]
+    #[doc = "Checks if the value of the field is `AD0`"]
     #[inline]
-    pub fn is_ad0_(&self) -> bool {
-        *self == FUNCR::AD0_
+    pub fn is_ad0(&self) -> bool {
+        *self == FUNCR::AD0
     }
-    #[doc = "Checks if the value of the field is `CT32B0_MAT3_`"]
+    #[doc = "Checks if the value of the field is `CT32B0_MAT3`"]
     #[inline]
-    pub fn is_ct32b0_mat3_(&self) -> bool {
-        *self == FUNCR::CT32B0_MAT3_
+    pub fn is_ct32b0_mat3(&self) -> bool {
+        *self == FUNCR::CT32B0_MAT3
     }
 }
 #[doc = "Possible values of the field `MODE`"]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum MODER {
     #[doc = "Inactive (no pull-down/pull-up resistor enabled)."]
-    INACTIVE_NO_PULL_DO,
+    INACTIVE,
     #[doc = "Pull-down resistor enabled."]
-    PULL_DOWN_RESISTOR_E,
+    PULL_DOWN,
     #[doc = "Pull-up resistor enabled."]
-    PULL_UP_RESISTOR_ENA,
+    PULL_UP,
     #[doc = "Repeater mode."]
-    REPEATER_MODE_,
+    REPEATER,
 }
 impl MODER {
     #[doc = r" Value of the field as raw bits"]
     #[inline]
     pub fn bits(&self) -> u8 {
         match *self {
-            MODER::INACTIVE_NO_PULL_DO => 0,
-            MODER::PULL_DOWN_RESISTOR_E => 1,
-            MODER::PULL_UP_RESISTOR_ENA => 2,
-            MODER::REPEATER_MODE_ => 3,
+            MODER::INACTIVE => 0,
+            MODER::PULL_DOWN => 1,
+            MODER::PULL_UP => 2,
+            MODER::REPEATER => 3,
         }
     }
     #[allow(missing_docs)]
@@ -129,41 +129,41 @@ impl MODER {
     #[inline]
     pub fn _from(value: u8) -> MODER {
         match value {
-            0 => MODER::INACTIVE_NO_PULL_DO,
-            1 => MODER::PULL_DOWN_RESISTOR_E,
-            2 => MODER::PULL_UP_RESISTOR_ENA,
-            3 => MODER::REPEATER_MODE_,
+            0 => MODER::INACTIVE,
+            1 => MODER::PULL_DOWN,
+            2 => MODER::PULL_UP,
+            3 => MODER::REPEATER,
             _ => unreachable!(),
         }
     }
-    #[doc = "Checks if the value of the field is `INACTIVE_NO_PULL_DO`"]
+    #[doc = "Checks if the value of the field is `INACTIVE`"]
     #[inline]
-    pub fn is_inactive_no_pull_do(&self) -> bool {
-        *self == MODER::INACTIVE_NO_PULL_DO
+    pub fn is_inactive(&self) -> bool {
+        *self == MODER::INACTIVE
     }
-    #[doc = "Checks if the value of the field is `PULL_DOWN_RESISTOR_E`"]
+    #[doc = "Checks if the value of the field is `PULL_DOWN`"]
     #[inline]
-    pub fn is_pull_down_resistor_e(&self) -> bool {
-        *self == MODER::PULL_DOWN_RESISTOR_E
+    pub fn is_pull_down(&self) -> bool {
+        *self == MODER::PULL_DOWN
     }
-    #[doc = "Checks if the value of the field is `PULL_UP_RESISTOR_ENA`"]
+    #[doc = "Checks if the value of the field is `PULL_UP`"]
     #[inline]
-    pub fn is_pull_up_resistor_ena(&self) -> bool {
-        *self == MODER::PULL_UP_RESISTOR_ENA
+    pub fn is_pull_up(&self) -> bool {
+        *self == MODER::PULL_UP
     }
-    #[doc = "Checks if the value of the field is `REPEATER_MODE_`"]
+    #[doc = "Checks if the value of the field is `REPEATER`"]
     #[inline]
-    pub fn is_repeater_mode_(&self) -> bool {
-        *self == MODER::REPEATER_MODE_
+    pub fn is_repeater(&self) -> bool {
+        *self == MODER::REPEATER
     }
 }
 #[doc = "Possible values of the field `HYS`"]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum HYSR {
     #[doc = "Disable."]
-    DISABLE_,
+    DISABLED,
     #[doc = "Enable."]
-    ENABLE_,
+    ENABLED,
 }
 impl HYSR {
     #[doc = r" Returns `true` if the bit is clear (0)"]
@@ -180,8 +180,8 @@ impl HYSR {
     #[inline]
     pub fn bit(&self) -> bool {
         match *self {
-            HYSR::DISABLE_ => false,
-            HYSR::ENABLE_ => true,
+            HYSR::DISABLED => false,
+            HYSR::ENABLED => true,
         }
     }
     #[allow(missing_docs)]
@@ -189,28 +189,28 @@ impl HYSR {
     #[inline]
     pub fn _from(value: bool) -> HYSR {
         match value {
-            false => HYSR::DISABLE_,
-            true => HYSR::ENABLE_,
+            false => HYSR::DISABLED,
+            true => HYSR::ENABLED,
         }
     }
-    #[doc = "Checks if the value of the field is `DISABLE_`"]
+    #[doc = "Checks if the value of the field is `DISABLED`"]
     #[inline]
-    pub fn is_disable_(&self) -> bool {
-        *self == HYSR::DISABLE_
+    pub fn is_disabled(&self) -> bool {
+        *self == HYSR::DISABLED
     }
-    #[doc = "Checks if the value of the field is `ENABLE_`"]
+    #[doc = "Checks if the value of the field is `ENABLED`"]
     #[inline]
-    pub fn is_enable_(&self) -> bool {
-        *self == HYSR::ENABLE_
+    pub fn is_enabled(&self) -> bool {
+        *self == HYSR::ENABLED
     }
 }
 #[doc = "Possible values of the field `INV`"]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum INVR {
     #[doc = "Input not inverted (HIGH on pin reads as 1, LOW on pin reads as 0)."]
-    INPUT_NOT_INVERTED_,
+    NOT_INVERTED,
     #[doc = "Input inverted (HIGH on pin reads as 0, LOW on pin reads as 1)."]
-    INPUT_INVERTED_HIGH,
+    INVERTED,
 }
 impl INVR {
     #[doc = r" Returns `true` if the bit is clear (0)"]
@@ -227,8 +227,8 @@ impl INVR {
     #[inline]
     pub fn bit(&self) -> bool {
         match *self {
-            INVR::INPUT_NOT_INVERTED_ => false,
-            INVR::INPUT_INVERTED_HIGH => true,
+            INVR::NOT_INVERTED => false,
+            INVR::INVERTED => true,
         }
     }
     #[allow(missing_docs)]
@@ -236,28 +236,28 @@ impl INVR {
     #[inline]
     pub fn _from(value: bool) -> INVR {
         match value {
-            false => INVR::INPUT_NOT_INVERTED_,
-            true => INVR::INPUT_INVERTED_HIGH,
+            false => INVR::NOT_INVERTED,
+            true => INVR::INVERTED,
         }
     }
-    #[doc = "Checks if the value of the field is `INPUT_NOT_INVERTED_`"]
+    #[doc = "Checks if the value of the field is `NOT_INVERTED`"]
     #[inline]
-    pub fn is_input_not_inverted_(&self) -> bool {
-        *self == INVR::INPUT_NOT_INVERTED_
+    pub fn is_not_inverted(&self) -> bool {
+        *self == INVR::NOT_INVERTED
     }
-    #[doc = "Checks if the value of the field is `INPUT_INVERTED_HIGH`"]
+    #[doc = "Checks if the value of the field is `INVERTED`"]
     #[inline]
-    pub fn is_input_inverted_high(&self) -> bool {
-        *self == INVR::INPUT_INVERTED_HIGH
+    pub fn is_inverted(&self) -> bool {
+        *self == INVR::INVERTED
     }
 }
 #[doc = "Possible values of the field `ADMODE`"]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum ADMODER {
     #[doc = "Analog input mode."]
-    ANALOG_INPUT_MODE_,
+    ANALOG,
     #[doc = "Digital functional mode."]
-    DIGITAL_FUNCTIONAL_M,
+    DIGITAL,
 }
 impl ADMODER {
     #[doc = r" Returns `true` if the bit is clear (0)"]
@@ -274,8 +274,8 @@ impl ADMODER {
     #[inline]
     pub fn bit(&self) -> bool {
         match *self {
-            ADMODER::ANALOG_INPUT_MODE_ => false,
-            ADMODER::DIGITAL_FUNCTIONAL_M => true,
+            ADMODER::ANALOG => false,
+            ADMODER::DIGITAL => true,
         }
     }
     #[allow(missing_docs)]
@@ -283,28 +283,28 @@ impl ADMODER {
     #[inline]
     pub fn _from(value: bool) -> ADMODER {
         match value {
-            false => ADMODER::ANALOG_INPUT_MODE_,
-            true => ADMODER::DIGITAL_FUNCTIONAL_M,
+            false => ADMODER::ANALOG,
+            true => ADMODER::DIGITAL,
         }
     }
-    #[doc = "Checks if the value of the field is `ANALOG_INPUT_MODE_`"]
+    #[doc = "Checks if the value of the field is `ANALOG`"]
     #[inline]
-    pub fn is_analog_input_mode_(&self) -> bool {
-        *self == ADMODER::ANALOG_INPUT_MODE_
+    pub fn is_analog(&self) -> bool {
+        *self == ADMODER::ANALOG
     }
-    #[doc = "Checks if the value of the field is `DIGITAL_FUNCTIONAL_M`"]
+    #[doc = "Checks if the value of the field is `DIGITAL`"]
     #[inline]
-    pub fn is_digital_functional_m(&self) -> bool {
-        *self == ADMODER::DIGITAL_FUNCTIONAL_M
+    pub fn is_digital(&self) -> bool {
+        *self == ADMODER::DIGITAL
     }
 }
 #[doc = "Possible values of the field `FILTR`"]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum FILTRR {
     #[doc = "Filter enabled."]
-    FILTER_ENABLED_,
+    ENABLED,
     #[doc = "Filter disabled."]
-    FILTER_DISABLED_,
+    DISABLED,
 }
 impl FILTRR {
     #[doc = r" Returns `true` if the bit is clear (0)"]
@@ -321,8 +321,8 @@ impl FILTRR {
     #[inline]
     pub fn bit(&self) -> bool {
         match *self {
-            FILTRR::FILTER_ENABLED_ => false,
-            FILTRR::FILTER_DISABLED_ => true,
+            FILTRR::ENABLED => false,
+            FILTRR::DISABLED => true,
         }
     }
     #[allow(missing_docs)]
@@ -330,28 +330,28 @@ impl FILTRR {
     #[inline]
     pub fn _from(value: bool) -> FILTRR {
         match value {
-            false => FILTRR::FILTER_ENABLED_,
-            true => FILTRR::FILTER_DISABLED_,
+            false => FILTRR::ENABLED,
+            true => FILTRR::DISABLED,
         }
     }
-    #[doc = "Checks if the value of the field is `FILTER_ENABLED_`"]
+    #[doc = "Checks if the value of the field is `ENABLED`"]
     #[inline]
-    pub fn is_filter_enabled_(&self) -> bool {
-        *self == FILTRR::FILTER_ENABLED_
+    pub fn is_enabled(&self) -> bool {
+        *self == FILTRR::ENABLED
     }
-    #[doc = "Checks if the value of the field is `FILTER_DISABLED_`"]
+    #[doc = "Checks if the value of the field is `DISABLED`"]
     #[inline]
-    pub fn is_filter_disabled_(&self) -> bool {
-        *self == FILTRR::FILTER_DISABLED_
+    pub fn is_disabled(&self) -> bool {
+        *self == FILTRR::DISABLED
     }
 }
 #[doc = "Possible values of the field `OD`"]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum ODR {
     #[doc = "Disable."]
-    DISABLE_,
+    DISABLED,
     #[doc = "Open-drain mode enabled.  This is not a true open-drain mode."]
-    OPEN_DRAIN_MODE_ENAB,
+    OPEN_DRAIN,
 }
 impl ODR {
     #[doc = r" Returns `true` if the bit is clear (0)"]
@@ -368,8 +368,8 @@ impl ODR {
     #[inline]
     pub fn bit(&self) -> bool {
         match *self {
-            ODR::DISABLE_ => false,
-            ODR::OPEN_DRAIN_MODE_ENAB => true,
+            ODR::DISABLED => false,
+            ODR::OPEN_DRAIN => true,
         }
     }
     #[allow(missing_docs)]
@@ -377,31 +377,31 @@ impl ODR {
     #[inline]
     pub fn _from(value: bool) -> ODR {
         match value {
-            false => ODR::DISABLE_,
-            true => ODR::OPEN_DRAIN_MODE_ENAB,
+            false => ODR::DISABLED,
+            true => ODR::OPEN_DRAIN,
         }
     }
-    #[doc = "Checks if the value of the field is `DISABLE_`"]
+    #[doc = "Checks if the value of the field is `DISABLED`"]
     #[inline]
-    pub fn is_disable_(&self) -> bool {
-        *self == ODR::DISABLE_
+    pub fn is_disabled(&self) -> bool {
+        *self == ODR::DISABLED
     }
-    #[doc = "Checks if the value of the field is `OPEN_DRAIN_MODE_ENAB`"]
+    #[doc = "Checks if the value of the field is `OPEN_DRAIN`"]
     #[inline]
-    pub fn is_open_drain_mode_enab(&self) -> bool {
-        *self == ODR::OPEN_DRAIN_MODE_ENAB
+    pub fn is_open_drain(&self) -> bool {
+        *self == ODR::OPEN_DRAIN
     }
 }
 #[doc = "Values that can be written to the field `FUNC`"]
 pub enum FUNCW {
     #[doc = "TDI."]
-    TDI_,
+    TDI,
     #[doc = "PIO0_11."]
-    PIO0_11_,
+    PIO0_11,
     #[doc = "AD0."]
-    AD0_,
+    AD0,
     #[doc = "CT32B0_MAT3."]
-    CT32B0_MAT3_,
+    CT32B0_MAT3,
 }
 impl FUNCW {
     #[allow(missing_docs)]
@@ -409,10 +409,10 @@ impl FUNCW {
     #[inline]
     pub fn _bits(&self) -> u8 {
         match *self {
-            FUNCW::TDI_ => 0,
-            FUNCW::PIO0_11_ => 1,
-            FUNCW::AD0_ => 2,
-            FUNCW::CT32B0_MAT3_ => 3,
+            FUNCW::TDI => 0,
+            FUNCW::PIO0_11 => 1,
+            FUNCW::AD0 => 2,
+            FUNCW::CT32B0_MAT3 => 3,
         }
     }
 }
@@ -428,23 +428,23 @@ impl<'a> _FUNCW<'a> {
     }
     #[doc = "TDI."]
     #[inline]
-    pub fn tdi_(self) -> &'a mut W {
-        self.variant(FUNCW::TDI_)
+    pub fn tdi(self) -> &'a mut W {
+        self.variant(FUNCW::TDI)
     }
     #[doc = "PIO0_11."]
     #[inline]
-    pub fn pio0_11_(self) -> &'a mut W {
-        self.variant(FUNCW::PIO0_11_)
+    pub fn pio0_11(self) -> &'a mut W {
+        self.variant(FUNCW::PIO0_11)
     }
     #[doc = "AD0."]
     #[inline]
-    pub fn ad0_(self) -> &'a mut W {
-        self.variant(FUNCW::AD0_)
+    pub fn ad0(self) -> &'a mut W {
+        self.variant(FUNCW::AD0)
     }
     #[doc = "CT32B0_MAT3."]
     #[inline]
-    pub fn ct32b0_mat3_(self) -> &'a mut W {
-        self.variant(FUNCW::CT32B0_MAT3_)
+    pub fn ct32b0_mat3(self) -> &'a mut W {
+        self.variant(FUNCW::CT32B0_MAT3)
     }
     #[doc = r" Writes raw bits to the field"]
     #[inline]
@@ -459,13 +459,13 @@ impl<'a> _FUNCW<'a> {
 #[doc = "Values that can be written to the field `MODE`"]
 pub enum MODEW {
     #[doc = "Inactive (no pull-down/pull-up resistor enabled)."]
-    INACTIVE_NO_PULL_DO,
+    INACTIVE,
     #[doc = "Pull-down resistor enabled."]
-    PULL_DOWN_RESISTOR_E,
+    PULL_DOWN,
     #[doc = "Pull-up resistor enabled."]
-    PULL_UP_RESISTOR_ENA,
+    PULL_UP,
     #[doc = "Repeater mode."]
-    REPEATER_MODE_,
+    REPEATER,
 }
 impl MODEW {
     #[allow(missing_docs)]
@@ -473,10 +473,10 @@ impl MODEW {
     #[inline]
     pub fn _bits(&self) -> u8 {
         match *self {
-            MODEW::INACTIVE_NO_PULL_DO => 0,
-            MODEW::PULL_DOWN_RESISTOR_E => 1,
-            MODEW::PULL_UP_RESISTOR_ENA => 2,
-            MODEW::REPEATER_MODE_ => 3,
+            MODEW::INACTIVE => 0,
+            MODEW::PULL_DOWN => 1,
+            MODEW::PULL_UP => 2,
+            MODEW::REPEATER => 3,
         }
     }
 }
@@ -494,23 +494,23 @@ impl<'a> _MODEW<'a> {
     }
     #[doc = "Inactive (no pull-down/pull-up resistor enabled)."]
     #[inline]
-    pub fn inactive_no_pull_do(self) -> &'a mut W {
-        self.variant(MODEW::INACTIVE_NO_PULL_DO)
+    pub fn inactive(self) -> &'a mut W {
+        self.variant(MODEW::INACTIVE)
     }
     #[doc = "Pull-down resistor enabled."]
     #[inline]
-    pub fn pull_down_resistor_e(self) -> &'a mut W {
-        self.variant(MODEW::PULL_DOWN_RESISTOR_E)
+    pub fn pull_down(self) -> &'a mut W {
+        self.variant(MODEW::PULL_DOWN)
     }
     #[doc = "Pull-up resistor enabled."]
     #[inline]
-    pub fn pull_up_resistor_ena(self) -> &'a mut W {
-        self.variant(MODEW::PULL_UP_RESISTOR_ENA)
+    pub fn pull_up(self) -> &'a mut W {
+        self.variant(MODEW::PULL_UP)
     }
     #[doc = "Repeater mode."]
     #[inline]
-    pub fn repeater_mode_(self) -> &'a mut W {
-        self.variant(MODEW::REPEATER_MODE_)
+    pub fn repeater(self) -> &'a mut W {
+        self.variant(MODEW::REPEATER)
     }
     #[doc = r" Writes raw bits to the field"]
     #[inline]
@@ -525,9 +525,9 @@ impl<'a> _MODEW<'a> {
 #[doc = "Values that can be written to the field `HYS`"]
 pub enum HYSW {
     #[doc = "Disable."]
-    DISABLE_,
+    DISABLED,
     #[doc = "Enable."]
-    ENABLE_,
+    ENABLED,
 }
 impl HYSW {
     #[allow(missing_docs)]
@@ -535,8 +535,8 @@ impl HYSW {
     #[inline]
     pub fn _bits(&self) -> bool {
         match *self {
-            HYSW::DISABLE_ => false,
-            HYSW::ENABLE_ => true,
+            HYSW::DISABLED => false,
+            HYSW::ENABLED => true,
         }
     }
 }
@@ -554,13 +554,13 @@ impl<'a> _HYSW<'a> {
     }
     #[doc = "Disable."]
     #[inline]
-    pub fn disable_(self) -> &'a mut W {
-        self.variant(HYSW::DISABLE_)
+    pub fn disabled(self) -> &'a mut W {
+        self.variant(HYSW::DISABLED)
     }
     #[doc = "Enable."]
     #[inline]
-    pub fn enable_(self) -> &'a mut W {
-        self.variant(HYSW::ENABLE_)
+    pub fn enabled(self) -> &'a mut W {
+        self.variant(HYSW::ENABLED)
     }
     #[doc = r" Sets the field bit"]
     pub fn set_bit(self) -> &'a mut W {
@@ -583,9 +583,9 @@ impl<'a> _HYSW<'a> {
 #[doc = "Values that can be written to the field `INV`"]
 pub enum INVW {
     #[doc = "Input not inverted (HIGH on pin reads as 1, LOW on pin reads as 0)."]
-    INPUT_NOT_INVERTED_,
+    NOT_INVERTED,
     #[doc = "Input inverted (HIGH on pin reads as 0, LOW on pin reads as 1)."]
-    INPUT_INVERTED_HIGH,
+    INVERTED,
 }
 impl INVW {
     #[allow(missing_docs)]
@@ -593,8 +593,8 @@ impl INVW {
     #[inline]
     pub fn _bits(&self) -> bool {
         match *self {
-            INVW::INPUT_NOT_INVERTED_ => false,
-            INVW::INPUT_INVERTED_HIGH => true,
+            INVW::NOT_INVERTED => false,
+            INVW::INVERTED => true,
         }
     }
 }
@@ -612,13 +612,13 @@ impl<'a> _INVW<'a> {
     }
     #[doc = "Input not inverted (HIGH on pin reads as 1, LOW on pin reads as 0)."]
     #[inline]
-    pub fn input_not_inverted_(self) -> &'a mut W {
-        self.variant(INVW::INPUT_NOT_INVERTED_)
+    pub fn not_inverted(self) -> &'a mut W {
+        self.variant(INVW::NOT_INVERTED)
     }
     #[doc = "Input inverted (HIGH on pin reads as 0, LOW on pin reads as 1)."]
     #[inline]
-    pub fn input_inverted_high(self) -> &'a mut W {
-        self.variant(INVW::INPUT_INVERTED_HIGH)
+    pub fn inverted(self) -> &'a mut W {
+        self.variant(INVW::INVERTED)
     }
     #[doc = r" Sets the field bit"]
     pub fn set_bit(self) -> &'a mut W {
@@ -641,9 +641,9 @@ impl<'a> _INVW<'a> {
 #[doc = "Values that can be written to the field `ADMODE`"]
 pub enum ADMODEW {
     #[doc = "Analog input mode."]
-    ANALOG_INPUT_MODE_,
+    ANALOG,
     #[doc = "Digital functional mode."]
-    DIGITAL_FUNCTIONAL_M,
+    DIGITAL,
 }
 impl ADMODEW {
     #[allow(missing_docs)]
@@ -651,8 +651,8 @@ impl ADMODEW {
     #[inline]
     pub fn _bits(&self) -> bool {
         match *self {
-            ADMODEW::ANALOG_INPUT_MODE_ => false,
-            ADMODEW::DIGITAL_FUNCTIONAL_M => true,
+            ADMODEW::ANALOG => false,
+            ADMODEW::DIGITAL => true,
         }
     }
 }
@@ -670,13 +670,13 @@ impl<'a> _ADMODEW<'a> {
     }
     #[doc = "Analog input mode."]
     #[inline]
-    pub fn analog_input_mode_(self) -> &'a mut W {
-        self.variant(ADMODEW::ANALOG_INPUT_MODE_)
+    pub fn analog(self) -> &'a mut W {
+        self.variant(ADMODEW::ANALOG)
     }
     #[doc = "Digital functional mode."]
     #[inline]
-    pub fn digital_functional_m(self) -> &'a mut W {
-        self.variant(ADMODEW::DIGITAL_FUNCTIONAL_M)
+    pub fn digital(self) -> &'a mut W {
+        self.variant(ADMODEW::DIGITAL)
     }
     #[doc = r" Sets the field bit"]
     pub fn set_bit(self) -> &'a mut W {
@@ -699,9 +699,9 @@ impl<'a> _ADMODEW<'a> {
 #[doc = "Values that can be written to the field `FILTR`"]
 pub enum FILTRW {
     #[doc = "Filter enabled."]
-    FILTER_ENABLED_,
+    ENABLED,
     #[doc = "Filter disabled."]
-    FILTER_DISABLED_,
+    DISABLED,
 }
 impl FILTRW {
     #[allow(missing_docs)]
@@ -709,8 +709,8 @@ impl FILTRW {
     #[inline]
     pub fn _bits(&self) -> bool {
         match *self {
-            FILTRW::FILTER_ENABLED_ => false,
-            FILTRW::FILTER_DISABLED_ => true,
+            FILTRW::ENABLED => false,
+            FILTRW::DISABLED => true,
         }
     }
 }
@@ -728,13 +728,13 @@ impl<'a> _FILTRW<'a> {
     }
     #[doc = "Filter enabled."]
     #[inline]
-    pub fn filter_enabled_(self) -> &'a mut W {
-        self.variant(FILTRW::FILTER_ENABLED_)
+    pub fn enabled(self) -> &'a mut W {
+        self.variant(FILTRW::ENABLED)
     }
     #[doc = "Filter disabled."]
     #[inline]
-    pub fn filter_disabled_(self) -> &'a mut W {
-        self.variant(FILTRW::FILTER_DISABLED_)
+    pub fn disabled(self) -> &'a mut W {
+        self.variant(FILTRW::DISABLED)
     }
     #[doc = r" Sets the field bit"]
     pub fn set_bit(self) -> &'a mut W {
@@ -757,9 +757,9 @@ impl<'a> _FILTRW<'a> {
 #[doc = "Values that can be written to the field `OD`"]
 pub enum ODW {
     #[doc = "Disable."]
-    DISABLE_,
+    DISABLED,
     #[doc = "Open-drain mode enabled.  This is not a true open-drain mode."]
-    OPEN_DRAIN_MODE_ENAB,
+    OPEN_DRAIN,
 }
 impl ODW {
     #[allow(missing_docs)]
@@ -767,8 +767,8 @@ impl ODW {
     #[inline]
     pub fn _bits(&self) -> bool {
         match *self {
-            ODW::DISABLE_ => false,
-            ODW::OPEN_DRAIN_MODE_ENAB => true,
+            ODW::DISABLED => false,
+            ODW::OPEN_DRAIN => true,
         }
     }
 }
@@ -786,13 +786,13 @@ impl<'a> _ODW<'a> {
     }
     #[doc = "Disable."]
     #[inline]
-    pub fn disable_(self) -> &'a mut W {
-        self.variant(ODW::DISABLE_)
+    pub fn disabled(self) -> &'a mut W {
+        self.variant(ODW::DISABLED)
     }
     #[doc = "Open-drain mode enabled. This is not a true open-drain mode."]
     #[inline]
-    pub fn open_drain_mode_enab(self) -> &'a mut W {
-        self.variant(ODW::OPEN_DRAIN_MODE_ENAB)
+    pub fn open_drain(self) -> &'a mut W {
+        self.variant(ODW::OPEN_DRAIN)
     }
     #[doc = r" Sets the field bit"]
     pub fn set_bit(self) -> &'a mut W {

--- a/lpc11uxx/src/iocon/tdo_pio0_13.rs
+++ b/lpc11uxx/src/iocon/tdo_pio0_13.rs
@@ -46,13 +46,13 @@ impl super::TDO_PIO0_13 {
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum FUNCR {
     #[doc = "TDO."]
-    TDO_,
+    TDO,
     #[doc = "PIO0_13."]
-    PIO0_13_,
+    PIO0_13,
     #[doc = "AD2."]
-    AD2_,
+    AD2,
     #[doc = "CT32B1_MAT0."]
-    CT32B1_MAT0_,
+    CT32B1_MAT0,
     #[doc = r" Reserved"]
     _Reserved(u8),
 }
@@ -61,10 +61,10 @@ impl FUNCR {
     #[inline]
     pub fn bits(&self) -> u8 {
         match *self {
-            FUNCR::TDO_ => 0,
-            FUNCR::PIO0_13_ => 1,
-            FUNCR::AD2_ => 2,
-            FUNCR::CT32B1_MAT0_ => 3,
+            FUNCR::TDO => 0,
+            FUNCR::PIO0_13 => 1,
+            FUNCR::AD2 => 2,
+            FUNCR::CT32B1_MAT0 => 3,
             FUNCR::_Reserved(bits) => bits,
         }
     }
@@ -73,55 +73,55 @@ impl FUNCR {
     #[inline]
     pub fn _from(value: u8) -> FUNCR {
         match value {
-            0 => FUNCR::TDO_,
-            1 => FUNCR::PIO0_13_,
-            2 => FUNCR::AD2_,
-            3 => FUNCR::CT32B1_MAT0_,
+            0 => FUNCR::TDO,
+            1 => FUNCR::PIO0_13,
+            2 => FUNCR::AD2,
+            3 => FUNCR::CT32B1_MAT0,
             i => FUNCR::_Reserved(i),
         }
     }
-    #[doc = "Checks if the value of the field is `TDO_`"]
+    #[doc = "Checks if the value of the field is `TDO`"]
     #[inline]
-    pub fn is_tdo_(&self) -> bool {
-        *self == FUNCR::TDO_
+    pub fn is_tdo(&self) -> bool {
+        *self == FUNCR::TDO
     }
-    #[doc = "Checks if the value of the field is `PIO0_13_`"]
+    #[doc = "Checks if the value of the field is `PIO0_13`"]
     #[inline]
-    pub fn is_pio0_13_(&self) -> bool {
-        *self == FUNCR::PIO0_13_
+    pub fn is_pio0_13(&self) -> bool {
+        *self == FUNCR::PIO0_13
     }
-    #[doc = "Checks if the value of the field is `AD2_`"]
+    #[doc = "Checks if the value of the field is `AD2`"]
     #[inline]
-    pub fn is_ad2_(&self) -> bool {
-        *self == FUNCR::AD2_
+    pub fn is_ad2(&self) -> bool {
+        *self == FUNCR::AD2
     }
-    #[doc = "Checks if the value of the field is `CT32B1_MAT0_`"]
+    #[doc = "Checks if the value of the field is `CT32B1_MAT0`"]
     #[inline]
-    pub fn is_ct32b1_mat0_(&self) -> bool {
-        *self == FUNCR::CT32B1_MAT0_
+    pub fn is_ct32b1_mat0(&self) -> bool {
+        *self == FUNCR::CT32B1_MAT0
     }
 }
 #[doc = "Possible values of the field `MODE`"]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum MODER {
     #[doc = "Inactive (no pull-down/pull-up resistor enabled)."]
-    INACTIVE_NO_PULL_DO,
+    INACTIVE,
     #[doc = "Pull-down resistor enabled."]
-    PULL_DOWN_RESISTOR_E,
+    PULL_DOWN,
     #[doc = "Pull-up resistor enabled."]
-    PULL_UP_RESISTOR_ENA,
+    PULL_UP,
     #[doc = "Repeater mode."]
-    REPEATER_MODE_,
+    REPEATER,
 }
 impl MODER {
     #[doc = r" Value of the field as raw bits"]
     #[inline]
     pub fn bits(&self) -> u8 {
         match *self {
-            MODER::INACTIVE_NO_PULL_DO => 0,
-            MODER::PULL_DOWN_RESISTOR_E => 1,
-            MODER::PULL_UP_RESISTOR_ENA => 2,
-            MODER::REPEATER_MODE_ => 3,
+            MODER::INACTIVE => 0,
+            MODER::PULL_DOWN => 1,
+            MODER::PULL_UP => 2,
+            MODER::REPEATER => 3,
         }
     }
     #[allow(missing_docs)]
@@ -129,41 +129,41 @@ impl MODER {
     #[inline]
     pub fn _from(value: u8) -> MODER {
         match value {
-            0 => MODER::INACTIVE_NO_PULL_DO,
-            1 => MODER::PULL_DOWN_RESISTOR_E,
-            2 => MODER::PULL_UP_RESISTOR_ENA,
-            3 => MODER::REPEATER_MODE_,
+            0 => MODER::INACTIVE,
+            1 => MODER::PULL_DOWN,
+            2 => MODER::PULL_UP,
+            3 => MODER::REPEATER,
             _ => unreachable!(),
         }
     }
-    #[doc = "Checks if the value of the field is `INACTIVE_NO_PULL_DO`"]
+    #[doc = "Checks if the value of the field is `INACTIVE`"]
     #[inline]
-    pub fn is_inactive_no_pull_do(&self) -> bool {
-        *self == MODER::INACTIVE_NO_PULL_DO
+    pub fn is_inactive(&self) -> bool {
+        *self == MODER::INACTIVE
     }
-    #[doc = "Checks if the value of the field is `PULL_DOWN_RESISTOR_E`"]
+    #[doc = "Checks if the value of the field is `PULL_DOWN`"]
     #[inline]
-    pub fn is_pull_down_resistor_e(&self) -> bool {
-        *self == MODER::PULL_DOWN_RESISTOR_E
+    pub fn is_pull_down(&self) -> bool {
+        *self == MODER::PULL_DOWN
     }
-    #[doc = "Checks if the value of the field is `PULL_UP_RESISTOR_ENA`"]
+    #[doc = "Checks if the value of the field is `PULL_UP`"]
     #[inline]
-    pub fn is_pull_up_resistor_ena(&self) -> bool {
-        *self == MODER::PULL_UP_RESISTOR_ENA
+    pub fn is_pull_up(&self) -> bool {
+        *self == MODER::PULL_UP
     }
-    #[doc = "Checks if the value of the field is `REPEATER_MODE_`"]
+    #[doc = "Checks if the value of the field is `REPEATER`"]
     #[inline]
-    pub fn is_repeater_mode_(&self) -> bool {
-        *self == MODER::REPEATER_MODE_
+    pub fn is_repeater(&self) -> bool {
+        *self == MODER::REPEATER
     }
 }
 #[doc = "Possible values of the field `HYS`"]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum HYSR {
     #[doc = "Disable."]
-    DISABLE_,
+    DISABLED,
     #[doc = "Enable."]
-    ENABLE_,
+    ENABLED,
 }
 impl HYSR {
     #[doc = r" Returns `true` if the bit is clear (0)"]
@@ -180,8 +180,8 @@ impl HYSR {
     #[inline]
     pub fn bit(&self) -> bool {
         match *self {
-            HYSR::DISABLE_ => false,
-            HYSR::ENABLE_ => true,
+            HYSR::DISABLED => false,
+            HYSR::ENABLED => true,
         }
     }
     #[allow(missing_docs)]
@@ -189,28 +189,28 @@ impl HYSR {
     #[inline]
     pub fn _from(value: bool) -> HYSR {
         match value {
-            false => HYSR::DISABLE_,
-            true => HYSR::ENABLE_,
+            false => HYSR::DISABLED,
+            true => HYSR::ENABLED,
         }
     }
-    #[doc = "Checks if the value of the field is `DISABLE_`"]
+    #[doc = "Checks if the value of the field is `DISABLED`"]
     #[inline]
-    pub fn is_disable_(&self) -> bool {
-        *self == HYSR::DISABLE_
+    pub fn is_disabled(&self) -> bool {
+        *self == HYSR::DISABLED
     }
-    #[doc = "Checks if the value of the field is `ENABLE_`"]
+    #[doc = "Checks if the value of the field is `ENABLED`"]
     #[inline]
-    pub fn is_enable_(&self) -> bool {
-        *self == HYSR::ENABLE_
+    pub fn is_enabled(&self) -> bool {
+        *self == HYSR::ENABLED
     }
 }
 #[doc = "Possible values of the field `INV`"]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum INVR {
     #[doc = "Input not inverted (HIGH on pin reads as 1, LOW on pin reads as 0)."]
-    INPUT_NOT_INVERTED_,
+    NOT_INVERTED,
     #[doc = "Input inverted (HIGH on pin reads as 0, LOW on pin reads as 1)."]
-    INPUT_INVERTED_HIGH,
+    INVERTED,
 }
 impl INVR {
     #[doc = r" Returns `true` if the bit is clear (0)"]
@@ -227,8 +227,8 @@ impl INVR {
     #[inline]
     pub fn bit(&self) -> bool {
         match *self {
-            INVR::INPUT_NOT_INVERTED_ => false,
-            INVR::INPUT_INVERTED_HIGH => true,
+            INVR::NOT_INVERTED => false,
+            INVR::INVERTED => true,
         }
     }
     #[allow(missing_docs)]
@@ -236,28 +236,28 @@ impl INVR {
     #[inline]
     pub fn _from(value: bool) -> INVR {
         match value {
-            false => INVR::INPUT_NOT_INVERTED_,
-            true => INVR::INPUT_INVERTED_HIGH,
+            false => INVR::NOT_INVERTED,
+            true => INVR::INVERTED,
         }
     }
-    #[doc = "Checks if the value of the field is `INPUT_NOT_INVERTED_`"]
+    #[doc = "Checks if the value of the field is `NOT_INVERTED`"]
     #[inline]
-    pub fn is_input_not_inverted_(&self) -> bool {
-        *self == INVR::INPUT_NOT_INVERTED_
+    pub fn is_not_inverted(&self) -> bool {
+        *self == INVR::NOT_INVERTED
     }
-    #[doc = "Checks if the value of the field is `INPUT_INVERTED_HIGH`"]
+    #[doc = "Checks if the value of the field is `INVERTED`"]
     #[inline]
-    pub fn is_input_inverted_high(&self) -> bool {
-        *self == INVR::INPUT_INVERTED_HIGH
+    pub fn is_inverted(&self) -> bool {
+        *self == INVR::INVERTED
     }
 }
 #[doc = "Possible values of the field `ADMODE`"]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum ADMODER {
     #[doc = "Analog input mode."]
-    ANALOG_INPUT_MODE_,
+    ANALOG,
     #[doc = "Digital functional mode."]
-    DIGITAL_FUNCTIONAL_M,
+    DIGITAL,
 }
 impl ADMODER {
     #[doc = r" Returns `true` if the bit is clear (0)"]
@@ -274,8 +274,8 @@ impl ADMODER {
     #[inline]
     pub fn bit(&self) -> bool {
         match *self {
-            ADMODER::ANALOG_INPUT_MODE_ => false,
-            ADMODER::DIGITAL_FUNCTIONAL_M => true,
+            ADMODER::ANALOG => false,
+            ADMODER::DIGITAL => true,
         }
     }
     #[allow(missing_docs)]
@@ -283,28 +283,28 @@ impl ADMODER {
     #[inline]
     pub fn _from(value: bool) -> ADMODER {
         match value {
-            false => ADMODER::ANALOG_INPUT_MODE_,
-            true => ADMODER::DIGITAL_FUNCTIONAL_M,
+            false => ADMODER::ANALOG,
+            true => ADMODER::DIGITAL,
         }
     }
-    #[doc = "Checks if the value of the field is `ANALOG_INPUT_MODE_`"]
+    #[doc = "Checks if the value of the field is `ANALOG`"]
     #[inline]
-    pub fn is_analog_input_mode_(&self) -> bool {
-        *self == ADMODER::ANALOG_INPUT_MODE_
+    pub fn is_analog(&self) -> bool {
+        *self == ADMODER::ANALOG
     }
-    #[doc = "Checks if the value of the field is `DIGITAL_FUNCTIONAL_M`"]
+    #[doc = "Checks if the value of the field is `DIGITAL`"]
     #[inline]
-    pub fn is_digital_functional_m(&self) -> bool {
-        *self == ADMODER::DIGITAL_FUNCTIONAL_M
+    pub fn is_digital(&self) -> bool {
+        *self == ADMODER::DIGITAL
     }
 }
 #[doc = "Possible values of the field `FILTR`"]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum FILTRR {
     #[doc = "Filter enabled."]
-    FILTER_ENABLED_,
+    ENABLED,
     #[doc = "Filter disabled."]
-    FILTER_DISABLED_,
+    DISABLED,
 }
 impl FILTRR {
     #[doc = r" Returns `true` if the bit is clear (0)"]
@@ -321,8 +321,8 @@ impl FILTRR {
     #[inline]
     pub fn bit(&self) -> bool {
         match *self {
-            FILTRR::FILTER_ENABLED_ => false,
-            FILTRR::FILTER_DISABLED_ => true,
+            FILTRR::ENABLED => false,
+            FILTRR::DISABLED => true,
         }
     }
     #[allow(missing_docs)]
@@ -330,28 +330,28 @@ impl FILTRR {
     #[inline]
     pub fn _from(value: bool) -> FILTRR {
         match value {
-            false => FILTRR::FILTER_ENABLED_,
-            true => FILTRR::FILTER_DISABLED_,
+            false => FILTRR::ENABLED,
+            true => FILTRR::DISABLED,
         }
     }
-    #[doc = "Checks if the value of the field is `FILTER_ENABLED_`"]
+    #[doc = "Checks if the value of the field is `ENABLED`"]
     #[inline]
-    pub fn is_filter_enabled_(&self) -> bool {
-        *self == FILTRR::FILTER_ENABLED_
+    pub fn is_enabled(&self) -> bool {
+        *self == FILTRR::ENABLED
     }
-    #[doc = "Checks if the value of the field is `FILTER_DISABLED_`"]
+    #[doc = "Checks if the value of the field is `DISABLED`"]
     #[inline]
-    pub fn is_filter_disabled_(&self) -> bool {
-        *self == FILTRR::FILTER_DISABLED_
+    pub fn is_disabled(&self) -> bool {
+        *self == FILTRR::DISABLED
     }
 }
 #[doc = "Possible values of the field `OD`"]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum ODR {
     #[doc = "Disable."]
-    DISABLE_,
+    DISABLED,
     #[doc = "Open-drain mode enabled.  This is not a true open-drain mode."]
-    OPEN_DRAIN_MODE_ENAB,
+    OPEN_DRAIN,
 }
 impl ODR {
     #[doc = r" Returns `true` if the bit is clear (0)"]
@@ -368,8 +368,8 @@ impl ODR {
     #[inline]
     pub fn bit(&self) -> bool {
         match *self {
-            ODR::DISABLE_ => false,
-            ODR::OPEN_DRAIN_MODE_ENAB => true,
+            ODR::DISABLED => false,
+            ODR::OPEN_DRAIN => true,
         }
     }
     #[allow(missing_docs)]
@@ -377,31 +377,31 @@ impl ODR {
     #[inline]
     pub fn _from(value: bool) -> ODR {
         match value {
-            false => ODR::DISABLE_,
-            true => ODR::OPEN_DRAIN_MODE_ENAB,
+            false => ODR::DISABLED,
+            true => ODR::OPEN_DRAIN,
         }
     }
-    #[doc = "Checks if the value of the field is `DISABLE_`"]
+    #[doc = "Checks if the value of the field is `DISABLED`"]
     #[inline]
-    pub fn is_disable_(&self) -> bool {
-        *self == ODR::DISABLE_
+    pub fn is_disabled(&self) -> bool {
+        *self == ODR::DISABLED
     }
-    #[doc = "Checks if the value of the field is `OPEN_DRAIN_MODE_ENAB`"]
+    #[doc = "Checks if the value of the field is `OPEN_DRAIN`"]
     #[inline]
-    pub fn is_open_drain_mode_enab(&self) -> bool {
-        *self == ODR::OPEN_DRAIN_MODE_ENAB
+    pub fn is_open_drain(&self) -> bool {
+        *self == ODR::OPEN_DRAIN
     }
 }
 #[doc = "Values that can be written to the field `FUNC`"]
 pub enum FUNCW {
     #[doc = "TDO."]
-    TDO_,
+    TDO,
     #[doc = "PIO0_13."]
-    PIO0_13_,
+    PIO0_13,
     #[doc = "AD2."]
-    AD2_,
+    AD2,
     #[doc = "CT32B1_MAT0."]
-    CT32B1_MAT0_,
+    CT32B1_MAT0,
 }
 impl FUNCW {
     #[allow(missing_docs)]
@@ -409,10 +409,10 @@ impl FUNCW {
     #[inline]
     pub fn _bits(&self) -> u8 {
         match *self {
-            FUNCW::TDO_ => 0,
-            FUNCW::PIO0_13_ => 1,
-            FUNCW::AD2_ => 2,
-            FUNCW::CT32B1_MAT0_ => 3,
+            FUNCW::TDO => 0,
+            FUNCW::PIO0_13 => 1,
+            FUNCW::AD2 => 2,
+            FUNCW::CT32B1_MAT0 => 3,
         }
     }
 }
@@ -428,23 +428,23 @@ impl<'a> _FUNCW<'a> {
     }
     #[doc = "TDO."]
     #[inline]
-    pub fn tdo_(self) -> &'a mut W {
-        self.variant(FUNCW::TDO_)
+    pub fn tdo(self) -> &'a mut W {
+        self.variant(FUNCW::TDO)
     }
     #[doc = "PIO0_13."]
     #[inline]
-    pub fn pio0_13_(self) -> &'a mut W {
-        self.variant(FUNCW::PIO0_13_)
+    pub fn pio0_13(self) -> &'a mut W {
+        self.variant(FUNCW::PIO0_13)
     }
     #[doc = "AD2."]
     #[inline]
-    pub fn ad2_(self) -> &'a mut W {
-        self.variant(FUNCW::AD2_)
+    pub fn ad2(self) -> &'a mut W {
+        self.variant(FUNCW::AD2)
     }
     #[doc = "CT32B1_MAT0."]
     #[inline]
-    pub fn ct32b1_mat0_(self) -> &'a mut W {
-        self.variant(FUNCW::CT32B1_MAT0_)
+    pub fn ct32b1_mat0(self) -> &'a mut W {
+        self.variant(FUNCW::CT32B1_MAT0)
     }
     #[doc = r" Writes raw bits to the field"]
     #[inline]
@@ -459,13 +459,13 @@ impl<'a> _FUNCW<'a> {
 #[doc = "Values that can be written to the field `MODE`"]
 pub enum MODEW {
     #[doc = "Inactive (no pull-down/pull-up resistor enabled)."]
-    INACTIVE_NO_PULL_DO,
+    INACTIVE,
     #[doc = "Pull-down resistor enabled."]
-    PULL_DOWN_RESISTOR_E,
+    PULL_DOWN,
     #[doc = "Pull-up resistor enabled."]
-    PULL_UP_RESISTOR_ENA,
+    PULL_UP,
     #[doc = "Repeater mode."]
-    REPEATER_MODE_,
+    REPEATER,
 }
 impl MODEW {
     #[allow(missing_docs)]
@@ -473,10 +473,10 @@ impl MODEW {
     #[inline]
     pub fn _bits(&self) -> u8 {
         match *self {
-            MODEW::INACTIVE_NO_PULL_DO => 0,
-            MODEW::PULL_DOWN_RESISTOR_E => 1,
-            MODEW::PULL_UP_RESISTOR_ENA => 2,
-            MODEW::REPEATER_MODE_ => 3,
+            MODEW::INACTIVE => 0,
+            MODEW::PULL_DOWN => 1,
+            MODEW::PULL_UP => 2,
+            MODEW::REPEATER => 3,
         }
     }
 }
@@ -494,23 +494,23 @@ impl<'a> _MODEW<'a> {
     }
     #[doc = "Inactive (no pull-down/pull-up resistor enabled)."]
     #[inline]
-    pub fn inactive_no_pull_do(self) -> &'a mut W {
-        self.variant(MODEW::INACTIVE_NO_PULL_DO)
+    pub fn inactive(self) -> &'a mut W {
+        self.variant(MODEW::INACTIVE)
     }
     #[doc = "Pull-down resistor enabled."]
     #[inline]
-    pub fn pull_down_resistor_e(self) -> &'a mut W {
-        self.variant(MODEW::PULL_DOWN_RESISTOR_E)
+    pub fn pull_down(self) -> &'a mut W {
+        self.variant(MODEW::PULL_DOWN)
     }
     #[doc = "Pull-up resistor enabled."]
     #[inline]
-    pub fn pull_up_resistor_ena(self) -> &'a mut W {
-        self.variant(MODEW::PULL_UP_RESISTOR_ENA)
+    pub fn pull_up(self) -> &'a mut W {
+        self.variant(MODEW::PULL_UP)
     }
     #[doc = "Repeater mode."]
     #[inline]
-    pub fn repeater_mode_(self) -> &'a mut W {
-        self.variant(MODEW::REPEATER_MODE_)
+    pub fn repeater(self) -> &'a mut W {
+        self.variant(MODEW::REPEATER)
     }
     #[doc = r" Writes raw bits to the field"]
     #[inline]
@@ -525,9 +525,9 @@ impl<'a> _MODEW<'a> {
 #[doc = "Values that can be written to the field `HYS`"]
 pub enum HYSW {
     #[doc = "Disable."]
-    DISABLE_,
+    DISABLED,
     #[doc = "Enable."]
-    ENABLE_,
+    ENABLED,
 }
 impl HYSW {
     #[allow(missing_docs)]
@@ -535,8 +535,8 @@ impl HYSW {
     #[inline]
     pub fn _bits(&self) -> bool {
         match *self {
-            HYSW::DISABLE_ => false,
-            HYSW::ENABLE_ => true,
+            HYSW::DISABLED => false,
+            HYSW::ENABLED => true,
         }
     }
 }
@@ -554,13 +554,13 @@ impl<'a> _HYSW<'a> {
     }
     #[doc = "Disable."]
     #[inline]
-    pub fn disable_(self) -> &'a mut W {
-        self.variant(HYSW::DISABLE_)
+    pub fn disabled(self) -> &'a mut W {
+        self.variant(HYSW::DISABLED)
     }
     #[doc = "Enable."]
     #[inline]
-    pub fn enable_(self) -> &'a mut W {
-        self.variant(HYSW::ENABLE_)
+    pub fn enabled(self) -> &'a mut W {
+        self.variant(HYSW::ENABLED)
     }
     #[doc = r" Sets the field bit"]
     pub fn set_bit(self) -> &'a mut W {
@@ -583,9 +583,9 @@ impl<'a> _HYSW<'a> {
 #[doc = "Values that can be written to the field `INV`"]
 pub enum INVW {
     #[doc = "Input not inverted (HIGH on pin reads as 1, LOW on pin reads as 0)."]
-    INPUT_NOT_INVERTED_,
+    NOT_INVERTED,
     #[doc = "Input inverted (HIGH on pin reads as 0, LOW on pin reads as 1)."]
-    INPUT_INVERTED_HIGH,
+    INVERTED,
 }
 impl INVW {
     #[allow(missing_docs)]
@@ -593,8 +593,8 @@ impl INVW {
     #[inline]
     pub fn _bits(&self) -> bool {
         match *self {
-            INVW::INPUT_NOT_INVERTED_ => false,
-            INVW::INPUT_INVERTED_HIGH => true,
+            INVW::NOT_INVERTED => false,
+            INVW::INVERTED => true,
         }
     }
 }
@@ -612,13 +612,13 @@ impl<'a> _INVW<'a> {
     }
     #[doc = "Input not inverted (HIGH on pin reads as 1, LOW on pin reads as 0)."]
     #[inline]
-    pub fn input_not_inverted_(self) -> &'a mut W {
-        self.variant(INVW::INPUT_NOT_INVERTED_)
+    pub fn not_inverted(self) -> &'a mut W {
+        self.variant(INVW::NOT_INVERTED)
     }
     #[doc = "Input inverted (HIGH on pin reads as 0, LOW on pin reads as 1)."]
     #[inline]
-    pub fn input_inverted_high(self) -> &'a mut W {
-        self.variant(INVW::INPUT_INVERTED_HIGH)
+    pub fn inverted(self) -> &'a mut W {
+        self.variant(INVW::INVERTED)
     }
     #[doc = r" Sets the field bit"]
     pub fn set_bit(self) -> &'a mut W {
@@ -641,9 +641,9 @@ impl<'a> _INVW<'a> {
 #[doc = "Values that can be written to the field `ADMODE`"]
 pub enum ADMODEW {
     #[doc = "Analog input mode."]
-    ANALOG_INPUT_MODE_,
+    ANALOG,
     #[doc = "Digital functional mode."]
-    DIGITAL_FUNCTIONAL_M,
+    DIGITAL,
 }
 impl ADMODEW {
     #[allow(missing_docs)]
@@ -651,8 +651,8 @@ impl ADMODEW {
     #[inline]
     pub fn _bits(&self) -> bool {
         match *self {
-            ADMODEW::ANALOG_INPUT_MODE_ => false,
-            ADMODEW::DIGITAL_FUNCTIONAL_M => true,
+            ADMODEW::ANALOG => false,
+            ADMODEW::DIGITAL => true,
         }
     }
 }
@@ -670,13 +670,13 @@ impl<'a> _ADMODEW<'a> {
     }
     #[doc = "Analog input mode."]
     #[inline]
-    pub fn analog_input_mode_(self) -> &'a mut W {
-        self.variant(ADMODEW::ANALOG_INPUT_MODE_)
+    pub fn analog(self) -> &'a mut W {
+        self.variant(ADMODEW::ANALOG)
     }
     #[doc = "Digital functional mode."]
     #[inline]
-    pub fn digital_functional_m(self) -> &'a mut W {
-        self.variant(ADMODEW::DIGITAL_FUNCTIONAL_M)
+    pub fn digital(self) -> &'a mut W {
+        self.variant(ADMODEW::DIGITAL)
     }
     #[doc = r" Sets the field bit"]
     pub fn set_bit(self) -> &'a mut W {
@@ -699,9 +699,9 @@ impl<'a> _ADMODEW<'a> {
 #[doc = "Values that can be written to the field `FILTR`"]
 pub enum FILTRW {
     #[doc = "Filter enabled."]
-    FILTER_ENABLED_,
+    ENABLED,
     #[doc = "Filter disabled."]
-    FILTER_DISABLED_,
+    DISABLED,
 }
 impl FILTRW {
     #[allow(missing_docs)]
@@ -709,8 +709,8 @@ impl FILTRW {
     #[inline]
     pub fn _bits(&self) -> bool {
         match *self {
-            FILTRW::FILTER_ENABLED_ => false,
-            FILTRW::FILTER_DISABLED_ => true,
+            FILTRW::ENABLED => false,
+            FILTRW::DISABLED => true,
         }
     }
 }
@@ -728,13 +728,13 @@ impl<'a> _FILTRW<'a> {
     }
     #[doc = "Filter enabled."]
     #[inline]
-    pub fn filter_enabled_(self) -> &'a mut W {
-        self.variant(FILTRW::FILTER_ENABLED_)
+    pub fn enabled(self) -> &'a mut W {
+        self.variant(FILTRW::ENABLED)
     }
     #[doc = "Filter disabled."]
     #[inline]
-    pub fn filter_disabled_(self) -> &'a mut W {
-        self.variant(FILTRW::FILTER_DISABLED_)
+    pub fn disabled(self) -> &'a mut W {
+        self.variant(FILTRW::DISABLED)
     }
     #[doc = r" Sets the field bit"]
     pub fn set_bit(self) -> &'a mut W {
@@ -757,9 +757,9 @@ impl<'a> _FILTRW<'a> {
 #[doc = "Values that can be written to the field `OD`"]
 pub enum ODW {
     #[doc = "Disable."]
-    DISABLE_,
+    DISABLED,
     #[doc = "Open-drain mode enabled.  This is not a true open-drain mode."]
-    OPEN_DRAIN_MODE_ENAB,
+    OPEN_DRAIN,
 }
 impl ODW {
     #[allow(missing_docs)]
@@ -767,8 +767,8 @@ impl ODW {
     #[inline]
     pub fn _bits(&self) -> bool {
         match *self {
-            ODW::DISABLE_ => false,
-            ODW::OPEN_DRAIN_MODE_ENAB => true,
+            ODW::DISABLED => false,
+            ODW::OPEN_DRAIN => true,
         }
     }
 }
@@ -786,13 +786,13 @@ impl<'a> _ODW<'a> {
     }
     #[doc = "Disable."]
     #[inline]
-    pub fn disable_(self) -> &'a mut W {
-        self.variant(ODW::DISABLE_)
+    pub fn disabled(self) -> &'a mut W {
+        self.variant(ODW::DISABLED)
     }
     #[doc = "Open-drain mode enabled. This is not a true open-drain mode."]
     #[inline]
-    pub fn open_drain_mode_enab(self) -> &'a mut W {
-        self.variant(ODW::OPEN_DRAIN_MODE_ENAB)
+    pub fn open_drain(self) -> &'a mut W {
+        self.variant(ODW::OPEN_DRAIN)
     }
     #[doc = r" Sets the field bit"]
     pub fn set_bit(self) -> &'a mut W {

--- a/lpc11uxx/src/iocon/tms_pio0_12.rs
+++ b/lpc11uxx/src/iocon/tms_pio0_12.rs
@@ -46,13 +46,13 @@ impl super::TMS_PIO0_12 {
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum FUNCR {
     #[doc = "TMS."]
-    TMS_,
+    TMS,
     #[doc = "PIO0_12."]
-    PIO0_12_,
+    PIO0_12,
     #[doc = "AD1."]
-    AD1_,
+    AD1,
     #[doc = "CT32B1_CAP0."]
-    CT32B1_CAP0_,
+    CT32B1_CAP0,
     #[doc = r" Reserved"]
     _Reserved(u8),
 }
@@ -61,10 +61,10 @@ impl FUNCR {
     #[inline]
     pub fn bits(&self) -> u8 {
         match *self {
-            FUNCR::TMS_ => 0,
-            FUNCR::PIO0_12_ => 1,
-            FUNCR::AD1_ => 2,
-            FUNCR::CT32B1_CAP0_ => 3,
+            FUNCR::TMS => 0,
+            FUNCR::PIO0_12 => 1,
+            FUNCR::AD1 => 2,
+            FUNCR::CT32B1_CAP0 => 3,
             FUNCR::_Reserved(bits) => bits,
         }
     }
@@ -73,55 +73,55 @@ impl FUNCR {
     #[inline]
     pub fn _from(value: u8) -> FUNCR {
         match value {
-            0 => FUNCR::TMS_,
-            1 => FUNCR::PIO0_12_,
-            2 => FUNCR::AD1_,
-            3 => FUNCR::CT32B1_CAP0_,
+            0 => FUNCR::TMS,
+            1 => FUNCR::PIO0_12,
+            2 => FUNCR::AD1,
+            3 => FUNCR::CT32B1_CAP0,
             i => FUNCR::_Reserved(i),
         }
     }
-    #[doc = "Checks if the value of the field is `TMS_`"]
+    #[doc = "Checks if the value of the field is `TMS`"]
     #[inline]
-    pub fn is_tms_(&self) -> bool {
-        *self == FUNCR::TMS_
+    pub fn is_tms(&self) -> bool {
+        *self == FUNCR::TMS
     }
-    #[doc = "Checks if the value of the field is `PIO0_12_`"]
+    #[doc = "Checks if the value of the field is `PIO0_12`"]
     #[inline]
-    pub fn is_pio0_12_(&self) -> bool {
-        *self == FUNCR::PIO0_12_
+    pub fn is_pio0_12(&self) -> bool {
+        *self == FUNCR::PIO0_12
     }
-    #[doc = "Checks if the value of the field is `AD1_`"]
+    #[doc = "Checks if the value of the field is `AD1`"]
     #[inline]
-    pub fn is_ad1_(&self) -> bool {
-        *self == FUNCR::AD1_
+    pub fn is_ad1(&self) -> bool {
+        *self == FUNCR::AD1
     }
-    #[doc = "Checks if the value of the field is `CT32B1_CAP0_`"]
+    #[doc = "Checks if the value of the field is `CT32B1_CAP0`"]
     #[inline]
-    pub fn is_ct32b1_cap0_(&self) -> bool {
-        *self == FUNCR::CT32B1_CAP0_
+    pub fn is_ct32b1_cap0(&self) -> bool {
+        *self == FUNCR::CT32B1_CAP0
     }
 }
 #[doc = "Possible values of the field `MODE`"]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum MODER {
     #[doc = "Inactive (no pull-down/pull-up resistor enabled)."]
-    INACTIVE_NO_PULL_DO,
+    INACTIVE,
     #[doc = "Pull-down resistor enabled."]
-    PULL_DOWN_RESISTOR_E,
+    PULL_DOWN,
     #[doc = "Pull-up resistor enabled."]
-    PULL_UP_RESISTOR_ENA,
+    PULL_UP,
     #[doc = "Repeater mode."]
-    REPEATER_MODE_,
+    REPEATER,
 }
 impl MODER {
     #[doc = r" Value of the field as raw bits"]
     #[inline]
     pub fn bits(&self) -> u8 {
         match *self {
-            MODER::INACTIVE_NO_PULL_DO => 0,
-            MODER::PULL_DOWN_RESISTOR_E => 1,
-            MODER::PULL_UP_RESISTOR_ENA => 2,
-            MODER::REPEATER_MODE_ => 3,
+            MODER::INACTIVE => 0,
+            MODER::PULL_DOWN => 1,
+            MODER::PULL_UP => 2,
+            MODER::REPEATER => 3,
         }
     }
     #[allow(missing_docs)]
@@ -129,41 +129,41 @@ impl MODER {
     #[inline]
     pub fn _from(value: u8) -> MODER {
         match value {
-            0 => MODER::INACTIVE_NO_PULL_DO,
-            1 => MODER::PULL_DOWN_RESISTOR_E,
-            2 => MODER::PULL_UP_RESISTOR_ENA,
-            3 => MODER::REPEATER_MODE_,
+            0 => MODER::INACTIVE,
+            1 => MODER::PULL_DOWN,
+            2 => MODER::PULL_UP,
+            3 => MODER::REPEATER,
             _ => unreachable!(),
         }
     }
-    #[doc = "Checks if the value of the field is `INACTIVE_NO_PULL_DO`"]
+    #[doc = "Checks if the value of the field is `INACTIVE`"]
     #[inline]
-    pub fn is_inactive_no_pull_do(&self) -> bool {
-        *self == MODER::INACTIVE_NO_PULL_DO
+    pub fn is_inactive(&self) -> bool {
+        *self == MODER::INACTIVE
     }
-    #[doc = "Checks if the value of the field is `PULL_DOWN_RESISTOR_E`"]
+    #[doc = "Checks if the value of the field is `PULL_DOWN`"]
     #[inline]
-    pub fn is_pull_down_resistor_e(&self) -> bool {
-        *self == MODER::PULL_DOWN_RESISTOR_E
+    pub fn is_pull_down(&self) -> bool {
+        *self == MODER::PULL_DOWN
     }
-    #[doc = "Checks if the value of the field is `PULL_UP_RESISTOR_ENA`"]
+    #[doc = "Checks if the value of the field is `PULL_UP`"]
     #[inline]
-    pub fn is_pull_up_resistor_ena(&self) -> bool {
-        *self == MODER::PULL_UP_RESISTOR_ENA
+    pub fn is_pull_up(&self) -> bool {
+        *self == MODER::PULL_UP
     }
-    #[doc = "Checks if the value of the field is `REPEATER_MODE_`"]
+    #[doc = "Checks if the value of the field is `REPEATER`"]
     #[inline]
-    pub fn is_repeater_mode_(&self) -> bool {
-        *self == MODER::REPEATER_MODE_
+    pub fn is_repeater(&self) -> bool {
+        *self == MODER::REPEATER
     }
 }
 #[doc = "Possible values of the field `HYS`"]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum HYSR {
     #[doc = "Disable."]
-    DISABLE_,
+    DISABLED,
     #[doc = "Enable."]
-    ENABLE_,
+    ENABLED,
 }
 impl HYSR {
     #[doc = r" Returns `true` if the bit is clear (0)"]
@@ -180,8 +180,8 @@ impl HYSR {
     #[inline]
     pub fn bit(&self) -> bool {
         match *self {
-            HYSR::DISABLE_ => false,
-            HYSR::ENABLE_ => true,
+            HYSR::DISABLED => false,
+            HYSR::ENABLED => true,
         }
     }
     #[allow(missing_docs)]
@@ -189,28 +189,28 @@ impl HYSR {
     #[inline]
     pub fn _from(value: bool) -> HYSR {
         match value {
-            false => HYSR::DISABLE_,
-            true => HYSR::ENABLE_,
+            false => HYSR::DISABLED,
+            true => HYSR::ENABLED,
         }
     }
-    #[doc = "Checks if the value of the field is `DISABLE_`"]
+    #[doc = "Checks if the value of the field is `DISABLED`"]
     #[inline]
-    pub fn is_disable_(&self) -> bool {
-        *self == HYSR::DISABLE_
+    pub fn is_disabled(&self) -> bool {
+        *self == HYSR::DISABLED
     }
-    #[doc = "Checks if the value of the field is `ENABLE_`"]
+    #[doc = "Checks if the value of the field is `ENABLED`"]
     #[inline]
-    pub fn is_enable_(&self) -> bool {
-        *self == HYSR::ENABLE_
+    pub fn is_enabled(&self) -> bool {
+        *self == HYSR::ENABLED
     }
 }
 #[doc = "Possible values of the field `INV`"]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum INVR {
     #[doc = "Input not inverted (HIGH on pin reads as 1, LOW on pin reads as 0)."]
-    INPUT_NOT_INVERTED_,
+    NOT_INVERTED,
     #[doc = "Input inverted (HIGH on pin reads as 0, LOW on pin reads as 1)."]
-    INPUT_INVERTED_HIGH,
+    INVERTED,
 }
 impl INVR {
     #[doc = r" Returns `true` if the bit is clear (0)"]
@@ -227,8 +227,8 @@ impl INVR {
     #[inline]
     pub fn bit(&self) -> bool {
         match *self {
-            INVR::INPUT_NOT_INVERTED_ => false,
-            INVR::INPUT_INVERTED_HIGH => true,
+            INVR::NOT_INVERTED => false,
+            INVR::INVERTED => true,
         }
     }
     #[allow(missing_docs)]
@@ -236,28 +236,28 @@ impl INVR {
     #[inline]
     pub fn _from(value: bool) -> INVR {
         match value {
-            false => INVR::INPUT_NOT_INVERTED_,
-            true => INVR::INPUT_INVERTED_HIGH,
+            false => INVR::NOT_INVERTED,
+            true => INVR::INVERTED,
         }
     }
-    #[doc = "Checks if the value of the field is `INPUT_NOT_INVERTED_`"]
+    #[doc = "Checks if the value of the field is `NOT_INVERTED`"]
     #[inline]
-    pub fn is_input_not_inverted_(&self) -> bool {
-        *self == INVR::INPUT_NOT_INVERTED_
+    pub fn is_not_inverted(&self) -> bool {
+        *self == INVR::NOT_INVERTED
     }
-    #[doc = "Checks if the value of the field is `INPUT_INVERTED_HIGH`"]
+    #[doc = "Checks if the value of the field is `INVERTED`"]
     #[inline]
-    pub fn is_input_inverted_high(&self) -> bool {
-        *self == INVR::INPUT_INVERTED_HIGH
+    pub fn is_inverted(&self) -> bool {
+        *self == INVR::INVERTED
     }
 }
 #[doc = "Possible values of the field `ADMODE`"]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum ADMODER {
     #[doc = "Analog input mode."]
-    ANALOG_INPUT_MODE_,
+    ANALOG,
     #[doc = "Digital functional mode."]
-    DIGITAL_FUNCTIONAL_M,
+    DIGITAL,
 }
 impl ADMODER {
     #[doc = r" Returns `true` if the bit is clear (0)"]
@@ -274,8 +274,8 @@ impl ADMODER {
     #[inline]
     pub fn bit(&self) -> bool {
         match *self {
-            ADMODER::ANALOG_INPUT_MODE_ => false,
-            ADMODER::DIGITAL_FUNCTIONAL_M => true,
+            ADMODER::ANALOG => false,
+            ADMODER::DIGITAL => true,
         }
     }
     #[allow(missing_docs)]
@@ -283,28 +283,28 @@ impl ADMODER {
     #[inline]
     pub fn _from(value: bool) -> ADMODER {
         match value {
-            false => ADMODER::ANALOG_INPUT_MODE_,
-            true => ADMODER::DIGITAL_FUNCTIONAL_M,
+            false => ADMODER::ANALOG,
+            true => ADMODER::DIGITAL,
         }
     }
-    #[doc = "Checks if the value of the field is `ANALOG_INPUT_MODE_`"]
+    #[doc = "Checks if the value of the field is `ANALOG`"]
     #[inline]
-    pub fn is_analog_input_mode_(&self) -> bool {
-        *self == ADMODER::ANALOG_INPUT_MODE_
+    pub fn is_analog(&self) -> bool {
+        *self == ADMODER::ANALOG
     }
-    #[doc = "Checks if the value of the field is `DIGITAL_FUNCTIONAL_M`"]
+    #[doc = "Checks if the value of the field is `DIGITAL`"]
     #[inline]
-    pub fn is_digital_functional_m(&self) -> bool {
-        *self == ADMODER::DIGITAL_FUNCTIONAL_M
+    pub fn is_digital(&self) -> bool {
+        *self == ADMODER::DIGITAL
     }
 }
 #[doc = "Possible values of the field `FILTR`"]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum FILTRR {
     #[doc = "Filter enabled."]
-    FILTER_ENABLED_,
+    ENABLED,
     #[doc = "Filter disabled."]
-    FILTER_DISABLED_,
+    DISABLED,
 }
 impl FILTRR {
     #[doc = r" Returns `true` if the bit is clear (0)"]
@@ -321,8 +321,8 @@ impl FILTRR {
     #[inline]
     pub fn bit(&self) -> bool {
         match *self {
-            FILTRR::FILTER_ENABLED_ => false,
-            FILTRR::FILTER_DISABLED_ => true,
+            FILTRR::ENABLED => false,
+            FILTRR::DISABLED => true,
         }
     }
     #[allow(missing_docs)]
@@ -330,28 +330,28 @@ impl FILTRR {
     #[inline]
     pub fn _from(value: bool) -> FILTRR {
         match value {
-            false => FILTRR::FILTER_ENABLED_,
-            true => FILTRR::FILTER_DISABLED_,
+            false => FILTRR::ENABLED,
+            true => FILTRR::DISABLED,
         }
     }
-    #[doc = "Checks if the value of the field is `FILTER_ENABLED_`"]
+    #[doc = "Checks if the value of the field is `ENABLED`"]
     #[inline]
-    pub fn is_filter_enabled_(&self) -> bool {
-        *self == FILTRR::FILTER_ENABLED_
+    pub fn is_enabled(&self) -> bool {
+        *self == FILTRR::ENABLED
     }
-    #[doc = "Checks if the value of the field is `FILTER_DISABLED_`"]
+    #[doc = "Checks if the value of the field is `DISABLED`"]
     #[inline]
-    pub fn is_filter_disabled_(&self) -> bool {
-        *self == FILTRR::FILTER_DISABLED_
+    pub fn is_disabled(&self) -> bool {
+        *self == FILTRR::DISABLED
     }
 }
 #[doc = "Possible values of the field `OD`"]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum ODR {
     #[doc = "Disable."]
-    DISABLE_,
+    DISABLED,
     #[doc = "Open-drain mode enabled.  This is not a true open-drain mode."]
-    OPEN_DRAIN_MODE_ENAB,
+    OPEN_DRAIN,
 }
 impl ODR {
     #[doc = r" Returns `true` if the bit is clear (0)"]
@@ -368,8 +368,8 @@ impl ODR {
     #[inline]
     pub fn bit(&self) -> bool {
         match *self {
-            ODR::DISABLE_ => false,
-            ODR::OPEN_DRAIN_MODE_ENAB => true,
+            ODR::DISABLED => false,
+            ODR::OPEN_DRAIN => true,
         }
     }
     #[allow(missing_docs)]
@@ -377,31 +377,31 @@ impl ODR {
     #[inline]
     pub fn _from(value: bool) -> ODR {
         match value {
-            false => ODR::DISABLE_,
-            true => ODR::OPEN_DRAIN_MODE_ENAB,
+            false => ODR::DISABLED,
+            true => ODR::OPEN_DRAIN,
         }
     }
-    #[doc = "Checks if the value of the field is `DISABLE_`"]
+    #[doc = "Checks if the value of the field is `DISABLED`"]
     #[inline]
-    pub fn is_disable_(&self) -> bool {
-        *self == ODR::DISABLE_
+    pub fn is_disabled(&self) -> bool {
+        *self == ODR::DISABLED
     }
-    #[doc = "Checks if the value of the field is `OPEN_DRAIN_MODE_ENAB`"]
+    #[doc = "Checks if the value of the field is `OPEN_DRAIN`"]
     #[inline]
-    pub fn is_open_drain_mode_enab(&self) -> bool {
-        *self == ODR::OPEN_DRAIN_MODE_ENAB
+    pub fn is_open_drain(&self) -> bool {
+        *self == ODR::OPEN_DRAIN
     }
 }
 #[doc = "Values that can be written to the field `FUNC`"]
 pub enum FUNCW {
     #[doc = "TMS."]
-    TMS_,
+    TMS,
     #[doc = "PIO0_12."]
-    PIO0_12_,
+    PIO0_12,
     #[doc = "AD1."]
-    AD1_,
+    AD1,
     #[doc = "CT32B1_CAP0."]
-    CT32B1_CAP0_,
+    CT32B1_CAP0,
 }
 impl FUNCW {
     #[allow(missing_docs)]
@@ -409,10 +409,10 @@ impl FUNCW {
     #[inline]
     pub fn _bits(&self) -> u8 {
         match *self {
-            FUNCW::TMS_ => 0,
-            FUNCW::PIO0_12_ => 1,
-            FUNCW::AD1_ => 2,
-            FUNCW::CT32B1_CAP0_ => 3,
+            FUNCW::TMS => 0,
+            FUNCW::PIO0_12 => 1,
+            FUNCW::AD1 => 2,
+            FUNCW::CT32B1_CAP0 => 3,
         }
     }
 }
@@ -428,23 +428,23 @@ impl<'a> _FUNCW<'a> {
     }
     #[doc = "TMS."]
     #[inline]
-    pub fn tms_(self) -> &'a mut W {
-        self.variant(FUNCW::TMS_)
+    pub fn tms(self) -> &'a mut W {
+        self.variant(FUNCW::TMS)
     }
     #[doc = "PIO0_12."]
     #[inline]
-    pub fn pio0_12_(self) -> &'a mut W {
-        self.variant(FUNCW::PIO0_12_)
+    pub fn pio0_12(self) -> &'a mut W {
+        self.variant(FUNCW::PIO0_12)
     }
     #[doc = "AD1."]
     #[inline]
-    pub fn ad1_(self) -> &'a mut W {
-        self.variant(FUNCW::AD1_)
+    pub fn ad1(self) -> &'a mut W {
+        self.variant(FUNCW::AD1)
     }
     #[doc = "CT32B1_CAP0."]
     #[inline]
-    pub fn ct32b1_cap0_(self) -> &'a mut W {
-        self.variant(FUNCW::CT32B1_CAP0_)
+    pub fn ct32b1_cap0(self) -> &'a mut W {
+        self.variant(FUNCW::CT32B1_CAP0)
     }
     #[doc = r" Writes raw bits to the field"]
     #[inline]
@@ -459,13 +459,13 @@ impl<'a> _FUNCW<'a> {
 #[doc = "Values that can be written to the field `MODE`"]
 pub enum MODEW {
     #[doc = "Inactive (no pull-down/pull-up resistor enabled)."]
-    INACTIVE_NO_PULL_DO,
+    INACTIVE,
     #[doc = "Pull-down resistor enabled."]
-    PULL_DOWN_RESISTOR_E,
+    PULL_DOWN,
     #[doc = "Pull-up resistor enabled."]
-    PULL_UP_RESISTOR_ENA,
+    PULL_UP,
     #[doc = "Repeater mode."]
-    REPEATER_MODE_,
+    REPEATER,
 }
 impl MODEW {
     #[allow(missing_docs)]
@@ -473,10 +473,10 @@ impl MODEW {
     #[inline]
     pub fn _bits(&self) -> u8 {
         match *self {
-            MODEW::INACTIVE_NO_PULL_DO => 0,
-            MODEW::PULL_DOWN_RESISTOR_E => 1,
-            MODEW::PULL_UP_RESISTOR_ENA => 2,
-            MODEW::REPEATER_MODE_ => 3,
+            MODEW::INACTIVE => 0,
+            MODEW::PULL_DOWN => 1,
+            MODEW::PULL_UP => 2,
+            MODEW::REPEATER => 3,
         }
     }
 }
@@ -494,23 +494,23 @@ impl<'a> _MODEW<'a> {
     }
     #[doc = "Inactive (no pull-down/pull-up resistor enabled)."]
     #[inline]
-    pub fn inactive_no_pull_do(self) -> &'a mut W {
-        self.variant(MODEW::INACTIVE_NO_PULL_DO)
+    pub fn inactive(self) -> &'a mut W {
+        self.variant(MODEW::INACTIVE)
     }
     #[doc = "Pull-down resistor enabled."]
     #[inline]
-    pub fn pull_down_resistor_e(self) -> &'a mut W {
-        self.variant(MODEW::PULL_DOWN_RESISTOR_E)
+    pub fn pull_down(self) -> &'a mut W {
+        self.variant(MODEW::PULL_DOWN)
     }
     #[doc = "Pull-up resistor enabled."]
     #[inline]
-    pub fn pull_up_resistor_ena(self) -> &'a mut W {
-        self.variant(MODEW::PULL_UP_RESISTOR_ENA)
+    pub fn pull_up(self) -> &'a mut W {
+        self.variant(MODEW::PULL_UP)
     }
     #[doc = "Repeater mode."]
     #[inline]
-    pub fn repeater_mode_(self) -> &'a mut W {
-        self.variant(MODEW::REPEATER_MODE_)
+    pub fn repeater(self) -> &'a mut W {
+        self.variant(MODEW::REPEATER)
     }
     #[doc = r" Writes raw bits to the field"]
     #[inline]
@@ -525,9 +525,9 @@ impl<'a> _MODEW<'a> {
 #[doc = "Values that can be written to the field `HYS`"]
 pub enum HYSW {
     #[doc = "Disable."]
-    DISABLE_,
+    DISABLED,
     #[doc = "Enable."]
-    ENABLE_,
+    ENABLED,
 }
 impl HYSW {
     #[allow(missing_docs)]
@@ -535,8 +535,8 @@ impl HYSW {
     #[inline]
     pub fn _bits(&self) -> bool {
         match *self {
-            HYSW::DISABLE_ => false,
-            HYSW::ENABLE_ => true,
+            HYSW::DISABLED => false,
+            HYSW::ENABLED => true,
         }
     }
 }
@@ -554,13 +554,13 @@ impl<'a> _HYSW<'a> {
     }
     #[doc = "Disable."]
     #[inline]
-    pub fn disable_(self) -> &'a mut W {
-        self.variant(HYSW::DISABLE_)
+    pub fn disabled(self) -> &'a mut W {
+        self.variant(HYSW::DISABLED)
     }
     #[doc = "Enable."]
     #[inline]
-    pub fn enable_(self) -> &'a mut W {
-        self.variant(HYSW::ENABLE_)
+    pub fn enabled(self) -> &'a mut W {
+        self.variant(HYSW::ENABLED)
     }
     #[doc = r" Sets the field bit"]
     pub fn set_bit(self) -> &'a mut W {
@@ -583,9 +583,9 @@ impl<'a> _HYSW<'a> {
 #[doc = "Values that can be written to the field `INV`"]
 pub enum INVW {
     #[doc = "Input not inverted (HIGH on pin reads as 1, LOW on pin reads as 0)."]
-    INPUT_NOT_INVERTED_,
+    NOT_INVERTED,
     #[doc = "Input inverted (HIGH on pin reads as 0, LOW on pin reads as 1)."]
-    INPUT_INVERTED_HIGH,
+    INVERTED,
 }
 impl INVW {
     #[allow(missing_docs)]
@@ -593,8 +593,8 @@ impl INVW {
     #[inline]
     pub fn _bits(&self) -> bool {
         match *self {
-            INVW::INPUT_NOT_INVERTED_ => false,
-            INVW::INPUT_INVERTED_HIGH => true,
+            INVW::NOT_INVERTED => false,
+            INVW::INVERTED => true,
         }
     }
 }
@@ -612,13 +612,13 @@ impl<'a> _INVW<'a> {
     }
     #[doc = "Input not inverted (HIGH on pin reads as 1, LOW on pin reads as 0)."]
     #[inline]
-    pub fn input_not_inverted_(self) -> &'a mut W {
-        self.variant(INVW::INPUT_NOT_INVERTED_)
+    pub fn not_inverted(self) -> &'a mut W {
+        self.variant(INVW::NOT_INVERTED)
     }
     #[doc = "Input inverted (HIGH on pin reads as 0, LOW on pin reads as 1)."]
     #[inline]
-    pub fn input_inverted_high(self) -> &'a mut W {
-        self.variant(INVW::INPUT_INVERTED_HIGH)
+    pub fn inverted(self) -> &'a mut W {
+        self.variant(INVW::INVERTED)
     }
     #[doc = r" Sets the field bit"]
     pub fn set_bit(self) -> &'a mut W {
@@ -641,9 +641,9 @@ impl<'a> _INVW<'a> {
 #[doc = "Values that can be written to the field `ADMODE`"]
 pub enum ADMODEW {
     #[doc = "Analog input mode."]
-    ANALOG_INPUT_MODE_,
+    ANALOG,
     #[doc = "Digital functional mode."]
-    DIGITAL_FUNCTIONAL_M,
+    DIGITAL,
 }
 impl ADMODEW {
     #[allow(missing_docs)]
@@ -651,8 +651,8 @@ impl ADMODEW {
     #[inline]
     pub fn _bits(&self) -> bool {
         match *self {
-            ADMODEW::ANALOG_INPUT_MODE_ => false,
-            ADMODEW::DIGITAL_FUNCTIONAL_M => true,
+            ADMODEW::ANALOG => false,
+            ADMODEW::DIGITAL => true,
         }
     }
 }
@@ -670,13 +670,13 @@ impl<'a> _ADMODEW<'a> {
     }
     #[doc = "Analog input mode."]
     #[inline]
-    pub fn analog_input_mode_(self) -> &'a mut W {
-        self.variant(ADMODEW::ANALOG_INPUT_MODE_)
+    pub fn analog(self) -> &'a mut W {
+        self.variant(ADMODEW::ANALOG)
     }
     #[doc = "Digital functional mode."]
     #[inline]
-    pub fn digital_functional_m(self) -> &'a mut W {
-        self.variant(ADMODEW::DIGITAL_FUNCTIONAL_M)
+    pub fn digital(self) -> &'a mut W {
+        self.variant(ADMODEW::DIGITAL)
     }
     #[doc = r" Sets the field bit"]
     pub fn set_bit(self) -> &'a mut W {
@@ -699,9 +699,9 @@ impl<'a> _ADMODEW<'a> {
 #[doc = "Values that can be written to the field `FILTR`"]
 pub enum FILTRW {
     #[doc = "Filter enabled."]
-    FILTER_ENABLED_,
+    ENABLED,
     #[doc = "Filter disabled."]
-    FILTER_DISABLED_,
+    DISABLED,
 }
 impl FILTRW {
     #[allow(missing_docs)]
@@ -709,8 +709,8 @@ impl FILTRW {
     #[inline]
     pub fn _bits(&self) -> bool {
         match *self {
-            FILTRW::FILTER_ENABLED_ => false,
-            FILTRW::FILTER_DISABLED_ => true,
+            FILTRW::ENABLED => false,
+            FILTRW::DISABLED => true,
         }
     }
 }
@@ -728,13 +728,13 @@ impl<'a> _FILTRW<'a> {
     }
     #[doc = "Filter enabled."]
     #[inline]
-    pub fn filter_enabled_(self) -> &'a mut W {
-        self.variant(FILTRW::FILTER_ENABLED_)
+    pub fn enabled(self) -> &'a mut W {
+        self.variant(FILTRW::ENABLED)
     }
     #[doc = "Filter disabled."]
     #[inline]
-    pub fn filter_disabled_(self) -> &'a mut W {
-        self.variant(FILTRW::FILTER_DISABLED_)
+    pub fn disabled(self) -> &'a mut W {
+        self.variant(FILTRW::DISABLED)
     }
     #[doc = r" Sets the field bit"]
     pub fn set_bit(self) -> &'a mut W {
@@ -757,9 +757,9 @@ impl<'a> _FILTRW<'a> {
 #[doc = "Values that can be written to the field `OD`"]
 pub enum ODW {
     #[doc = "Disable."]
-    DISABLE_,
+    DISABLED,
     #[doc = "Open-drain mode enabled.  This is not a true open-drain mode."]
-    OPEN_DRAIN_MODE_ENAB,
+    OPEN_DRAIN,
 }
 impl ODW {
     #[allow(missing_docs)]
@@ -767,8 +767,8 @@ impl ODW {
     #[inline]
     pub fn _bits(&self) -> bool {
         match *self {
-            ODW::DISABLE_ => false,
-            ODW::OPEN_DRAIN_MODE_ENAB => true,
+            ODW::DISABLED => false,
+            ODW::OPEN_DRAIN => true,
         }
     }
 }
@@ -786,13 +786,13 @@ impl<'a> _ODW<'a> {
     }
     #[doc = "Disable."]
     #[inline]
-    pub fn disable_(self) -> &'a mut W {
-        self.variant(ODW::DISABLE_)
+    pub fn disabled(self) -> &'a mut W {
+        self.variant(ODW::DISABLED)
     }
     #[doc = "Open-drain mode enabled. This is not a true open-drain mode."]
     #[inline]
-    pub fn open_drain_mode_enab(self) -> &'a mut W {
-        self.variant(ODW::OPEN_DRAIN_MODE_ENAB)
+    pub fn open_drain(self) -> &'a mut W {
+        self.variant(ODW::OPEN_DRAIN)
     }
     #[doc = r" Sets the field bit"]
     pub fn set_bit(self) -> &'a mut W {

--- a/lpc11uxx/src/iocon/trst_pio0_14.rs
+++ b/lpc11uxx/src/iocon/trst_pio0_14.rs
@@ -46,13 +46,13 @@ impl super::TRST_PIO0_14 {
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum FUNCR {
     #[doc = "TRST."]
-    TRST_,
+    TRST,
     #[doc = "PIO0_14."]
-    PIO0_14_,
+    PIO0_14,
     #[doc = "AD3."]
-    AD3_,
+    AD3,
     #[doc = "CT32B1_MAT1."]
-    CT32B1_MAT1_,
+    CT32B1_MAT1,
     #[doc = r" Reserved"]
     _Reserved(u8),
 }
@@ -61,10 +61,10 @@ impl FUNCR {
     #[inline]
     pub fn bits(&self) -> u8 {
         match *self {
-            FUNCR::TRST_ => 0,
-            FUNCR::PIO0_14_ => 1,
-            FUNCR::AD3_ => 2,
-            FUNCR::CT32B1_MAT1_ => 3,
+            FUNCR::TRST => 0,
+            FUNCR::PIO0_14 => 1,
+            FUNCR::AD3 => 2,
+            FUNCR::CT32B1_MAT1 => 3,
             FUNCR::_Reserved(bits) => bits,
         }
     }
@@ -73,55 +73,55 @@ impl FUNCR {
     #[inline]
     pub fn _from(value: u8) -> FUNCR {
         match value {
-            0 => FUNCR::TRST_,
-            1 => FUNCR::PIO0_14_,
-            2 => FUNCR::AD3_,
-            3 => FUNCR::CT32B1_MAT1_,
+            0 => FUNCR::TRST,
+            1 => FUNCR::PIO0_14,
+            2 => FUNCR::AD3,
+            3 => FUNCR::CT32B1_MAT1,
             i => FUNCR::_Reserved(i),
         }
     }
-    #[doc = "Checks if the value of the field is `TRST_`"]
+    #[doc = "Checks if the value of the field is `TRST`"]
     #[inline]
-    pub fn is_trst_(&self) -> bool {
-        *self == FUNCR::TRST_
+    pub fn is_trst(&self) -> bool {
+        *self == FUNCR::TRST
     }
-    #[doc = "Checks if the value of the field is `PIO0_14_`"]
+    #[doc = "Checks if the value of the field is `PIO0_14`"]
     #[inline]
-    pub fn is_pio0_14_(&self) -> bool {
-        *self == FUNCR::PIO0_14_
+    pub fn is_pio0_14(&self) -> bool {
+        *self == FUNCR::PIO0_14
     }
-    #[doc = "Checks if the value of the field is `AD3_`"]
+    #[doc = "Checks if the value of the field is `AD3`"]
     #[inline]
-    pub fn is_ad3_(&self) -> bool {
-        *self == FUNCR::AD3_
+    pub fn is_ad3(&self) -> bool {
+        *self == FUNCR::AD3
     }
-    #[doc = "Checks if the value of the field is `CT32B1_MAT1_`"]
+    #[doc = "Checks if the value of the field is `CT32B1_MAT1`"]
     #[inline]
-    pub fn is_ct32b1_mat1_(&self) -> bool {
-        *self == FUNCR::CT32B1_MAT1_
+    pub fn is_ct32b1_mat1(&self) -> bool {
+        *self == FUNCR::CT32B1_MAT1
     }
 }
 #[doc = "Possible values of the field `MODE`"]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum MODER {
     #[doc = "Inactive (no pull-down/pull-up resistor enabled)."]
-    INACTIVE_NO_PULL_DO,
+    INACTIVE,
     #[doc = "Pull-down resistor enabled."]
-    PULL_DOWN_RESISTOR_E,
+    PULL_DOWN,
     #[doc = "Pull-up resistor enabled."]
-    PULL_UP_RESISTOR_ENA,
+    PULL_UP,
     #[doc = "Repeater mode."]
-    REPEATER_MODE_,
+    REPEATER,
 }
 impl MODER {
     #[doc = r" Value of the field as raw bits"]
     #[inline]
     pub fn bits(&self) -> u8 {
         match *self {
-            MODER::INACTIVE_NO_PULL_DO => 0,
-            MODER::PULL_DOWN_RESISTOR_E => 1,
-            MODER::PULL_UP_RESISTOR_ENA => 2,
-            MODER::REPEATER_MODE_ => 3,
+            MODER::INACTIVE => 0,
+            MODER::PULL_DOWN => 1,
+            MODER::PULL_UP => 2,
+            MODER::REPEATER => 3,
         }
     }
     #[allow(missing_docs)]
@@ -129,41 +129,41 @@ impl MODER {
     #[inline]
     pub fn _from(value: u8) -> MODER {
         match value {
-            0 => MODER::INACTIVE_NO_PULL_DO,
-            1 => MODER::PULL_DOWN_RESISTOR_E,
-            2 => MODER::PULL_UP_RESISTOR_ENA,
-            3 => MODER::REPEATER_MODE_,
+            0 => MODER::INACTIVE,
+            1 => MODER::PULL_DOWN,
+            2 => MODER::PULL_UP,
+            3 => MODER::REPEATER,
             _ => unreachable!(),
         }
     }
-    #[doc = "Checks if the value of the field is `INACTIVE_NO_PULL_DO`"]
+    #[doc = "Checks if the value of the field is `INACTIVE`"]
     #[inline]
-    pub fn is_inactive_no_pull_do(&self) -> bool {
-        *self == MODER::INACTIVE_NO_PULL_DO
+    pub fn is_inactive(&self) -> bool {
+        *self == MODER::INACTIVE
     }
-    #[doc = "Checks if the value of the field is `PULL_DOWN_RESISTOR_E`"]
+    #[doc = "Checks if the value of the field is `PULL_DOWN`"]
     #[inline]
-    pub fn is_pull_down_resistor_e(&self) -> bool {
-        *self == MODER::PULL_DOWN_RESISTOR_E
+    pub fn is_pull_down(&self) -> bool {
+        *self == MODER::PULL_DOWN
     }
-    #[doc = "Checks if the value of the field is `PULL_UP_RESISTOR_ENA`"]
+    #[doc = "Checks if the value of the field is `PULL_UP`"]
     #[inline]
-    pub fn is_pull_up_resistor_ena(&self) -> bool {
-        *self == MODER::PULL_UP_RESISTOR_ENA
+    pub fn is_pull_up(&self) -> bool {
+        *self == MODER::PULL_UP
     }
-    #[doc = "Checks if the value of the field is `REPEATER_MODE_`"]
+    #[doc = "Checks if the value of the field is `REPEATER`"]
     #[inline]
-    pub fn is_repeater_mode_(&self) -> bool {
-        *self == MODER::REPEATER_MODE_
+    pub fn is_repeater(&self) -> bool {
+        *self == MODER::REPEATER
     }
 }
 #[doc = "Possible values of the field `HYS`"]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum HYSR {
     #[doc = "Disable."]
-    DISABLE_,
+    DISABLED,
     #[doc = "Enable."]
-    ENABLE_,
+    ENABLED,
 }
 impl HYSR {
     #[doc = r" Returns `true` if the bit is clear (0)"]
@@ -180,8 +180,8 @@ impl HYSR {
     #[inline]
     pub fn bit(&self) -> bool {
         match *self {
-            HYSR::DISABLE_ => false,
-            HYSR::ENABLE_ => true,
+            HYSR::DISABLED => false,
+            HYSR::ENABLED => true,
         }
     }
     #[allow(missing_docs)]
@@ -189,28 +189,28 @@ impl HYSR {
     #[inline]
     pub fn _from(value: bool) -> HYSR {
         match value {
-            false => HYSR::DISABLE_,
-            true => HYSR::ENABLE_,
+            false => HYSR::DISABLED,
+            true => HYSR::ENABLED,
         }
     }
-    #[doc = "Checks if the value of the field is `DISABLE_`"]
+    #[doc = "Checks if the value of the field is `DISABLED`"]
     #[inline]
-    pub fn is_disable_(&self) -> bool {
-        *self == HYSR::DISABLE_
+    pub fn is_disabled(&self) -> bool {
+        *self == HYSR::DISABLED
     }
-    #[doc = "Checks if the value of the field is `ENABLE_`"]
+    #[doc = "Checks if the value of the field is `ENABLED`"]
     #[inline]
-    pub fn is_enable_(&self) -> bool {
-        *self == HYSR::ENABLE_
+    pub fn is_enabled(&self) -> bool {
+        *self == HYSR::ENABLED
     }
 }
 #[doc = "Possible values of the field `INV`"]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum INVR {
     #[doc = "Input not inverted (HIGH on pin reads as 1, LOW on pin reads as 0)."]
-    INPUT_NOT_INVERTED_,
+    NOT_INVERTED,
     #[doc = "Input inverted (HIGH on pin reads as 0, LOW on pin reads as 1)."]
-    INPUT_INVERTED_HIGH,
+    INVERTED,
 }
 impl INVR {
     #[doc = r" Returns `true` if the bit is clear (0)"]
@@ -227,8 +227,8 @@ impl INVR {
     #[inline]
     pub fn bit(&self) -> bool {
         match *self {
-            INVR::INPUT_NOT_INVERTED_ => false,
-            INVR::INPUT_INVERTED_HIGH => true,
+            INVR::NOT_INVERTED => false,
+            INVR::INVERTED => true,
         }
     }
     #[allow(missing_docs)]
@@ -236,28 +236,28 @@ impl INVR {
     #[inline]
     pub fn _from(value: bool) -> INVR {
         match value {
-            false => INVR::INPUT_NOT_INVERTED_,
-            true => INVR::INPUT_INVERTED_HIGH,
+            false => INVR::NOT_INVERTED,
+            true => INVR::INVERTED,
         }
     }
-    #[doc = "Checks if the value of the field is `INPUT_NOT_INVERTED_`"]
+    #[doc = "Checks if the value of the field is `NOT_INVERTED`"]
     #[inline]
-    pub fn is_input_not_inverted_(&self) -> bool {
-        *self == INVR::INPUT_NOT_INVERTED_
+    pub fn is_not_inverted(&self) -> bool {
+        *self == INVR::NOT_INVERTED
     }
-    #[doc = "Checks if the value of the field is `INPUT_INVERTED_HIGH`"]
+    #[doc = "Checks if the value of the field is `INVERTED`"]
     #[inline]
-    pub fn is_input_inverted_high(&self) -> bool {
-        *self == INVR::INPUT_INVERTED_HIGH
+    pub fn is_inverted(&self) -> bool {
+        *self == INVR::INVERTED
     }
 }
 #[doc = "Possible values of the field `ADMODE`"]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum ADMODER {
     #[doc = "Analog input mode."]
-    ANALOG_INPUT_MODE_,
+    ANALOG,
     #[doc = "Digital functional mode."]
-    DIGITAL_FUNCTIONAL_M,
+    DIGITAL,
 }
 impl ADMODER {
     #[doc = r" Returns `true` if the bit is clear (0)"]
@@ -274,8 +274,8 @@ impl ADMODER {
     #[inline]
     pub fn bit(&self) -> bool {
         match *self {
-            ADMODER::ANALOG_INPUT_MODE_ => false,
-            ADMODER::DIGITAL_FUNCTIONAL_M => true,
+            ADMODER::ANALOG => false,
+            ADMODER::DIGITAL => true,
         }
     }
     #[allow(missing_docs)]
@@ -283,28 +283,28 @@ impl ADMODER {
     #[inline]
     pub fn _from(value: bool) -> ADMODER {
         match value {
-            false => ADMODER::ANALOG_INPUT_MODE_,
-            true => ADMODER::DIGITAL_FUNCTIONAL_M,
+            false => ADMODER::ANALOG,
+            true => ADMODER::DIGITAL,
         }
     }
-    #[doc = "Checks if the value of the field is `ANALOG_INPUT_MODE_`"]
+    #[doc = "Checks if the value of the field is `ANALOG`"]
     #[inline]
-    pub fn is_analog_input_mode_(&self) -> bool {
-        *self == ADMODER::ANALOG_INPUT_MODE_
+    pub fn is_analog(&self) -> bool {
+        *self == ADMODER::ANALOG
     }
-    #[doc = "Checks if the value of the field is `DIGITAL_FUNCTIONAL_M`"]
+    #[doc = "Checks if the value of the field is `DIGITAL`"]
     #[inline]
-    pub fn is_digital_functional_m(&self) -> bool {
-        *self == ADMODER::DIGITAL_FUNCTIONAL_M
+    pub fn is_digital(&self) -> bool {
+        *self == ADMODER::DIGITAL
     }
 }
 #[doc = "Possible values of the field `FILTR`"]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum FILTRR {
     #[doc = "Filter enabled."]
-    FILTER_ENABLED_,
+    ENABLED,
     #[doc = "Filter disabled."]
-    FILTER_DISABLED_,
+    DISABLED,
 }
 impl FILTRR {
     #[doc = r" Returns `true` if the bit is clear (0)"]
@@ -321,8 +321,8 @@ impl FILTRR {
     #[inline]
     pub fn bit(&self) -> bool {
         match *self {
-            FILTRR::FILTER_ENABLED_ => false,
-            FILTRR::FILTER_DISABLED_ => true,
+            FILTRR::ENABLED => false,
+            FILTRR::DISABLED => true,
         }
     }
     #[allow(missing_docs)]
@@ -330,28 +330,28 @@ impl FILTRR {
     #[inline]
     pub fn _from(value: bool) -> FILTRR {
         match value {
-            false => FILTRR::FILTER_ENABLED_,
-            true => FILTRR::FILTER_DISABLED_,
+            false => FILTRR::ENABLED,
+            true => FILTRR::DISABLED,
         }
     }
-    #[doc = "Checks if the value of the field is `FILTER_ENABLED_`"]
+    #[doc = "Checks if the value of the field is `ENABLED`"]
     #[inline]
-    pub fn is_filter_enabled_(&self) -> bool {
-        *self == FILTRR::FILTER_ENABLED_
+    pub fn is_enabled(&self) -> bool {
+        *self == FILTRR::ENABLED
     }
-    #[doc = "Checks if the value of the field is `FILTER_DISABLED_`"]
+    #[doc = "Checks if the value of the field is `DISABLED`"]
     #[inline]
-    pub fn is_filter_disabled_(&self) -> bool {
-        *self == FILTRR::FILTER_DISABLED_
+    pub fn is_disabled(&self) -> bool {
+        *self == FILTRR::DISABLED
     }
 }
 #[doc = "Possible values of the field `OD`"]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum ODR {
     #[doc = "Disable."]
-    DISABLE_,
+    DISABLED,
     #[doc = "Open-drain mode enabled.  This is not a true open-drain mode."]
-    OPEN_DRAIN_MODE_ENAB,
+    OPEN_DRAIN,
 }
 impl ODR {
     #[doc = r" Returns `true` if the bit is clear (0)"]
@@ -368,8 +368,8 @@ impl ODR {
     #[inline]
     pub fn bit(&self) -> bool {
         match *self {
-            ODR::DISABLE_ => false,
-            ODR::OPEN_DRAIN_MODE_ENAB => true,
+            ODR::DISABLED => false,
+            ODR::OPEN_DRAIN => true,
         }
     }
     #[allow(missing_docs)]
@@ -377,31 +377,31 @@ impl ODR {
     #[inline]
     pub fn _from(value: bool) -> ODR {
         match value {
-            false => ODR::DISABLE_,
-            true => ODR::OPEN_DRAIN_MODE_ENAB,
+            false => ODR::DISABLED,
+            true => ODR::OPEN_DRAIN,
         }
     }
-    #[doc = "Checks if the value of the field is `DISABLE_`"]
+    #[doc = "Checks if the value of the field is `DISABLED`"]
     #[inline]
-    pub fn is_disable_(&self) -> bool {
-        *self == ODR::DISABLE_
+    pub fn is_disabled(&self) -> bool {
+        *self == ODR::DISABLED
     }
-    #[doc = "Checks if the value of the field is `OPEN_DRAIN_MODE_ENAB`"]
+    #[doc = "Checks if the value of the field is `OPEN_DRAIN`"]
     #[inline]
-    pub fn is_open_drain_mode_enab(&self) -> bool {
-        *self == ODR::OPEN_DRAIN_MODE_ENAB
+    pub fn is_open_drain(&self) -> bool {
+        *self == ODR::OPEN_DRAIN
     }
 }
 #[doc = "Values that can be written to the field `FUNC`"]
 pub enum FUNCW {
     #[doc = "TRST."]
-    TRST_,
+    TRST,
     #[doc = "PIO0_14."]
-    PIO0_14_,
+    PIO0_14,
     #[doc = "AD3."]
-    AD3_,
+    AD3,
     #[doc = "CT32B1_MAT1."]
-    CT32B1_MAT1_,
+    CT32B1_MAT1,
 }
 impl FUNCW {
     #[allow(missing_docs)]
@@ -409,10 +409,10 @@ impl FUNCW {
     #[inline]
     pub fn _bits(&self) -> u8 {
         match *self {
-            FUNCW::TRST_ => 0,
-            FUNCW::PIO0_14_ => 1,
-            FUNCW::AD3_ => 2,
-            FUNCW::CT32B1_MAT1_ => 3,
+            FUNCW::TRST => 0,
+            FUNCW::PIO0_14 => 1,
+            FUNCW::AD3 => 2,
+            FUNCW::CT32B1_MAT1 => 3,
         }
     }
 }
@@ -428,23 +428,23 @@ impl<'a> _FUNCW<'a> {
     }
     #[doc = "TRST."]
     #[inline]
-    pub fn trst_(self) -> &'a mut W {
-        self.variant(FUNCW::TRST_)
+    pub fn trst(self) -> &'a mut W {
+        self.variant(FUNCW::TRST)
     }
     #[doc = "PIO0_14."]
     #[inline]
-    pub fn pio0_14_(self) -> &'a mut W {
-        self.variant(FUNCW::PIO0_14_)
+    pub fn pio0_14(self) -> &'a mut W {
+        self.variant(FUNCW::PIO0_14)
     }
     #[doc = "AD3."]
     #[inline]
-    pub fn ad3_(self) -> &'a mut W {
-        self.variant(FUNCW::AD3_)
+    pub fn ad3(self) -> &'a mut W {
+        self.variant(FUNCW::AD3)
     }
     #[doc = "CT32B1_MAT1."]
     #[inline]
-    pub fn ct32b1_mat1_(self) -> &'a mut W {
-        self.variant(FUNCW::CT32B1_MAT1_)
+    pub fn ct32b1_mat1(self) -> &'a mut W {
+        self.variant(FUNCW::CT32B1_MAT1)
     }
     #[doc = r" Writes raw bits to the field"]
     #[inline]
@@ -459,13 +459,13 @@ impl<'a> _FUNCW<'a> {
 #[doc = "Values that can be written to the field `MODE`"]
 pub enum MODEW {
     #[doc = "Inactive (no pull-down/pull-up resistor enabled)."]
-    INACTIVE_NO_PULL_DO,
+    INACTIVE,
     #[doc = "Pull-down resistor enabled."]
-    PULL_DOWN_RESISTOR_E,
+    PULL_DOWN,
     #[doc = "Pull-up resistor enabled."]
-    PULL_UP_RESISTOR_ENA,
+    PULL_UP,
     #[doc = "Repeater mode."]
-    REPEATER_MODE_,
+    REPEATER,
 }
 impl MODEW {
     #[allow(missing_docs)]
@@ -473,10 +473,10 @@ impl MODEW {
     #[inline]
     pub fn _bits(&self) -> u8 {
         match *self {
-            MODEW::INACTIVE_NO_PULL_DO => 0,
-            MODEW::PULL_DOWN_RESISTOR_E => 1,
-            MODEW::PULL_UP_RESISTOR_ENA => 2,
-            MODEW::REPEATER_MODE_ => 3,
+            MODEW::INACTIVE => 0,
+            MODEW::PULL_DOWN => 1,
+            MODEW::PULL_UP => 2,
+            MODEW::REPEATER => 3,
         }
     }
 }
@@ -494,23 +494,23 @@ impl<'a> _MODEW<'a> {
     }
     #[doc = "Inactive (no pull-down/pull-up resistor enabled)."]
     #[inline]
-    pub fn inactive_no_pull_do(self) -> &'a mut W {
-        self.variant(MODEW::INACTIVE_NO_PULL_DO)
+    pub fn inactive(self) -> &'a mut W {
+        self.variant(MODEW::INACTIVE)
     }
     #[doc = "Pull-down resistor enabled."]
     #[inline]
-    pub fn pull_down_resistor_e(self) -> &'a mut W {
-        self.variant(MODEW::PULL_DOWN_RESISTOR_E)
+    pub fn pull_down(self) -> &'a mut W {
+        self.variant(MODEW::PULL_DOWN)
     }
     #[doc = "Pull-up resistor enabled."]
     #[inline]
-    pub fn pull_up_resistor_ena(self) -> &'a mut W {
-        self.variant(MODEW::PULL_UP_RESISTOR_ENA)
+    pub fn pull_up(self) -> &'a mut W {
+        self.variant(MODEW::PULL_UP)
     }
     #[doc = "Repeater mode."]
     #[inline]
-    pub fn repeater_mode_(self) -> &'a mut W {
-        self.variant(MODEW::REPEATER_MODE_)
+    pub fn repeater(self) -> &'a mut W {
+        self.variant(MODEW::REPEATER)
     }
     #[doc = r" Writes raw bits to the field"]
     #[inline]
@@ -525,9 +525,9 @@ impl<'a> _MODEW<'a> {
 #[doc = "Values that can be written to the field `HYS`"]
 pub enum HYSW {
     #[doc = "Disable."]
-    DISABLE_,
+    DISABLED,
     #[doc = "Enable."]
-    ENABLE_,
+    ENABLED,
 }
 impl HYSW {
     #[allow(missing_docs)]
@@ -535,8 +535,8 @@ impl HYSW {
     #[inline]
     pub fn _bits(&self) -> bool {
         match *self {
-            HYSW::DISABLE_ => false,
-            HYSW::ENABLE_ => true,
+            HYSW::DISABLED => false,
+            HYSW::ENABLED => true,
         }
     }
 }
@@ -554,13 +554,13 @@ impl<'a> _HYSW<'a> {
     }
     #[doc = "Disable."]
     #[inline]
-    pub fn disable_(self) -> &'a mut W {
-        self.variant(HYSW::DISABLE_)
+    pub fn disabled(self) -> &'a mut W {
+        self.variant(HYSW::DISABLED)
     }
     #[doc = "Enable."]
     #[inline]
-    pub fn enable_(self) -> &'a mut W {
-        self.variant(HYSW::ENABLE_)
+    pub fn enabled(self) -> &'a mut W {
+        self.variant(HYSW::ENABLED)
     }
     #[doc = r" Sets the field bit"]
     pub fn set_bit(self) -> &'a mut W {
@@ -583,9 +583,9 @@ impl<'a> _HYSW<'a> {
 #[doc = "Values that can be written to the field `INV`"]
 pub enum INVW {
     #[doc = "Input not inverted (HIGH on pin reads as 1, LOW on pin reads as 0)."]
-    INPUT_NOT_INVERTED_,
+    NOT_INVERTED,
     #[doc = "Input inverted (HIGH on pin reads as 0, LOW on pin reads as 1)."]
-    INPUT_INVERTED_HIGH,
+    INVERTED,
 }
 impl INVW {
     #[allow(missing_docs)]
@@ -593,8 +593,8 @@ impl INVW {
     #[inline]
     pub fn _bits(&self) -> bool {
         match *self {
-            INVW::INPUT_NOT_INVERTED_ => false,
-            INVW::INPUT_INVERTED_HIGH => true,
+            INVW::NOT_INVERTED => false,
+            INVW::INVERTED => true,
         }
     }
 }
@@ -612,13 +612,13 @@ impl<'a> _INVW<'a> {
     }
     #[doc = "Input not inverted (HIGH on pin reads as 1, LOW on pin reads as 0)."]
     #[inline]
-    pub fn input_not_inverted_(self) -> &'a mut W {
-        self.variant(INVW::INPUT_NOT_INVERTED_)
+    pub fn not_inverted(self) -> &'a mut W {
+        self.variant(INVW::NOT_INVERTED)
     }
     #[doc = "Input inverted (HIGH on pin reads as 0, LOW on pin reads as 1)."]
     #[inline]
-    pub fn input_inverted_high(self) -> &'a mut W {
-        self.variant(INVW::INPUT_INVERTED_HIGH)
+    pub fn inverted(self) -> &'a mut W {
+        self.variant(INVW::INVERTED)
     }
     #[doc = r" Sets the field bit"]
     pub fn set_bit(self) -> &'a mut W {
@@ -641,9 +641,9 @@ impl<'a> _INVW<'a> {
 #[doc = "Values that can be written to the field `ADMODE`"]
 pub enum ADMODEW {
     #[doc = "Analog input mode."]
-    ANALOG_INPUT_MODE_,
+    ANALOG,
     #[doc = "Digital functional mode."]
-    DIGITAL_FUNCTIONAL_M,
+    DIGITAL,
 }
 impl ADMODEW {
     #[allow(missing_docs)]
@@ -651,8 +651,8 @@ impl ADMODEW {
     #[inline]
     pub fn _bits(&self) -> bool {
         match *self {
-            ADMODEW::ANALOG_INPUT_MODE_ => false,
-            ADMODEW::DIGITAL_FUNCTIONAL_M => true,
+            ADMODEW::ANALOG => false,
+            ADMODEW::DIGITAL => true,
         }
     }
 }
@@ -670,13 +670,13 @@ impl<'a> _ADMODEW<'a> {
     }
     #[doc = "Analog input mode."]
     #[inline]
-    pub fn analog_input_mode_(self) -> &'a mut W {
-        self.variant(ADMODEW::ANALOG_INPUT_MODE_)
+    pub fn analog(self) -> &'a mut W {
+        self.variant(ADMODEW::ANALOG)
     }
     #[doc = "Digital functional mode."]
     #[inline]
-    pub fn digital_functional_m(self) -> &'a mut W {
-        self.variant(ADMODEW::DIGITAL_FUNCTIONAL_M)
+    pub fn digital(self) -> &'a mut W {
+        self.variant(ADMODEW::DIGITAL)
     }
     #[doc = r" Sets the field bit"]
     pub fn set_bit(self) -> &'a mut W {
@@ -699,9 +699,9 @@ impl<'a> _ADMODEW<'a> {
 #[doc = "Values that can be written to the field `FILTR`"]
 pub enum FILTRW {
     #[doc = "Filter enabled."]
-    FILTER_ENABLED_,
+    ENABLED,
     #[doc = "Filter disabled."]
-    FILTER_DISABLED_,
+    DISABLED,
 }
 impl FILTRW {
     #[allow(missing_docs)]
@@ -709,8 +709,8 @@ impl FILTRW {
     #[inline]
     pub fn _bits(&self) -> bool {
         match *self {
-            FILTRW::FILTER_ENABLED_ => false,
-            FILTRW::FILTER_DISABLED_ => true,
+            FILTRW::ENABLED => false,
+            FILTRW::DISABLED => true,
         }
     }
 }
@@ -728,13 +728,13 @@ impl<'a> _FILTRW<'a> {
     }
     #[doc = "Filter enabled."]
     #[inline]
-    pub fn filter_enabled_(self) -> &'a mut W {
-        self.variant(FILTRW::FILTER_ENABLED_)
+    pub fn enabled(self) -> &'a mut W {
+        self.variant(FILTRW::ENABLED)
     }
     #[doc = "Filter disabled."]
     #[inline]
-    pub fn filter_disabled_(self) -> &'a mut W {
-        self.variant(FILTRW::FILTER_DISABLED_)
+    pub fn disabled(self) -> &'a mut W {
+        self.variant(FILTRW::DISABLED)
     }
     #[doc = r" Sets the field bit"]
     pub fn set_bit(self) -> &'a mut W {
@@ -757,9 +757,9 @@ impl<'a> _FILTRW<'a> {
 #[doc = "Values that can be written to the field `OD`"]
 pub enum ODW {
     #[doc = "Disable."]
-    DISABLE_,
+    DISABLED,
     #[doc = "Open-drain mode enabled.  This is not a true open-drain mode."]
-    OPEN_DRAIN_MODE_ENAB,
+    OPEN_DRAIN,
 }
 impl ODW {
     #[allow(missing_docs)]
@@ -767,8 +767,8 @@ impl ODW {
     #[inline]
     pub fn _bits(&self) -> bool {
         match *self {
-            ODW::DISABLE_ => false,
-            ODW::OPEN_DRAIN_MODE_ENAB => true,
+            ODW::DISABLED => false,
+            ODW::OPEN_DRAIN => true,
         }
     }
 }
@@ -786,13 +786,13 @@ impl<'a> _ODW<'a> {
     }
     #[doc = "Disable."]
     #[inline]
-    pub fn disable_(self) -> &'a mut W {
-        self.variant(ODW::DISABLE_)
+    pub fn disabled(self) -> &'a mut W {
+        self.variant(ODW::DISABLED)
     }
     #[doc = "Open-drain mode enabled. This is not a true open-drain mode."]
     #[inline]
-    pub fn open_drain_mode_enab(self) -> &'a mut W {
-        self.variant(ODW::OPEN_DRAIN_MODE_ENAB)
+    pub fn open_drain(self) -> &'a mut W {
+        self.variant(ODW::OPEN_DRAIN)
     }
     #[doc = r" Sets the field bit"]
     pub fn set_bit(self) -> &'a mut W {

--- a/lpc11uxx/src/ssp0/cr1.rs
+++ b/lpc11uxx/src/ssp0/cr1.rs
@@ -46,9 +46,9 @@ impl super::CR1 {
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum LBMR {
     #[doc = "During normal operation."]
-    DURING_NORMAL_OPERAT,
+    NORMAL_OPERATION,
     #[doc = "Serial input is taken from the serial output (MOSI or MISO) rather than the serial input pin (MISO or MOSI respectively)."]
-    SERIAL_INPUT_IS_TAKE,
+    SERIAL_OUTPUT,
 }
 impl LBMR {
     #[doc = r" Returns `true` if the bit is clear (0)"]
@@ -65,8 +65,8 @@ impl LBMR {
     #[inline]
     pub fn bit(&self) -> bool {
         match *self {
-            LBMR::DURING_NORMAL_OPERAT => false,
-            LBMR::SERIAL_INPUT_IS_TAKE => true,
+            LBMR::NORMAL_OPERATION => false,
+            LBMR::SERIAL_OUTPUT => true,
         }
     }
     #[allow(missing_docs)]
@@ -74,19 +74,19 @@ impl LBMR {
     #[inline]
     pub fn _from(value: bool) -> LBMR {
         match value {
-            false => LBMR::DURING_NORMAL_OPERAT,
-            true => LBMR::SERIAL_INPUT_IS_TAKE,
+            false => LBMR::NORMAL_OPERATION,
+            true => LBMR::SERIAL_OUTPUT,
         }
     }
-    #[doc = "Checks if the value of the field is `DURING_NORMAL_OPERAT`"]
+    #[doc = "Checks if the value of the field is `NORMAL_OPERATION`"]
     #[inline]
-    pub fn is_during_normal_operat(&self) -> bool {
-        *self == LBMR::DURING_NORMAL_OPERAT
+    pub fn is_normal_operation(&self) -> bool {
+        *self == LBMR::NORMAL_OPERATION
     }
-    #[doc = "Checks if the value of the field is `SERIAL_INPUT_IS_TAKE`"]
+    #[doc = "Checks if the value of the field is `SERIAL_OUTPUT`"]
     #[inline]
-    pub fn is_serial_input_is_take(&self) -> bool {
-        *self == LBMR::SERIAL_INPUT_IS_TAKE
+    pub fn is_serial_output(&self) -> bool {
+        *self == LBMR::SERIAL_OUTPUT
     }
 }
 #[doc = "Possible values of the field `SSE`"]
@@ -207,9 +207,9 @@ impl SODR {
 #[doc = "Values that can be written to the field `LBM`"]
 pub enum LBMW {
     #[doc = "During normal operation."]
-    DURING_NORMAL_OPERAT,
+    NORMAL_OPERATION,
     #[doc = "Serial input is taken from the serial output (MOSI or MISO) rather than the serial input pin (MISO or MOSI respectively)."]
-    SERIAL_INPUT_IS_TAKE,
+    SERIAL_OUTPUT,
 }
 impl LBMW {
     #[allow(missing_docs)]
@@ -217,8 +217,8 @@ impl LBMW {
     #[inline]
     pub fn _bits(&self) -> bool {
         match *self {
-            LBMW::DURING_NORMAL_OPERAT => false,
-            LBMW::SERIAL_INPUT_IS_TAKE => true,
+            LBMW::NORMAL_OPERATION => false,
+            LBMW::SERIAL_OUTPUT => true,
         }
     }
 }
@@ -236,13 +236,13 @@ impl<'a> _LBMW<'a> {
     }
     #[doc = "During normal operation."]
     #[inline]
-    pub fn during_normal_operat(self) -> &'a mut W {
-        self.variant(LBMW::DURING_NORMAL_OPERAT)
+    pub fn normal_operation(self) -> &'a mut W {
+        self.variant(LBMW::NORMAL_OPERATION)
     }
     #[doc = "Serial input is taken from the serial output (MOSI or MISO) rather than the serial input pin (MISO or MOSI respectively)."]
     #[inline]
-    pub fn serial_input_is_take(self) -> &'a mut W {
-        self.variant(LBMW::SERIAL_INPUT_IS_TAKE)
+    pub fn serial_output(self) -> &'a mut W {
+        self.variant(LBMW::SERIAL_OUTPUT)
     }
     #[doc = r" Sets the field bit"]
     pub fn set_bit(self) -> &'a mut W {

--- a/lpc11uxx/src/syscon/bodctrl.rs
+++ b/lpc11uxx/src/syscon/bodctrl.rs
@@ -102,7 +102,7 @@ impl BODRSTLEVR {
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum BODINTVALR {
     #[doc = "Level 0: Reserved."]
-    LEVEL_0_RESERVED_,
+    LEVEL_0_RESERVED,
     #[doc = "Level 1:The interrupt assertion threshold voltage is 2.22 V; the interrupt de-assertion threshold voltage is 2.35 V."]
     LEVEL_1THE_INTERRUP,
     #[doc = "Level 2: The interrupt assertion threshold voltage is 2.52 V; the interrupt de-assertion threshold voltage is 2.66 V."]
@@ -115,7 +115,7 @@ impl BODINTVALR {
     #[inline]
     pub fn bits(&self) -> u8 {
         match *self {
-            BODINTVALR::LEVEL_0_RESERVED_ => 0,
+            BODINTVALR::LEVEL_0_RESERVED => 0,
             BODINTVALR::LEVEL_1THE_INTERRUP => 1,
             BODINTVALR::LEVEL_2_THE_INTERRU => 2,
             BODINTVALR::LEVEL_3_THE_INTERRU => 3,
@@ -126,17 +126,17 @@ impl BODINTVALR {
     #[inline]
     pub fn _from(value: u8) -> BODINTVALR {
         match value {
-            0 => BODINTVALR::LEVEL_0_RESERVED_,
+            0 => BODINTVALR::LEVEL_0_RESERVED,
             1 => BODINTVALR::LEVEL_1THE_INTERRUP,
             2 => BODINTVALR::LEVEL_2_THE_INTERRU,
             3 => BODINTVALR::LEVEL_3_THE_INTERRU,
             _ => unreachable!(),
         }
     }
-    #[doc = "Checks if the value of the field is `LEVEL_0_RESERVED_`"]
+    #[doc = "Checks if the value of the field is `LEVEL_0_RESERVED`"]
     #[inline]
-    pub fn is_level_0_reserved_(&self) -> bool {
-        *self == BODINTVALR::LEVEL_0_RESERVED_
+    pub fn is_level_0_reserved(&self) -> bool {
+        *self == BODINTVALR::LEVEL_0_RESERVED
     }
     #[doc = "Checks if the value of the field is `LEVEL_1THE_INTERRUP`"]
     #[inline]
@@ -270,7 +270,7 @@ impl<'a> _BODRSTLEVW<'a> {
 #[doc = "Values that can be written to the field `BODINTVAL`"]
 pub enum BODINTVALW {
     #[doc = "Level 0: Reserved."]
-    LEVEL_0_RESERVED_,
+    LEVEL_0_RESERVED,
     #[doc = "Level 1:The interrupt assertion threshold voltage is 2.22 V; the interrupt de-assertion threshold voltage is 2.35 V."]
     LEVEL_1THE_INTERRUP,
     #[doc = "Level 2: The interrupt assertion threshold voltage is 2.52 V; the interrupt de-assertion threshold voltage is 2.66 V."]
@@ -284,7 +284,7 @@ impl BODINTVALW {
     #[inline]
     pub fn _bits(&self) -> u8 {
         match *self {
-            BODINTVALW::LEVEL_0_RESERVED_ => 0,
+            BODINTVALW::LEVEL_0_RESERVED => 0,
             BODINTVALW::LEVEL_1THE_INTERRUP => 1,
             BODINTVALW::LEVEL_2_THE_INTERRU => 2,
             BODINTVALW::LEVEL_3_THE_INTERRU => 3,
@@ -305,8 +305,8 @@ impl<'a> _BODINTVALW<'a> {
     }
     #[doc = "Level 0: Reserved."]
     #[inline]
-    pub fn level_0_reserved_(self) -> &'a mut W {
-        self.variant(BODINTVALW::LEVEL_0_RESERVED_)
+    pub fn level_0_reserved(self) -> &'a mut W {
+        self.variant(BODINTVALW::LEVEL_0_RESERVED)
     }
     #[doc = "Level 1:The interrupt assertion threshold voltage is 2.22 V; the interrupt de-assertion threshold voltage is 2.35 V."]
     #[inline]

--- a/lpc11uxx/src/syscon/clkoutsel.rs
+++ b/lpc11uxx/src/syscon/clkoutsel.rs
@@ -48,7 +48,7 @@ pub enum SELR {
     #[doc = "IRC oscillator"]
     IRC_OSCILLATOR,
     #[doc = "Crystal oscillator (SYSOSC)"]
-    CRYSTAL_OSCILLATOR_,
+    CRYSTAL_OSCILLATOR,
     #[doc = "LF oscillator (watchdog oscillator)"]
     LF_OSCILLATOR_WATCH,
     #[doc = "Main clock"]
@@ -60,7 +60,7 @@ impl SELR {
     pub fn bits(&self) -> u8 {
         match *self {
             SELR::IRC_OSCILLATOR => 0,
-            SELR::CRYSTAL_OSCILLATOR_ => 1,
+            SELR::CRYSTAL_OSCILLATOR => 1,
             SELR::LF_OSCILLATOR_WATCH => 2,
             SELR::MAIN_CLOCK => 3,
         }
@@ -71,7 +71,7 @@ impl SELR {
     pub fn _from(value: u8) -> SELR {
         match value {
             0 => SELR::IRC_OSCILLATOR,
-            1 => SELR::CRYSTAL_OSCILLATOR_,
+            1 => SELR::CRYSTAL_OSCILLATOR,
             2 => SELR::LF_OSCILLATOR_WATCH,
             3 => SELR::MAIN_CLOCK,
             _ => unreachable!(),
@@ -82,10 +82,10 @@ impl SELR {
     pub fn is_irc_oscillator(&self) -> bool {
         *self == SELR::IRC_OSCILLATOR
     }
-    #[doc = "Checks if the value of the field is `CRYSTAL_OSCILLATOR_`"]
+    #[doc = "Checks if the value of the field is `CRYSTAL_OSCILLATOR`"]
     #[inline]
-    pub fn is_crystal_oscillator_(&self) -> bool {
-        *self == SELR::CRYSTAL_OSCILLATOR_
+    pub fn is_crystal_oscillator(&self) -> bool {
+        *self == SELR::CRYSTAL_OSCILLATOR
     }
     #[doc = "Checks if the value of the field is `LF_OSCILLATOR_WATCH`"]
     #[inline]
@@ -103,7 +103,7 @@ pub enum SELW {
     #[doc = "IRC oscillator"]
     IRC_OSCILLATOR,
     #[doc = "Crystal oscillator (SYSOSC)"]
-    CRYSTAL_OSCILLATOR_,
+    CRYSTAL_OSCILLATOR,
     #[doc = "LF oscillator (watchdog oscillator)"]
     LF_OSCILLATOR_WATCH,
     #[doc = "Main clock"]
@@ -116,7 +116,7 @@ impl SELW {
     pub fn _bits(&self) -> u8 {
         match *self {
             SELW::IRC_OSCILLATOR => 0,
-            SELW::CRYSTAL_OSCILLATOR_ => 1,
+            SELW::CRYSTAL_OSCILLATOR => 1,
             SELW::LF_OSCILLATOR_WATCH => 2,
             SELW::MAIN_CLOCK => 3,
         }
@@ -141,8 +141,8 @@ impl<'a> _SELW<'a> {
     }
     #[doc = "Crystal oscillator (SYSOSC)"]
     #[inline]
-    pub fn crystal_oscillator_(self) -> &'a mut W {
-        self.variant(SELW::CRYSTAL_OSCILLATOR_)
+    pub fn crystal_oscillator(self) -> &'a mut W {
+        self.variant(SELW::CRYSTAL_OSCILLATOR)
     }
     #[doc = "LF oscillator (watchdog oscillator)"]
     #[inline]

--- a/lpc11uxx/src/syscon/sysahbclkctrl.rs
+++ b/lpc11uxx/src/syscon/sysahbclkctrl.rs
@@ -46,7 +46,7 @@ impl super::SYSAHBCLKCTRL {
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum SYSR {
     #[doc = "Enable"]
-    ENABLE,
+    ENABLED,
 }
 impl SYSR {
     #[doc = r" Returns `true` if the bit is clear (0)"]
@@ -63,7 +63,7 @@ impl SYSR {
     #[inline]
     pub fn bit(&self) -> bool {
         match *self {
-            SYSR::ENABLE => true,
+            SYSR::ENABLED => true,
         }
     }
     #[allow(missing_docs)]
@@ -71,23 +71,23 @@ impl SYSR {
     #[inline]
     pub fn _from(value: bool) -> SYSR {
         match value {
-            true => SYSR::ENABLE,
+            true => SYSR::ENABLED,
             _ => unreachable!(),
         }
     }
-    #[doc = "Checks if the value of the field is `ENABLE`"]
+    #[doc = "Checks if the value of the field is `ENABLED`"]
     #[inline]
-    pub fn is_enable(&self) -> bool {
-        *self == SYSR::ENABLE
+    pub fn is_enabled(&self) -> bool {
+        *self == SYSR::ENABLED
     }
 }
 #[doc = "Possible values of the field `ROM`"]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum ROMR {
     #[doc = "Disable"]
-    DISABLE,
+    DISABLED,
     #[doc = "Enable"]
-    ENABLE,
+    ENABLED,
 }
 impl ROMR {
     #[doc = r" Returns `true` if the bit is clear (0)"]
@@ -104,8 +104,8 @@ impl ROMR {
     #[inline]
     pub fn bit(&self) -> bool {
         match *self {
-            ROMR::DISABLE => false,
-            ROMR::ENABLE => true,
+            ROMR::DISABLED => false,
+            ROMR::ENABLED => true,
         }
     }
     #[allow(missing_docs)]
@@ -113,28 +113,28 @@ impl ROMR {
     #[inline]
     pub fn _from(value: bool) -> ROMR {
         match value {
-            false => ROMR::DISABLE,
-            true => ROMR::ENABLE,
+            false => ROMR::DISABLED,
+            true => ROMR::ENABLED,
         }
     }
-    #[doc = "Checks if the value of the field is `DISABLE`"]
+    #[doc = "Checks if the value of the field is `DISABLED`"]
     #[inline]
-    pub fn is_disable(&self) -> bool {
-        *self == ROMR::DISABLE
+    pub fn is_disabled(&self) -> bool {
+        *self == ROMR::DISABLED
     }
-    #[doc = "Checks if the value of the field is `ENABLE`"]
+    #[doc = "Checks if the value of the field is `ENABLED`"]
     #[inline]
-    pub fn is_enable(&self) -> bool {
-        *self == ROMR::ENABLE
+    pub fn is_enabled(&self) -> bool {
+        *self == ROMR::ENABLED
     }
 }
 #[doc = "Possible values of the field `RAM0`"]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum RAM0R {
     #[doc = "Disable"]
-    DISABLE,
+    DISABLED,
     #[doc = "Enable"]
-    ENABLE,
+    ENABLED,
 }
 impl RAM0R {
     #[doc = r" Returns `true` if the bit is clear (0)"]
@@ -151,8 +151,8 @@ impl RAM0R {
     #[inline]
     pub fn bit(&self) -> bool {
         match *self {
-            RAM0R::DISABLE => false,
-            RAM0R::ENABLE => true,
+            RAM0R::DISABLED => false,
+            RAM0R::ENABLED => true,
         }
     }
     #[allow(missing_docs)]
@@ -160,28 +160,28 @@ impl RAM0R {
     #[inline]
     pub fn _from(value: bool) -> RAM0R {
         match value {
-            false => RAM0R::DISABLE,
-            true => RAM0R::ENABLE,
+            false => RAM0R::DISABLED,
+            true => RAM0R::ENABLED,
         }
     }
-    #[doc = "Checks if the value of the field is `DISABLE`"]
+    #[doc = "Checks if the value of the field is `DISABLED`"]
     #[inline]
-    pub fn is_disable(&self) -> bool {
-        *self == RAM0R::DISABLE
+    pub fn is_disabled(&self) -> bool {
+        *self == RAM0R::DISABLED
     }
-    #[doc = "Checks if the value of the field is `ENABLE`"]
+    #[doc = "Checks if the value of the field is `ENABLED`"]
     #[inline]
-    pub fn is_enable(&self) -> bool {
-        *self == RAM0R::ENABLE
+    pub fn is_enabled(&self) -> bool {
+        *self == RAM0R::ENABLED
     }
 }
 #[doc = "Possible values of the field `FLASHREG`"]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum FLASHREGR {
     #[doc = "Disable"]
-    DISABLE,
+    DISABLED,
     #[doc = "Enable"]
-    ENABLE,
+    ENABLED,
 }
 impl FLASHREGR {
     #[doc = r" Returns `true` if the bit is clear (0)"]
@@ -198,8 +198,8 @@ impl FLASHREGR {
     #[inline]
     pub fn bit(&self) -> bool {
         match *self {
-            FLASHREGR::DISABLE => false,
-            FLASHREGR::ENABLE => true,
+            FLASHREGR::DISABLED => false,
+            FLASHREGR::ENABLED => true,
         }
     }
     #[allow(missing_docs)]
@@ -207,28 +207,28 @@ impl FLASHREGR {
     #[inline]
     pub fn _from(value: bool) -> FLASHREGR {
         match value {
-            false => FLASHREGR::DISABLE,
-            true => FLASHREGR::ENABLE,
+            false => FLASHREGR::DISABLED,
+            true => FLASHREGR::ENABLED,
         }
     }
-    #[doc = "Checks if the value of the field is `DISABLE`"]
+    #[doc = "Checks if the value of the field is `DISABLED`"]
     #[inline]
-    pub fn is_disable(&self) -> bool {
-        *self == FLASHREGR::DISABLE
+    pub fn is_disabled(&self) -> bool {
+        *self == FLASHREGR::DISABLED
     }
-    #[doc = "Checks if the value of the field is `ENABLE`"]
+    #[doc = "Checks if the value of the field is `ENABLED`"]
     #[inline]
-    pub fn is_enable(&self) -> bool {
-        *self == FLASHREGR::ENABLE
+    pub fn is_enabled(&self) -> bool {
+        *self == FLASHREGR::ENABLED
     }
 }
 #[doc = "Possible values of the field `FLASHARRAY`"]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum FLASHARRAYR {
     #[doc = "Disable"]
-    DISABLE,
+    DISABLED,
     #[doc = "Enable"]
-    ENABLE,
+    ENABLED,
 }
 impl FLASHARRAYR {
     #[doc = r" Returns `true` if the bit is clear (0)"]
@@ -245,8 +245,8 @@ impl FLASHARRAYR {
     #[inline]
     pub fn bit(&self) -> bool {
         match *self {
-            FLASHARRAYR::DISABLE => false,
-            FLASHARRAYR::ENABLE => true,
+            FLASHARRAYR::DISABLED => false,
+            FLASHARRAYR::ENABLED => true,
         }
     }
     #[allow(missing_docs)]
@@ -254,28 +254,28 @@ impl FLASHARRAYR {
     #[inline]
     pub fn _from(value: bool) -> FLASHARRAYR {
         match value {
-            false => FLASHARRAYR::DISABLE,
-            true => FLASHARRAYR::ENABLE,
+            false => FLASHARRAYR::DISABLED,
+            true => FLASHARRAYR::ENABLED,
         }
     }
-    #[doc = "Checks if the value of the field is `DISABLE`"]
+    #[doc = "Checks if the value of the field is `DISABLED`"]
     #[inline]
-    pub fn is_disable(&self) -> bool {
-        *self == FLASHARRAYR::DISABLE
+    pub fn is_disabled(&self) -> bool {
+        *self == FLASHARRAYR::DISABLED
     }
-    #[doc = "Checks if the value of the field is `ENABLE`"]
+    #[doc = "Checks if the value of the field is `ENABLED`"]
     #[inline]
-    pub fn is_enable(&self) -> bool {
-        *self == FLASHARRAYR::ENABLE
+    pub fn is_enabled(&self) -> bool {
+        *self == FLASHARRAYR::ENABLED
     }
 }
 #[doc = "Possible values of the field `I2C`"]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum I2CR {
     #[doc = "Disable"]
-    DISABLE,
+    DISABLED,
     #[doc = "Enable"]
-    ENABLE,
+    ENABLED,
 }
 impl I2CR {
     #[doc = r" Returns `true` if the bit is clear (0)"]
@@ -292,8 +292,8 @@ impl I2CR {
     #[inline]
     pub fn bit(&self) -> bool {
         match *self {
-            I2CR::DISABLE => false,
-            I2CR::ENABLE => true,
+            I2CR::DISABLED => false,
+            I2CR::ENABLED => true,
         }
     }
     #[allow(missing_docs)]
@@ -301,28 +301,28 @@ impl I2CR {
     #[inline]
     pub fn _from(value: bool) -> I2CR {
         match value {
-            false => I2CR::DISABLE,
-            true => I2CR::ENABLE,
+            false => I2CR::DISABLED,
+            true => I2CR::ENABLED,
         }
     }
-    #[doc = "Checks if the value of the field is `DISABLE`"]
+    #[doc = "Checks if the value of the field is `DISABLED`"]
     #[inline]
-    pub fn is_disable(&self) -> bool {
-        *self == I2CR::DISABLE
+    pub fn is_disabled(&self) -> bool {
+        *self == I2CR::DISABLED
     }
-    #[doc = "Checks if the value of the field is `ENABLE`"]
+    #[doc = "Checks if the value of the field is `ENABLED`"]
     #[inline]
-    pub fn is_enable(&self) -> bool {
-        *self == I2CR::ENABLE
+    pub fn is_enabled(&self) -> bool {
+        *self == I2CR::ENABLED
     }
 }
 #[doc = "Possible values of the field `GPIO`"]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum GPIOR {
     #[doc = "Disable"]
-    DISABLE,
+    DISABLED,
     #[doc = "Enable"]
-    ENABLE,
+    ENABLED,
 }
 impl GPIOR {
     #[doc = r" Returns `true` if the bit is clear (0)"]
@@ -339,8 +339,8 @@ impl GPIOR {
     #[inline]
     pub fn bit(&self) -> bool {
         match *self {
-            GPIOR::DISABLE => false,
-            GPIOR::ENABLE => true,
+            GPIOR::DISABLED => false,
+            GPIOR::ENABLED => true,
         }
     }
     #[allow(missing_docs)]
@@ -348,28 +348,28 @@ impl GPIOR {
     #[inline]
     pub fn _from(value: bool) -> GPIOR {
         match value {
-            false => GPIOR::DISABLE,
-            true => GPIOR::ENABLE,
+            false => GPIOR::DISABLED,
+            true => GPIOR::ENABLED,
         }
     }
-    #[doc = "Checks if the value of the field is `DISABLE`"]
+    #[doc = "Checks if the value of the field is `DISABLED`"]
     #[inline]
-    pub fn is_disable(&self) -> bool {
-        *self == GPIOR::DISABLE
+    pub fn is_disabled(&self) -> bool {
+        *self == GPIOR::DISABLED
     }
-    #[doc = "Checks if the value of the field is `ENABLE`"]
+    #[doc = "Checks if the value of the field is `ENABLED`"]
     #[inline]
-    pub fn is_enable(&self) -> bool {
-        *self == GPIOR::ENABLE
+    pub fn is_enabled(&self) -> bool {
+        *self == GPIOR::ENABLED
     }
 }
 #[doc = "Possible values of the field `CT16B0`"]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum CT16B0R {
     #[doc = "Disable"]
-    DISABLE,
+    DISABLED,
     #[doc = "Enable"]
-    ENABLE,
+    ENABLED,
 }
 impl CT16B0R {
     #[doc = r" Returns `true` if the bit is clear (0)"]
@@ -386,8 +386,8 @@ impl CT16B0R {
     #[inline]
     pub fn bit(&self) -> bool {
         match *self {
-            CT16B0R::DISABLE => false,
-            CT16B0R::ENABLE => true,
+            CT16B0R::DISABLED => false,
+            CT16B0R::ENABLED => true,
         }
     }
     #[allow(missing_docs)]
@@ -395,28 +395,28 @@ impl CT16B0R {
     #[inline]
     pub fn _from(value: bool) -> CT16B0R {
         match value {
-            false => CT16B0R::DISABLE,
-            true => CT16B0R::ENABLE,
+            false => CT16B0R::DISABLED,
+            true => CT16B0R::ENABLED,
         }
     }
-    #[doc = "Checks if the value of the field is `DISABLE`"]
+    #[doc = "Checks if the value of the field is `DISABLED`"]
     #[inline]
-    pub fn is_disable(&self) -> bool {
-        *self == CT16B0R::DISABLE
+    pub fn is_disabled(&self) -> bool {
+        *self == CT16B0R::DISABLED
     }
-    #[doc = "Checks if the value of the field is `ENABLE`"]
+    #[doc = "Checks if the value of the field is `ENABLED`"]
     #[inline]
-    pub fn is_enable(&self) -> bool {
-        *self == CT16B0R::ENABLE
+    pub fn is_enabled(&self) -> bool {
+        *self == CT16B0R::ENABLED
     }
 }
 #[doc = "Possible values of the field `CT16B1`"]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum CT16B1R {
     #[doc = "Disable"]
-    DISABLE,
+    DISABLED,
     #[doc = "Enable"]
-    ENABLE,
+    ENABLED,
 }
 impl CT16B1R {
     #[doc = r" Returns `true` if the bit is clear (0)"]
@@ -433,8 +433,8 @@ impl CT16B1R {
     #[inline]
     pub fn bit(&self) -> bool {
         match *self {
-            CT16B1R::DISABLE => false,
-            CT16B1R::ENABLE => true,
+            CT16B1R::DISABLED => false,
+            CT16B1R::ENABLED => true,
         }
     }
     #[allow(missing_docs)]
@@ -442,28 +442,28 @@ impl CT16B1R {
     #[inline]
     pub fn _from(value: bool) -> CT16B1R {
         match value {
-            false => CT16B1R::DISABLE,
-            true => CT16B1R::ENABLE,
+            false => CT16B1R::DISABLED,
+            true => CT16B1R::ENABLED,
         }
     }
-    #[doc = "Checks if the value of the field is `DISABLE`"]
+    #[doc = "Checks if the value of the field is `DISABLED`"]
     #[inline]
-    pub fn is_disable(&self) -> bool {
-        *self == CT16B1R::DISABLE
+    pub fn is_disabled(&self) -> bool {
+        *self == CT16B1R::DISABLED
     }
-    #[doc = "Checks if the value of the field is `ENABLE`"]
+    #[doc = "Checks if the value of the field is `ENABLED`"]
     #[inline]
-    pub fn is_enable(&self) -> bool {
-        *self == CT16B1R::ENABLE
+    pub fn is_enabled(&self) -> bool {
+        *self == CT16B1R::ENABLED
     }
 }
 #[doc = "Possible values of the field `CT32B0`"]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum CT32B0R {
     #[doc = "Disable"]
-    DISABLE,
+    DISABLED,
     #[doc = "Enable"]
-    ENABLE,
+    ENABLED,
 }
 impl CT32B0R {
     #[doc = r" Returns `true` if the bit is clear (0)"]
@@ -480,8 +480,8 @@ impl CT32B0R {
     #[inline]
     pub fn bit(&self) -> bool {
         match *self {
-            CT32B0R::DISABLE => false,
-            CT32B0R::ENABLE => true,
+            CT32B0R::DISABLED => false,
+            CT32B0R::ENABLED => true,
         }
     }
     #[allow(missing_docs)]
@@ -489,28 +489,28 @@ impl CT32B0R {
     #[inline]
     pub fn _from(value: bool) -> CT32B0R {
         match value {
-            false => CT32B0R::DISABLE,
-            true => CT32B0R::ENABLE,
+            false => CT32B0R::DISABLED,
+            true => CT32B0R::ENABLED,
         }
     }
-    #[doc = "Checks if the value of the field is `DISABLE`"]
+    #[doc = "Checks if the value of the field is `DISABLED`"]
     #[inline]
-    pub fn is_disable(&self) -> bool {
-        *self == CT32B0R::DISABLE
+    pub fn is_disabled(&self) -> bool {
+        *self == CT32B0R::DISABLED
     }
-    #[doc = "Checks if the value of the field is `ENABLE`"]
+    #[doc = "Checks if the value of the field is `ENABLED`"]
     #[inline]
-    pub fn is_enable(&self) -> bool {
-        *self == CT32B0R::ENABLE
+    pub fn is_enabled(&self) -> bool {
+        *self == CT32B0R::ENABLED
     }
 }
 #[doc = "Possible values of the field `CT32B1`"]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum CT32B1R {
     #[doc = "Disable"]
-    DISABLE,
+    DISABLED,
     #[doc = "Enable"]
-    ENABLE,
+    ENABLED,
 }
 impl CT32B1R {
     #[doc = r" Returns `true` if the bit is clear (0)"]
@@ -527,8 +527,8 @@ impl CT32B1R {
     #[inline]
     pub fn bit(&self) -> bool {
         match *self {
-            CT32B1R::DISABLE => false,
-            CT32B1R::ENABLE => true,
+            CT32B1R::DISABLED => false,
+            CT32B1R::ENABLED => true,
         }
     }
     #[allow(missing_docs)]
@@ -536,28 +536,28 @@ impl CT32B1R {
     #[inline]
     pub fn _from(value: bool) -> CT32B1R {
         match value {
-            false => CT32B1R::DISABLE,
-            true => CT32B1R::ENABLE,
+            false => CT32B1R::DISABLED,
+            true => CT32B1R::ENABLED,
         }
     }
-    #[doc = "Checks if the value of the field is `DISABLE`"]
+    #[doc = "Checks if the value of the field is `DISABLED`"]
     #[inline]
-    pub fn is_disable(&self) -> bool {
-        *self == CT32B1R::DISABLE
+    pub fn is_disabled(&self) -> bool {
+        *self == CT32B1R::DISABLED
     }
-    #[doc = "Checks if the value of the field is `ENABLE`"]
+    #[doc = "Checks if the value of the field is `ENABLED`"]
     #[inline]
-    pub fn is_enable(&self) -> bool {
-        *self == CT32B1R::ENABLE
+    pub fn is_enabled(&self) -> bool {
+        *self == CT32B1R::ENABLED
     }
 }
 #[doc = "Possible values of the field `SSP0`"]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum SSP0R {
     #[doc = "Disable"]
-    DISABLE,
+    DISABLED,
     #[doc = "Enable"]
-    ENABLE,
+    ENABLED,
 }
 impl SSP0R {
     #[doc = r" Returns `true` if the bit is clear (0)"]
@@ -574,8 +574,8 @@ impl SSP0R {
     #[inline]
     pub fn bit(&self) -> bool {
         match *self {
-            SSP0R::DISABLE => false,
-            SSP0R::ENABLE => true,
+            SSP0R::DISABLED => false,
+            SSP0R::ENABLED => true,
         }
     }
     #[allow(missing_docs)]
@@ -583,28 +583,28 @@ impl SSP0R {
     #[inline]
     pub fn _from(value: bool) -> SSP0R {
         match value {
-            false => SSP0R::DISABLE,
-            true => SSP0R::ENABLE,
+            false => SSP0R::DISABLED,
+            true => SSP0R::ENABLED,
         }
     }
-    #[doc = "Checks if the value of the field is `DISABLE`"]
+    #[doc = "Checks if the value of the field is `DISABLED`"]
     #[inline]
-    pub fn is_disable(&self) -> bool {
-        *self == SSP0R::DISABLE
+    pub fn is_disabled(&self) -> bool {
+        *self == SSP0R::DISABLED
     }
-    #[doc = "Checks if the value of the field is `ENABLE`"]
+    #[doc = "Checks if the value of the field is `ENABLED`"]
     #[inline]
-    pub fn is_enable(&self) -> bool {
-        *self == SSP0R::ENABLE
+    pub fn is_enabled(&self) -> bool {
+        *self == SSP0R::ENABLED
     }
 }
 #[doc = "Possible values of the field `USART`"]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum USARTR {
     #[doc = "Disable"]
-    DISABLE,
+    DISABLED,
     #[doc = "Enable"]
-    ENABLE,
+    ENABLED,
 }
 impl USARTR {
     #[doc = r" Returns `true` if the bit is clear (0)"]
@@ -621,8 +621,8 @@ impl USARTR {
     #[inline]
     pub fn bit(&self) -> bool {
         match *self {
-            USARTR::DISABLE => false,
-            USARTR::ENABLE => true,
+            USARTR::DISABLED => false,
+            USARTR::ENABLED => true,
         }
     }
     #[allow(missing_docs)]
@@ -630,28 +630,28 @@ impl USARTR {
     #[inline]
     pub fn _from(value: bool) -> USARTR {
         match value {
-            false => USARTR::DISABLE,
-            true => USARTR::ENABLE,
+            false => USARTR::DISABLED,
+            true => USARTR::ENABLED,
         }
     }
-    #[doc = "Checks if the value of the field is `DISABLE`"]
+    #[doc = "Checks if the value of the field is `DISABLED`"]
     #[inline]
-    pub fn is_disable(&self) -> bool {
-        *self == USARTR::DISABLE
+    pub fn is_disabled(&self) -> bool {
+        *self == USARTR::DISABLED
     }
-    #[doc = "Checks if the value of the field is `ENABLE`"]
+    #[doc = "Checks if the value of the field is `ENABLED`"]
     #[inline]
-    pub fn is_enable(&self) -> bool {
-        *self == USARTR::ENABLE
+    pub fn is_enabled(&self) -> bool {
+        *self == USARTR::ENABLED
     }
 }
 #[doc = "Possible values of the field `ADC`"]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum ADCR {
     #[doc = "Disable"]
-    DISABLE,
+    DISABLED,
     #[doc = "Enable"]
-    ENABLE,
+    ENABLED,
 }
 impl ADCR {
     #[doc = r" Returns `true` if the bit is clear (0)"]
@@ -668,8 +668,8 @@ impl ADCR {
     #[inline]
     pub fn bit(&self) -> bool {
         match *self {
-            ADCR::DISABLE => false,
-            ADCR::ENABLE => true,
+            ADCR::DISABLED => false,
+            ADCR::ENABLED => true,
         }
     }
     #[allow(missing_docs)]
@@ -677,28 +677,28 @@ impl ADCR {
     #[inline]
     pub fn _from(value: bool) -> ADCR {
         match value {
-            false => ADCR::DISABLE,
-            true => ADCR::ENABLE,
+            false => ADCR::DISABLED,
+            true => ADCR::ENABLED,
         }
     }
-    #[doc = "Checks if the value of the field is `DISABLE`"]
+    #[doc = "Checks if the value of the field is `DISABLED`"]
     #[inline]
-    pub fn is_disable(&self) -> bool {
-        *self == ADCR::DISABLE
+    pub fn is_disabled(&self) -> bool {
+        *self == ADCR::DISABLED
     }
-    #[doc = "Checks if the value of the field is `ENABLE`"]
+    #[doc = "Checks if the value of the field is `ENABLED`"]
     #[inline]
-    pub fn is_enable(&self) -> bool {
-        *self == ADCR::ENABLE
+    pub fn is_enabled(&self) -> bool {
+        *self == ADCR::ENABLED
     }
 }
 #[doc = "Possible values of the field `USB`"]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum USBR {
     #[doc = "Disable"]
-    DISABLE,
+    DISABLED,
     #[doc = "Enable"]
-    ENABLE,
+    ENABLED,
 }
 impl USBR {
     #[doc = r" Returns `true` if the bit is clear (0)"]
@@ -715,8 +715,8 @@ impl USBR {
     #[inline]
     pub fn bit(&self) -> bool {
         match *self {
-            USBR::DISABLE => false,
-            USBR::ENABLE => true,
+            USBR::DISABLED => false,
+            USBR::ENABLED => true,
         }
     }
     #[allow(missing_docs)]
@@ -724,28 +724,28 @@ impl USBR {
     #[inline]
     pub fn _from(value: bool) -> USBR {
         match value {
-            false => USBR::DISABLE,
-            true => USBR::ENABLE,
+            false => USBR::DISABLED,
+            true => USBR::ENABLED,
         }
     }
-    #[doc = "Checks if the value of the field is `DISABLE`"]
+    #[doc = "Checks if the value of the field is `DISABLED`"]
     #[inline]
-    pub fn is_disable(&self) -> bool {
-        *self == USBR::DISABLE
+    pub fn is_disabled(&self) -> bool {
+        *self == USBR::DISABLED
     }
-    #[doc = "Checks if the value of the field is `ENABLE`"]
+    #[doc = "Checks if the value of the field is `ENABLED`"]
     #[inline]
-    pub fn is_enable(&self) -> bool {
-        *self == USBR::ENABLE
+    pub fn is_enabled(&self) -> bool {
+        *self == USBR::ENABLED
     }
 }
 #[doc = "Possible values of the field `WWDT`"]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum WWDTR {
     #[doc = "Disable"]
-    DISABLE,
+    DISABLED,
     #[doc = "Enable"]
-    ENABLE,
+    ENABLED,
 }
 impl WWDTR {
     #[doc = r" Returns `true` if the bit is clear (0)"]
@@ -762,8 +762,8 @@ impl WWDTR {
     #[inline]
     pub fn bit(&self) -> bool {
         match *self {
-            WWDTR::DISABLE => false,
-            WWDTR::ENABLE => true,
+            WWDTR::DISABLED => false,
+            WWDTR::ENABLED => true,
         }
     }
     #[allow(missing_docs)]
@@ -771,28 +771,28 @@ impl WWDTR {
     #[inline]
     pub fn _from(value: bool) -> WWDTR {
         match value {
-            false => WWDTR::DISABLE,
-            true => WWDTR::ENABLE,
+            false => WWDTR::DISABLED,
+            true => WWDTR::ENABLED,
         }
     }
-    #[doc = "Checks if the value of the field is `DISABLE`"]
+    #[doc = "Checks if the value of the field is `DISABLED`"]
     #[inline]
-    pub fn is_disable(&self) -> bool {
-        *self == WWDTR::DISABLE
+    pub fn is_disabled(&self) -> bool {
+        *self == WWDTR::DISABLED
     }
-    #[doc = "Checks if the value of the field is `ENABLE`"]
+    #[doc = "Checks if the value of the field is `ENABLED`"]
     #[inline]
-    pub fn is_enable(&self) -> bool {
-        *self == WWDTR::ENABLE
+    pub fn is_enabled(&self) -> bool {
+        *self == WWDTR::ENABLED
     }
 }
 #[doc = "Possible values of the field `IOCON`"]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum IOCONR {
     #[doc = "Disable"]
-    DISABLE,
+    DISABLED,
     #[doc = "Enable"]
-    ENABLE,
+    ENABLED,
 }
 impl IOCONR {
     #[doc = r" Returns `true` if the bit is clear (0)"]
@@ -809,8 +809,8 @@ impl IOCONR {
     #[inline]
     pub fn bit(&self) -> bool {
         match *self {
-            IOCONR::DISABLE => false,
-            IOCONR::ENABLE => true,
+            IOCONR::DISABLED => false,
+            IOCONR::ENABLED => true,
         }
     }
     #[allow(missing_docs)]
@@ -818,28 +818,28 @@ impl IOCONR {
     #[inline]
     pub fn _from(value: bool) -> IOCONR {
         match value {
-            false => IOCONR::DISABLE,
-            true => IOCONR::ENABLE,
+            false => IOCONR::DISABLED,
+            true => IOCONR::ENABLED,
         }
     }
-    #[doc = "Checks if the value of the field is `DISABLE`"]
+    #[doc = "Checks if the value of the field is `DISABLED`"]
     #[inline]
-    pub fn is_disable(&self) -> bool {
-        *self == IOCONR::DISABLE
+    pub fn is_disabled(&self) -> bool {
+        *self == IOCONR::DISABLED
     }
-    #[doc = "Checks if the value of the field is `ENABLE`"]
+    #[doc = "Checks if the value of the field is `ENABLED`"]
     #[inline]
-    pub fn is_enable(&self) -> bool {
-        *self == IOCONR::ENABLE
+    pub fn is_enabled(&self) -> bool {
+        *self == IOCONR::ENABLED
     }
 }
 #[doc = "Possible values of the field `SSP1`"]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum SSP1R {
     #[doc = "Disable"]
-    DISABLE,
+    DISABLED,
     #[doc = "Enable"]
-    ENABLE,
+    ENABLED,
 }
 impl SSP1R {
     #[doc = r" Returns `true` if the bit is clear (0)"]
@@ -856,8 +856,8 @@ impl SSP1R {
     #[inline]
     pub fn bit(&self) -> bool {
         match *self {
-            SSP1R::DISABLE => false,
-            SSP1R::ENABLE => true,
+            SSP1R::DISABLED => false,
+            SSP1R::ENABLED => true,
         }
     }
     #[allow(missing_docs)]
@@ -865,28 +865,28 @@ impl SSP1R {
     #[inline]
     pub fn _from(value: bool) -> SSP1R {
         match value {
-            false => SSP1R::DISABLE,
-            true => SSP1R::ENABLE,
+            false => SSP1R::DISABLED,
+            true => SSP1R::ENABLED,
         }
     }
-    #[doc = "Checks if the value of the field is `DISABLE`"]
+    #[doc = "Checks if the value of the field is `DISABLED`"]
     #[inline]
-    pub fn is_disable(&self) -> bool {
-        *self == SSP1R::DISABLE
+    pub fn is_disabled(&self) -> bool {
+        *self == SSP1R::DISABLED
     }
-    #[doc = "Checks if the value of the field is `ENABLE`"]
+    #[doc = "Checks if the value of the field is `ENABLED`"]
     #[inline]
-    pub fn is_enable(&self) -> bool {
-        *self == SSP1R::ENABLE
+    pub fn is_enabled(&self) -> bool {
+        *self == SSP1R::ENABLED
     }
 }
 #[doc = "Possible values of the field `PINT`"]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum PINTR {
     #[doc = "Disable"]
-    DISABLE,
+    DISABLED,
     #[doc = "Enable"]
-    ENABLE,
+    ENABLED,
 }
 impl PINTR {
     #[doc = r" Returns `true` if the bit is clear (0)"]
@@ -903,8 +903,8 @@ impl PINTR {
     #[inline]
     pub fn bit(&self) -> bool {
         match *self {
-            PINTR::DISABLE => false,
-            PINTR::ENABLE => true,
+            PINTR::DISABLED => false,
+            PINTR::ENABLED => true,
         }
     }
     #[allow(missing_docs)]
@@ -912,28 +912,28 @@ impl PINTR {
     #[inline]
     pub fn _from(value: bool) -> PINTR {
         match value {
-            false => PINTR::DISABLE,
-            true => PINTR::ENABLE,
+            false => PINTR::DISABLED,
+            true => PINTR::ENABLED,
         }
     }
-    #[doc = "Checks if the value of the field is `DISABLE`"]
+    #[doc = "Checks if the value of the field is `DISABLED`"]
     #[inline]
-    pub fn is_disable(&self) -> bool {
-        *self == PINTR::DISABLE
+    pub fn is_disabled(&self) -> bool {
+        *self == PINTR::DISABLED
     }
-    #[doc = "Checks if the value of the field is `ENABLE`"]
+    #[doc = "Checks if the value of the field is `ENABLED`"]
     #[inline]
-    pub fn is_enable(&self) -> bool {
-        *self == PINTR::ENABLE
+    pub fn is_enabled(&self) -> bool {
+        *self == PINTR::ENABLED
     }
 }
 #[doc = "Possible values of the field `GROUP0INT`"]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum GROUP0INTR {
     #[doc = "Disable"]
-    DISABLE,
+    DISABLED,
     #[doc = "Enable"]
-    ENABLE,
+    ENABLED,
 }
 impl GROUP0INTR {
     #[doc = r" Returns `true` if the bit is clear (0)"]
@@ -950,8 +950,8 @@ impl GROUP0INTR {
     #[inline]
     pub fn bit(&self) -> bool {
         match *self {
-            GROUP0INTR::DISABLE => false,
-            GROUP0INTR::ENABLE => true,
+            GROUP0INTR::DISABLED => false,
+            GROUP0INTR::ENABLED => true,
         }
     }
     #[allow(missing_docs)]
@@ -959,28 +959,28 @@ impl GROUP0INTR {
     #[inline]
     pub fn _from(value: bool) -> GROUP0INTR {
         match value {
-            false => GROUP0INTR::DISABLE,
-            true => GROUP0INTR::ENABLE,
+            false => GROUP0INTR::DISABLED,
+            true => GROUP0INTR::ENABLED,
         }
     }
-    #[doc = "Checks if the value of the field is `DISABLE`"]
+    #[doc = "Checks if the value of the field is `DISABLED`"]
     #[inline]
-    pub fn is_disable(&self) -> bool {
-        *self == GROUP0INTR::DISABLE
+    pub fn is_disabled(&self) -> bool {
+        *self == GROUP0INTR::DISABLED
     }
-    #[doc = "Checks if the value of the field is `ENABLE`"]
+    #[doc = "Checks if the value of the field is `ENABLED`"]
     #[inline]
-    pub fn is_enable(&self) -> bool {
-        *self == GROUP0INTR::ENABLE
+    pub fn is_enabled(&self) -> bool {
+        *self == GROUP0INTR::ENABLED
     }
 }
 #[doc = "Possible values of the field `GROUP1INT`"]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum GROUP1INTR {
     #[doc = "Disable"]
-    DISABLE,
+    DISABLED,
     #[doc = "Enable"]
-    ENABLE,
+    ENABLED,
 }
 impl GROUP1INTR {
     #[doc = r" Returns `true` if the bit is clear (0)"]
@@ -997,8 +997,8 @@ impl GROUP1INTR {
     #[inline]
     pub fn bit(&self) -> bool {
         match *self {
-            GROUP1INTR::DISABLE => false,
-            GROUP1INTR::ENABLE => true,
+            GROUP1INTR::DISABLED => false,
+            GROUP1INTR::ENABLED => true,
         }
     }
     #[allow(missing_docs)]
@@ -1006,28 +1006,28 @@ impl GROUP1INTR {
     #[inline]
     pub fn _from(value: bool) -> GROUP1INTR {
         match value {
-            false => GROUP1INTR::DISABLE,
-            true => GROUP1INTR::ENABLE,
+            false => GROUP1INTR::DISABLED,
+            true => GROUP1INTR::ENABLED,
         }
     }
-    #[doc = "Checks if the value of the field is `DISABLE`"]
+    #[doc = "Checks if the value of the field is `DISABLED`"]
     #[inline]
-    pub fn is_disable(&self) -> bool {
-        *self == GROUP1INTR::DISABLE
+    pub fn is_disabled(&self) -> bool {
+        *self == GROUP1INTR::DISABLED
     }
-    #[doc = "Checks if the value of the field is `ENABLE`"]
+    #[doc = "Checks if the value of the field is `ENABLED`"]
     #[inline]
-    pub fn is_enable(&self) -> bool {
-        *self == GROUP1INTR::ENABLE
+    pub fn is_enabled(&self) -> bool {
+        *self == GROUP1INTR::ENABLED
     }
 }
 #[doc = "Possible values of the field `RAM1`"]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum RAM1R {
     #[doc = "Disable"]
-    DISABLE,
+    DISABLED,
     #[doc = "Enable"]
-    ENABLE,
+    ENABLED,
 }
 impl RAM1R {
     #[doc = r" Returns `true` if the bit is clear (0)"]
@@ -1044,8 +1044,8 @@ impl RAM1R {
     #[inline]
     pub fn bit(&self) -> bool {
         match *self {
-            RAM1R::DISABLE => false,
-            RAM1R::ENABLE => true,
+            RAM1R::DISABLED => false,
+            RAM1R::ENABLED => true,
         }
     }
     #[allow(missing_docs)]
@@ -1053,28 +1053,28 @@ impl RAM1R {
     #[inline]
     pub fn _from(value: bool) -> RAM1R {
         match value {
-            false => RAM1R::DISABLE,
-            true => RAM1R::ENABLE,
+            false => RAM1R::DISABLED,
+            true => RAM1R::ENABLED,
         }
     }
-    #[doc = "Checks if the value of the field is `DISABLE`"]
+    #[doc = "Checks if the value of the field is `DISABLED`"]
     #[inline]
-    pub fn is_disable(&self) -> bool {
-        *self == RAM1R::DISABLE
+    pub fn is_disabled(&self) -> bool {
+        *self == RAM1R::DISABLED
     }
-    #[doc = "Checks if the value of the field is `ENABLE`"]
+    #[doc = "Checks if the value of the field is `ENABLED`"]
     #[inline]
-    pub fn is_enable(&self) -> bool {
-        *self == RAM1R::ENABLE
+    pub fn is_enabled(&self) -> bool {
+        *self == RAM1R::ENABLED
     }
 }
 #[doc = "Possible values of the field `USBRAM`"]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum USBRAMR {
     #[doc = "Disable"]
-    DISABLE,
+    DISABLED,
     #[doc = "Enable"]
-    ENABLE,
+    ENABLED,
 }
 impl USBRAMR {
     #[doc = r" Returns `true` if the bit is clear (0)"]
@@ -1091,8 +1091,8 @@ impl USBRAMR {
     #[inline]
     pub fn bit(&self) -> bool {
         match *self {
-            USBRAMR::DISABLE => false,
-            USBRAMR::ENABLE => true,
+            USBRAMR::DISABLED => false,
+            USBRAMR::ENABLED => true,
         }
     }
     #[allow(missing_docs)]
@@ -1100,25 +1100,25 @@ impl USBRAMR {
     #[inline]
     pub fn _from(value: bool) -> USBRAMR {
         match value {
-            false => USBRAMR::DISABLE,
-            true => USBRAMR::ENABLE,
+            false => USBRAMR::DISABLED,
+            true => USBRAMR::ENABLED,
         }
     }
-    #[doc = "Checks if the value of the field is `DISABLE`"]
+    #[doc = "Checks if the value of the field is `DISABLED`"]
     #[inline]
-    pub fn is_disable(&self) -> bool {
-        *self == USBRAMR::DISABLE
+    pub fn is_disabled(&self) -> bool {
+        *self == USBRAMR::DISABLED
     }
-    #[doc = "Checks if the value of the field is `ENABLE`"]
+    #[doc = "Checks if the value of the field is `ENABLED`"]
     #[inline]
-    pub fn is_enable(&self) -> bool {
-        *self == USBRAMR::ENABLE
+    pub fn is_enabled(&self) -> bool {
+        *self == USBRAMR::ENABLED
     }
 }
 #[doc = "Values that can be written to the field `SYS`"]
 pub enum SYSW {
     #[doc = "Enable"]
-    ENABLE,
+    ENABLED,
 }
 impl SYSW {
     #[allow(missing_docs)]
@@ -1126,7 +1126,7 @@ impl SYSW {
     #[inline]
     pub fn _bits(&self) -> bool {
         match *self {
-            SYSW::ENABLE => true,
+            SYSW::ENABLED => true,
         }
     }
 }
@@ -1144,8 +1144,8 @@ impl<'a> _SYSW<'a> {
     }
     #[doc = "Enable"]
     #[inline]
-    pub fn enable(self) -> &'a mut W {
-        self.variant(SYSW::ENABLE)
+    pub fn enabled(self) -> &'a mut W {
+        self.variant(SYSW::ENABLED)
     }
     #[doc = r" Sets the field bit"]
     pub fn set_bit(self) -> &'a mut W {
@@ -1168,9 +1168,9 @@ impl<'a> _SYSW<'a> {
 #[doc = "Values that can be written to the field `ROM`"]
 pub enum ROMW {
     #[doc = "Disable"]
-    DISABLE,
+    DISABLED,
     #[doc = "Enable"]
-    ENABLE,
+    ENABLED,
 }
 impl ROMW {
     #[allow(missing_docs)]
@@ -1178,8 +1178,8 @@ impl ROMW {
     #[inline]
     pub fn _bits(&self) -> bool {
         match *self {
-            ROMW::DISABLE => false,
-            ROMW::ENABLE => true,
+            ROMW::DISABLED => false,
+            ROMW::ENABLED => true,
         }
     }
 }
@@ -1197,13 +1197,13 @@ impl<'a> _ROMW<'a> {
     }
     #[doc = "Disable"]
     #[inline]
-    pub fn disable(self) -> &'a mut W {
-        self.variant(ROMW::DISABLE)
+    pub fn disabled(self) -> &'a mut W {
+        self.variant(ROMW::DISABLED)
     }
     #[doc = "Enable"]
     #[inline]
-    pub fn enable(self) -> &'a mut W {
-        self.variant(ROMW::ENABLE)
+    pub fn enabled(self) -> &'a mut W {
+        self.variant(ROMW::ENABLED)
     }
     #[doc = r" Sets the field bit"]
     pub fn set_bit(self) -> &'a mut W {
@@ -1226,9 +1226,9 @@ impl<'a> _ROMW<'a> {
 #[doc = "Values that can be written to the field `RAM0`"]
 pub enum RAM0W {
     #[doc = "Disable"]
-    DISABLE,
+    DISABLED,
     #[doc = "Enable"]
-    ENABLE,
+    ENABLED,
 }
 impl RAM0W {
     #[allow(missing_docs)]
@@ -1236,8 +1236,8 @@ impl RAM0W {
     #[inline]
     pub fn _bits(&self) -> bool {
         match *self {
-            RAM0W::DISABLE => false,
-            RAM0W::ENABLE => true,
+            RAM0W::DISABLED => false,
+            RAM0W::ENABLED => true,
         }
     }
 }
@@ -1255,13 +1255,13 @@ impl<'a> _RAM0W<'a> {
     }
     #[doc = "Disable"]
     #[inline]
-    pub fn disable(self) -> &'a mut W {
-        self.variant(RAM0W::DISABLE)
+    pub fn disabled(self) -> &'a mut W {
+        self.variant(RAM0W::DISABLED)
     }
     #[doc = "Enable"]
     #[inline]
-    pub fn enable(self) -> &'a mut W {
-        self.variant(RAM0W::ENABLE)
+    pub fn enabled(self) -> &'a mut W {
+        self.variant(RAM0W::ENABLED)
     }
     #[doc = r" Sets the field bit"]
     pub fn set_bit(self) -> &'a mut W {
@@ -1284,9 +1284,9 @@ impl<'a> _RAM0W<'a> {
 #[doc = "Values that can be written to the field `FLASHREG`"]
 pub enum FLASHREGW {
     #[doc = "Disable"]
-    DISABLE,
+    DISABLED,
     #[doc = "Enable"]
-    ENABLE,
+    ENABLED,
 }
 impl FLASHREGW {
     #[allow(missing_docs)]
@@ -1294,8 +1294,8 @@ impl FLASHREGW {
     #[inline]
     pub fn _bits(&self) -> bool {
         match *self {
-            FLASHREGW::DISABLE => false,
-            FLASHREGW::ENABLE => true,
+            FLASHREGW::DISABLED => false,
+            FLASHREGW::ENABLED => true,
         }
     }
 }
@@ -1313,13 +1313,13 @@ impl<'a> _FLASHREGW<'a> {
     }
     #[doc = "Disable"]
     #[inline]
-    pub fn disable(self) -> &'a mut W {
-        self.variant(FLASHREGW::DISABLE)
+    pub fn disabled(self) -> &'a mut W {
+        self.variant(FLASHREGW::DISABLED)
     }
     #[doc = "Enable"]
     #[inline]
-    pub fn enable(self) -> &'a mut W {
-        self.variant(FLASHREGW::ENABLE)
+    pub fn enabled(self) -> &'a mut W {
+        self.variant(FLASHREGW::ENABLED)
     }
     #[doc = r" Sets the field bit"]
     pub fn set_bit(self) -> &'a mut W {
@@ -1342,9 +1342,9 @@ impl<'a> _FLASHREGW<'a> {
 #[doc = "Values that can be written to the field `FLASHARRAY`"]
 pub enum FLASHARRAYW {
     #[doc = "Disable"]
-    DISABLE,
+    DISABLED,
     #[doc = "Enable"]
-    ENABLE,
+    ENABLED,
 }
 impl FLASHARRAYW {
     #[allow(missing_docs)]
@@ -1352,8 +1352,8 @@ impl FLASHARRAYW {
     #[inline]
     pub fn _bits(&self) -> bool {
         match *self {
-            FLASHARRAYW::DISABLE => false,
-            FLASHARRAYW::ENABLE => true,
+            FLASHARRAYW::DISABLED => false,
+            FLASHARRAYW::ENABLED => true,
         }
     }
 }
@@ -1371,13 +1371,13 @@ impl<'a> _FLASHARRAYW<'a> {
     }
     #[doc = "Disable"]
     #[inline]
-    pub fn disable(self) -> &'a mut W {
-        self.variant(FLASHARRAYW::DISABLE)
+    pub fn disabled(self) -> &'a mut W {
+        self.variant(FLASHARRAYW::DISABLED)
     }
     #[doc = "Enable"]
     #[inline]
-    pub fn enable(self) -> &'a mut W {
-        self.variant(FLASHARRAYW::ENABLE)
+    pub fn enabled(self) -> &'a mut W {
+        self.variant(FLASHARRAYW::ENABLED)
     }
     #[doc = r" Sets the field bit"]
     pub fn set_bit(self) -> &'a mut W {
@@ -1400,9 +1400,9 @@ impl<'a> _FLASHARRAYW<'a> {
 #[doc = "Values that can be written to the field `I2C`"]
 pub enum I2CW {
     #[doc = "Disable"]
-    DISABLE,
+    DISABLED,
     #[doc = "Enable"]
-    ENABLE,
+    ENABLED,
 }
 impl I2CW {
     #[allow(missing_docs)]
@@ -1410,8 +1410,8 @@ impl I2CW {
     #[inline]
     pub fn _bits(&self) -> bool {
         match *self {
-            I2CW::DISABLE => false,
-            I2CW::ENABLE => true,
+            I2CW::DISABLED => false,
+            I2CW::ENABLED => true,
         }
     }
 }
@@ -1429,13 +1429,13 @@ impl<'a> _I2CW<'a> {
     }
     #[doc = "Disable"]
     #[inline]
-    pub fn disable(self) -> &'a mut W {
-        self.variant(I2CW::DISABLE)
+    pub fn disabled(self) -> &'a mut W {
+        self.variant(I2CW::DISABLED)
     }
     #[doc = "Enable"]
     #[inline]
-    pub fn enable(self) -> &'a mut W {
-        self.variant(I2CW::ENABLE)
+    pub fn enabled(self) -> &'a mut W {
+        self.variant(I2CW::ENABLED)
     }
     #[doc = r" Sets the field bit"]
     pub fn set_bit(self) -> &'a mut W {
@@ -1458,9 +1458,9 @@ impl<'a> _I2CW<'a> {
 #[doc = "Values that can be written to the field `GPIO`"]
 pub enum GPIOW {
     #[doc = "Disable"]
-    DISABLE,
+    DISABLED,
     #[doc = "Enable"]
-    ENABLE,
+    ENABLED,
 }
 impl GPIOW {
     #[allow(missing_docs)]
@@ -1468,8 +1468,8 @@ impl GPIOW {
     #[inline]
     pub fn _bits(&self) -> bool {
         match *self {
-            GPIOW::DISABLE => false,
-            GPIOW::ENABLE => true,
+            GPIOW::DISABLED => false,
+            GPIOW::ENABLED => true,
         }
     }
 }
@@ -1487,13 +1487,13 @@ impl<'a> _GPIOW<'a> {
     }
     #[doc = "Disable"]
     #[inline]
-    pub fn disable(self) -> &'a mut W {
-        self.variant(GPIOW::DISABLE)
+    pub fn disabled(self) -> &'a mut W {
+        self.variant(GPIOW::DISABLED)
     }
     #[doc = "Enable"]
     #[inline]
-    pub fn enable(self) -> &'a mut W {
-        self.variant(GPIOW::ENABLE)
+    pub fn enabled(self) -> &'a mut W {
+        self.variant(GPIOW::ENABLED)
     }
     #[doc = r" Sets the field bit"]
     pub fn set_bit(self) -> &'a mut W {
@@ -1516,9 +1516,9 @@ impl<'a> _GPIOW<'a> {
 #[doc = "Values that can be written to the field `CT16B0`"]
 pub enum CT16B0W {
     #[doc = "Disable"]
-    DISABLE,
+    DISABLED,
     #[doc = "Enable"]
-    ENABLE,
+    ENABLED,
 }
 impl CT16B0W {
     #[allow(missing_docs)]
@@ -1526,8 +1526,8 @@ impl CT16B0W {
     #[inline]
     pub fn _bits(&self) -> bool {
         match *self {
-            CT16B0W::DISABLE => false,
-            CT16B0W::ENABLE => true,
+            CT16B0W::DISABLED => false,
+            CT16B0W::ENABLED => true,
         }
     }
 }
@@ -1545,13 +1545,13 @@ impl<'a> _CT16B0W<'a> {
     }
     #[doc = "Disable"]
     #[inline]
-    pub fn disable(self) -> &'a mut W {
-        self.variant(CT16B0W::DISABLE)
+    pub fn disabled(self) -> &'a mut W {
+        self.variant(CT16B0W::DISABLED)
     }
     #[doc = "Enable"]
     #[inline]
-    pub fn enable(self) -> &'a mut W {
-        self.variant(CT16B0W::ENABLE)
+    pub fn enabled(self) -> &'a mut W {
+        self.variant(CT16B0W::ENABLED)
     }
     #[doc = r" Sets the field bit"]
     pub fn set_bit(self) -> &'a mut W {
@@ -1574,9 +1574,9 @@ impl<'a> _CT16B0W<'a> {
 #[doc = "Values that can be written to the field `CT16B1`"]
 pub enum CT16B1W {
     #[doc = "Disable"]
-    DISABLE,
+    DISABLED,
     #[doc = "Enable"]
-    ENABLE,
+    ENABLED,
 }
 impl CT16B1W {
     #[allow(missing_docs)]
@@ -1584,8 +1584,8 @@ impl CT16B1W {
     #[inline]
     pub fn _bits(&self) -> bool {
         match *self {
-            CT16B1W::DISABLE => false,
-            CT16B1W::ENABLE => true,
+            CT16B1W::DISABLED => false,
+            CT16B1W::ENABLED => true,
         }
     }
 }
@@ -1603,13 +1603,13 @@ impl<'a> _CT16B1W<'a> {
     }
     #[doc = "Disable"]
     #[inline]
-    pub fn disable(self) -> &'a mut W {
-        self.variant(CT16B1W::DISABLE)
+    pub fn disabled(self) -> &'a mut W {
+        self.variant(CT16B1W::DISABLED)
     }
     #[doc = "Enable"]
     #[inline]
-    pub fn enable(self) -> &'a mut W {
-        self.variant(CT16B1W::ENABLE)
+    pub fn enabled(self) -> &'a mut W {
+        self.variant(CT16B1W::ENABLED)
     }
     #[doc = r" Sets the field bit"]
     pub fn set_bit(self) -> &'a mut W {
@@ -1632,9 +1632,9 @@ impl<'a> _CT16B1W<'a> {
 #[doc = "Values that can be written to the field `CT32B0`"]
 pub enum CT32B0W {
     #[doc = "Disable"]
-    DISABLE,
+    DISABLED,
     #[doc = "Enable"]
-    ENABLE,
+    ENABLED,
 }
 impl CT32B0W {
     #[allow(missing_docs)]
@@ -1642,8 +1642,8 @@ impl CT32B0W {
     #[inline]
     pub fn _bits(&self) -> bool {
         match *self {
-            CT32B0W::DISABLE => false,
-            CT32B0W::ENABLE => true,
+            CT32B0W::DISABLED => false,
+            CT32B0W::ENABLED => true,
         }
     }
 }
@@ -1661,13 +1661,13 @@ impl<'a> _CT32B0W<'a> {
     }
     #[doc = "Disable"]
     #[inline]
-    pub fn disable(self) -> &'a mut W {
-        self.variant(CT32B0W::DISABLE)
+    pub fn disabled(self) -> &'a mut W {
+        self.variant(CT32B0W::DISABLED)
     }
     #[doc = "Enable"]
     #[inline]
-    pub fn enable(self) -> &'a mut W {
-        self.variant(CT32B0W::ENABLE)
+    pub fn enabled(self) -> &'a mut W {
+        self.variant(CT32B0W::ENABLED)
     }
     #[doc = r" Sets the field bit"]
     pub fn set_bit(self) -> &'a mut W {
@@ -1690,9 +1690,9 @@ impl<'a> _CT32B0W<'a> {
 #[doc = "Values that can be written to the field `CT32B1`"]
 pub enum CT32B1W {
     #[doc = "Disable"]
-    DISABLE,
+    DISABLED,
     #[doc = "Enable"]
-    ENABLE,
+    ENABLED,
 }
 impl CT32B1W {
     #[allow(missing_docs)]
@@ -1700,8 +1700,8 @@ impl CT32B1W {
     #[inline]
     pub fn _bits(&self) -> bool {
         match *self {
-            CT32B1W::DISABLE => false,
-            CT32B1W::ENABLE => true,
+            CT32B1W::DISABLED => false,
+            CT32B1W::ENABLED => true,
         }
     }
 }
@@ -1719,13 +1719,13 @@ impl<'a> _CT32B1W<'a> {
     }
     #[doc = "Disable"]
     #[inline]
-    pub fn disable(self) -> &'a mut W {
-        self.variant(CT32B1W::DISABLE)
+    pub fn disabled(self) -> &'a mut W {
+        self.variant(CT32B1W::DISABLED)
     }
     #[doc = "Enable"]
     #[inline]
-    pub fn enable(self) -> &'a mut W {
-        self.variant(CT32B1W::ENABLE)
+    pub fn enabled(self) -> &'a mut W {
+        self.variant(CT32B1W::ENABLED)
     }
     #[doc = r" Sets the field bit"]
     pub fn set_bit(self) -> &'a mut W {
@@ -1748,9 +1748,9 @@ impl<'a> _CT32B1W<'a> {
 #[doc = "Values that can be written to the field `SSP0`"]
 pub enum SSP0W {
     #[doc = "Disable"]
-    DISABLE,
+    DISABLED,
     #[doc = "Enable"]
-    ENABLE,
+    ENABLED,
 }
 impl SSP0W {
     #[allow(missing_docs)]
@@ -1758,8 +1758,8 @@ impl SSP0W {
     #[inline]
     pub fn _bits(&self) -> bool {
         match *self {
-            SSP0W::DISABLE => false,
-            SSP0W::ENABLE => true,
+            SSP0W::DISABLED => false,
+            SSP0W::ENABLED => true,
         }
     }
 }
@@ -1777,13 +1777,13 @@ impl<'a> _SSP0W<'a> {
     }
     #[doc = "Disable"]
     #[inline]
-    pub fn disable(self) -> &'a mut W {
-        self.variant(SSP0W::DISABLE)
+    pub fn disabled(self) -> &'a mut W {
+        self.variant(SSP0W::DISABLED)
     }
     #[doc = "Enable"]
     #[inline]
-    pub fn enable(self) -> &'a mut W {
-        self.variant(SSP0W::ENABLE)
+    pub fn enabled(self) -> &'a mut W {
+        self.variant(SSP0W::ENABLED)
     }
     #[doc = r" Sets the field bit"]
     pub fn set_bit(self) -> &'a mut W {
@@ -1806,9 +1806,9 @@ impl<'a> _SSP0W<'a> {
 #[doc = "Values that can be written to the field `USART`"]
 pub enum USARTW {
     #[doc = "Disable"]
-    DISABLE,
+    DISABLED,
     #[doc = "Enable"]
-    ENABLE,
+    ENABLED,
 }
 impl USARTW {
     #[allow(missing_docs)]
@@ -1816,8 +1816,8 @@ impl USARTW {
     #[inline]
     pub fn _bits(&self) -> bool {
         match *self {
-            USARTW::DISABLE => false,
-            USARTW::ENABLE => true,
+            USARTW::DISABLED => false,
+            USARTW::ENABLED => true,
         }
     }
 }
@@ -1835,13 +1835,13 @@ impl<'a> _USARTW<'a> {
     }
     #[doc = "Disable"]
     #[inline]
-    pub fn disable(self) -> &'a mut W {
-        self.variant(USARTW::DISABLE)
+    pub fn disabled(self) -> &'a mut W {
+        self.variant(USARTW::DISABLED)
     }
     #[doc = "Enable"]
     #[inline]
-    pub fn enable(self) -> &'a mut W {
-        self.variant(USARTW::ENABLE)
+    pub fn enabled(self) -> &'a mut W {
+        self.variant(USARTW::ENABLED)
     }
     #[doc = r" Sets the field bit"]
     pub fn set_bit(self) -> &'a mut W {
@@ -1864,9 +1864,9 @@ impl<'a> _USARTW<'a> {
 #[doc = "Values that can be written to the field `ADC`"]
 pub enum ADCW {
     #[doc = "Disable"]
-    DISABLE,
+    DISABLED,
     #[doc = "Enable"]
-    ENABLE,
+    ENABLED,
 }
 impl ADCW {
     #[allow(missing_docs)]
@@ -1874,8 +1874,8 @@ impl ADCW {
     #[inline]
     pub fn _bits(&self) -> bool {
         match *self {
-            ADCW::DISABLE => false,
-            ADCW::ENABLE => true,
+            ADCW::DISABLED => false,
+            ADCW::ENABLED => true,
         }
     }
 }
@@ -1893,13 +1893,13 @@ impl<'a> _ADCW<'a> {
     }
     #[doc = "Disable"]
     #[inline]
-    pub fn disable(self) -> &'a mut W {
-        self.variant(ADCW::DISABLE)
+    pub fn disabled(self) -> &'a mut W {
+        self.variant(ADCW::DISABLED)
     }
     #[doc = "Enable"]
     #[inline]
-    pub fn enable(self) -> &'a mut W {
-        self.variant(ADCW::ENABLE)
+    pub fn enabled(self) -> &'a mut W {
+        self.variant(ADCW::ENABLED)
     }
     #[doc = r" Sets the field bit"]
     pub fn set_bit(self) -> &'a mut W {
@@ -1922,9 +1922,9 @@ impl<'a> _ADCW<'a> {
 #[doc = "Values that can be written to the field `USB`"]
 pub enum USBW {
     #[doc = "Disable"]
-    DISABLE,
+    DISABLED,
     #[doc = "Enable"]
-    ENABLE,
+    ENABLED,
 }
 impl USBW {
     #[allow(missing_docs)]
@@ -1932,8 +1932,8 @@ impl USBW {
     #[inline]
     pub fn _bits(&self) -> bool {
         match *self {
-            USBW::DISABLE => false,
-            USBW::ENABLE => true,
+            USBW::DISABLED => false,
+            USBW::ENABLED => true,
         }
     }
 }
@@ -1951,13 +1951,13 @@ impl<'a> _USBW<'a> {
     }
     #[doc = "Disable"]
     #[inline]
-    pub fn disable(self) -> &'a mut W {
-        self.variant(USBW::DISABLE)
+    pub fn disabled(self) -> &'a mut W {
+        self.variant(USBW::DISABLED)
     }
     #[doc = "Enable"]
     #[inline]
-    pub fn enable(self) -> &'a mut W {
-        self.variant(USBW::ENABLE)
+    pub fn enabled(self) -> &'a mut W {
+        self.variant(USBW::ENABLED)
     }
     #[doc = r" Sets the field bit"]
     pub fn set_bit(self) -> &'a mut W {
@@ -1980,9 +1980,9 @@ impl<'a> _USBW<'a> {
 #[doc = "Values that can be written to the field `WWDT`"]
 pub enum WWDTW {
     #[doc = "Disable"]
-    DISABLE,
+    DISABLED,
     #[doc = "Enable"]
-    ENABLE,
+    ENABLED,
 }
 impl WWDTW {
     #[allow(missing_docs)]
@@ -1990,8 +1990,8 @@ impl WWDTW {
     #[inline]
     pub fn _bits(&self) -> bool {
         match *self {
-            WWDTW::DISABLE => false,
-            WWDTW::ENABLE => true,
+            WWDTW::DISABLED => false,
+            WWDTW::ENABLED => true,
         }
     }
 }
@@ -2009,13 +2009,13 @@ impl<'a> _WWDTW<'a> {
     }
     #[doc = "Disable"]
     #[inline]
-    pub fn disable(self) -> &'a mut W {
-        self.variant(WWDTW::DISABLE)
+    pub fn disabled(self) -> &'a mut W {
+        self.variant(WWDTW::DISABLED)
     }
     #[doc = "Enable"]
     #[inline]
-    pub fn enable(self) -> &'a mut W {
-        self.variant(WWDTW::ENABLE)
+    pub fn enabled(self) -> &'a mut W {
+        self.variant(WWDTW::ENABLED)
     }
     #[doc = r" Sets the field bit"]
     pub fn set_bit(self) -> &'a mut W {
@@ -2038,9 +2038,9 @@ impl<'a> _WWDTW<'a> {
 #[doc = "Values that can be written to the field `IOCON`"]
 pub enum IOCONW {
     #[doc = "Disable"]
-    DISABLE,
+    DISABLED,
     #[doc = "Enable"]
-    ENABLE,
+    ENABLED,
 }
 impl IOCONW {
     #[allow(missing_docs)]
@@ -2048,8 +2048,8 @@ impl IOCONW {
     #[inline]
     pub fn _bits(&self) -> bool {
         match *self {
-            IOCONW::DISABLE => false,
-            IOCONW::ENABLE => true,
+            IOCONW::DISABLED => false,
+            IOCONW::ENABLED => true,
         }
     }
 }
@@ -2067,13 +2067,13 @@ impl<'a> _IOCONW<'a> {
     }
     #[doc = "Disable"]
     #[inline]
-    pub fn disable(self) -> &'a mut W {
-        self.variant(IOCONW::DISABLE)
+    pub fn disabled(self) -> &'a mut W {
+        self.variant(IOCONW::DISABLED)
     }
     #[doc = "Enable"]
     #[inline]
-    pub fn enable(self) -> &'a mut W {
-        self.variant(IOCONW::ENABLE)
+    pub fn enabled(self) -> &'a mut W {
+        self.variant(IOCONW::ENABLED)
     }
     #[doc = r" Sets the field bit"]
     pub fn set_bit(self) -> &'a mut W {
@@ -2096,9 +2096,9 @@ impl<'a> _IOCONW<'a> {
 #[doc = "Values that can be written to the field `SSP1`"]
 pub enum SSP1W {
     #[doc = "Disable"]
-    DISABLE,
+    DISABLED,
     #[doc = "Enable"]
-    ENABLE,
+    ENABLED,
 }
 impl SSP1W {
     #[allow(missing_docs)]
@@ -2106,8 +2106,8 @@ impl SSP1W {
     #[inline]
     pub fn _bits(&self) -> bool {
         match *self {
-            SSP1W::DISABLE => false,
-            SSP1W::ENABLE => true,
+            SSP1W::DISABLED => false,
+            SSP1W::ENABLED => true,
         }
     }
 }
@@ -2125,13 +2125,13 @@ impl<'a> _SSP1W<'a> {
     }
     #[doc = "Disable"]
     #[inline]
-    pub fn disable(self) -> &'a mut W {
-        self.variant(SSP1W::DISABLE)
+    pub fn disabled(self) -> &'a mut W {
+        self.variant(SSP1W::DISABLED)
     }
     #[doc = "Enable"]
     #[inline]
-    pub fn enable(self) -> &'a mut W {
-        self.variant(SSP1W::ENABLE)
+    pub fn enabled(self) -> &'a mut W {
+        self.variant(SSP1W::ENABLED)
     }
     #[doc = r" Sets the field bit"]
     pub fn set_bit(self) -> &'a mut W {
@@ -2154,9 +2154,9 @@ impl<'a> _SSP1W<'a> {
 #[doc = "Values that can be written to the field `PINT`"]
 pub enum PINTW {
     #[doc = "Disable"]
-    DISABLE,
+    DISABLED,
     #[doc = "Enable"]
-    ENABLE,
+    ENABLED,
 }
 impl PINTW {
     #[allow(missing_docs)]
@@ -2164,8 +2164,8 @@ impl PINTW {
     #[inline]
     pub fn _bits(&self) -> bool {
         match *self {
-            PINTW::DISABLE => false,
-            PINTW::ENABLE => true,
+            PINTW::DISABLED => false,
+            PINTW::ENABLED => true,
         }
     }
 }
@@ -2183,13 +2183,13 @@ impl<'a> _PINTW<'a> {
     }
     #[doc = "Disable"]
     #[inline]
-    pub fn disable(self) -> &'a mut W {
-        self.variant(PINTW::DISABLE)
+    pub fn disabled(self) -> &'a mut W {
+        self.variant(PINTW::DISABLED)
     }
     #[doc = "Enable"]
     #[inline]
-    pub fn enable(self) -> &'a mut W {
-        self.variant(PINTW::ENABLE)
+    pub fn enabled(self) -> &'a mut W {
+        self.variant(PINTW::ENABLED)
     }
     #[doc = r" Sets the field bit"]
     pub fn set_bit(self) -> &'a mut W {
@@ -2212,9 +2212,9 @@ impl<'a> _PINTW<'a> {
 #[doc = "Values that can be written to the field `GROUP0INT`"]
 pub enum GROUP0INTW {
     #[doc = "Disable"]
-    DISABLE,
+    DISABLED,
     #[doc = "Enable"]
-    ENABLE,
+    ENABLED,
 }
 impl GROUP0INTW {
     #[allow(missing_docs)]
@@ -2222,8 +2222,8 @@ impl GROUP0INTW {
     #[inline]
     pub fn _bits(&self) -> bool {
         match *self {
-            GROUP0INTW::DISABLE => false,
-            GROUP0INTW::ENABLE => true,
+            GROUP0INTW::DISABLED => false,
+            GROUP0INTW::ENABLED => true,
         }
     }
 }
@@ -2241,13 +2241,13 @@ impl<'a> _GROUP0INTW<'a> {
     }
     #[doc = "Disable"]
     #[inline]
-    pub fn disable(self) -> &'a mut W {
-        self.variant(GROUP0INTW::DISABLE)
+    pub fn disabled(self) -> &'a mut W {
+        self.variant(GROUP0INTW::DISABLED)
     }
     #[doc = "Enable"]
     #[inline]
-    pub fn enable(self) -> &'a mut W {
-        self.variant(GROUP0INTW::ENABLE)
+    pub fn enabled(self) -> &'a mut W {
+        self.variant(GROUP0INTW::ENABLED)
     }
     #[doc = r" Sets the field bit"]
     pub fn set_bit(self) -> &'a mut W {
@@ -2270,9 +2270,9 @@ impl<'a> _GROUP0INTW<'a> {
 #[doc = "Values that can be written to the field `GROUP1INT`"]
 pub enum GROUP1INTW {
     #[doc = "Disable"]
-    DISABLE,
+    DISABLED,
     #[doc = "Enable"]
-    ENABLE,
+    ENABLED,
 }
 impl GROUP1INTW {
     #[allow(missing_docs)]
@@ -2280,8 +2280,8 @@ impl GROUP1INTW {
     #[inline]
     pub fn _bits(&self) -> bool {
         match *self {
-            GROUP1INTW::DISABLE => false,
-            GROUP1INTW::ENABLE => true,
+            GROUP1INTW::DISABLED => false,
+            GROUP1INTW::ENABLED => true,
         }
     }
 }
@@ -2299,13 +2299,13 @@ impl<'a> _GROUP1INTW<'a> {
     }
     #[doc = "Disable"]
     #[inline]
-    pub fn disable(self) -> &'a mut W {
-        self.variant(GROUP1INTW::DISABLE)
+    pub fn disabled(self) -> &'a mut W {
+        self.variant(GROUP1INTW::DISABLED)
     }
     #[doc = "Enable"]
     #[inline]
-    pub fn enable(self) -> &'a mut W {
-        self.variant(GROUP1INTW::ENABLE)
+    pub fn enabled(self) -> &'a mut W {
+        self.variant(GROUP1INTW::ENABLED)
     }
     #[doc = r" Sets the field bit"]
     pub fn set_bit(self) -> &'a mut W {
@@ -2328,9 +2328,9 @@ impl<'a> _GROUP1INTW<'a> {
 #[doc = "Values that can be written to the field `RAM1`"]
 pub enum RAM1W {
     #[doc = "Disable"]
-    DISABLE,
+    DISABLED,
     #[doc = "Enable"]
-    ENABLE,
+    ENABLED,
 }
 impl RAM1W {
     #[allow(missing_docs)]
@@ -2338,8 +2338,8 @@ impl RAM1W {
     #[inline]
     pub fn _bits(&self) -> bool {
         match *self {
-            RAM1W::DISABLE => false,
-            RAM1W::ENABLE => true,
+            RAM1W::DISABLED => false,
+            RAM1W::ENABLED => true,
         }
     }
 }
@@ -2357,13 +2357,13 @@ impl<'a> _RAM1W<'a> {
     }
     #[doc = "Disable"]
     #[inline]
-    pub fn disable(self) -> &'a mut W {
-        self.variant(RAM1W::DISABLE)
+    pub fn disabled(self) -> &'a mut W {
+        self.variant(RAM1W::DISABLED)
     }
     #[doc = "Enable"]
     #[inline]
-    pub fn enable(self) -> &'a mut W {
-        self.variant(RAM1W::ENABLE)
+    pub fn enabled(self) -> &'a mut W {
+        self.variant(RAM1W::ENABLED)
     }
     #[doc = r" Sets the field bit"]
     pub fn set_bit(self) -> &'a mut W {
@@ -2386,9 +2386,9 @@ impl<'a> _RAM1W<'a> {
 #[doc = "Values that can be written to the field `USBRAM`"]
 pub enum USBRAMW {
     #[doc = "Disable"]
-    DISABLE,
+    DISABLED,
     #[doc = "Enable"]
-    ENABLE,
+    ENABLED,
 }
 impl USBRAMW {
     #[allow(missing_docs)]
@@ -2396,8 +2396,8 @@ impl USBRAMW {
     #[inline]
     pub fn _bits(&self) -> bool {
         match *self {
-            USBRAMW::DISABLE => false,
-            USBRAMW::ENABLE => true,
+            USBRAMW::DISABLED => false,
+            USBRAMW::ENABLED => true,
         }
     }
 }
@@ -2415,13 +2415,13 @@ impl<'a> _USBRAMW<'a> {
     }
     #[doc = "Disable"]
     #[inline]
-    pub fn disable(self) -> &'a mut W {
-        self.variant(USBRAMW::DISABLE)
+    pub fn disabled(self) -> &'a mut W {
+        self.variant(USBRAMW::DISABLED)
     }
     #[doc = "Enable"]
     #[inline]
-    pub fn enable(self) -> &'a mut W {
-        self.variant(USBRAMW::ENABLE)
+    pub fn enabled(self) -> &'a mut W {
+        self.variant(USBRAMW::ENABLED)
     }
     #[doc = r" Sets the field bit"]
     pub fn set_bit(self) -> &'a mut W {

--- a/lpc11uxx/src/syscon/sysoscctrl.rs
+++ b/lpc11uxx/src/syscon/sysoscctrl.rs
@@ -46,9 +46,9 @@ impl super::SYSOSCCTRL {
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum BYPASSR {
     #[doc = "Oscillator is not bypassed."]
-    OSCILLATOR_IS_NOT_BY,
+    DISABLED,
     #[doc = "Bypass enabled. PLL input (sys_osc_clk) is fed directly from the XTALIN pin bypassing the oscillator. Use this mode when using an external clock source instead of the crystal oscillator."]
-    BYPASS_ENABLED_PLL_,
+    ENABLED,
 }
 impl BYPASSR {
     #[doc = r" Returns `true` if the bit is clear (0)"]
@@ -65,8 +65,8 @@ impl BYPASSR {
     #[inline]
     pub fn bit(&self) -> bool {
         match *self {
-            BYPASSR::OSCILLATOR_IS_NOT_BY => false,
-            BYPASSR::BYPASS_ENABLED_PLL_ => true,
+            BYPASSR::DISABLED => false,
+            BYPASSR::ENABLED => true,
         }
     }
     #[allow(missing_docs)]
@@ -74,19 +74,19 @@ impl BYPASSR {
     #[inline]
     pub fn _from(value: bool) -> BYPASSR {
         match value {
-            false => BYPASSR::OSCILLATOR_IS_NOT_BY,
-            true => BYPASSR::BYPASS_ENABLED_PLL_,
+            false => BYPASSR::DISABLED,
+            true => BYPASSR::ENABLED,
         }
     }
-    #[doc = "Checks if the value of the field is `OSCILLATOR_IS_NOT_BY`"]
+    #[doc = "Checks if the value of the field is `DISABLED`"]
     #[inline]
-    pub fn is_oscillator_is_not_by(&self) -> bool {
-        *self == BYPASSR::OSCILLATOR_IS_NOT_BY
+    pub fn is_disabled(&self) -> bool {
+        *self == BYPASSR::DISABLED
     }
-    #[doc = "Checks if the value of the field is `BYPASS_ENABLED_PLL_`"]
+    #[doc = "Checks if the value of the field is `ENABLED`"]
     #[inline]
-    pub fn is_bypass_enabled_pll_(&self) -> bool {
-        *self == BYPASSR::BYPASS_ENABLED_PLL_
+    pub fn is_enabled(&self) -> bool {
+        *self == BYPASSR::ENABLED
     }
 }
 #[doc = "Possible values of the field `FREQRANGE`"]
@@ -139,9 +139,9 @@ impl FREQRANGER {
 #[doc = "Values that can be written to the field `BYPASS`"]
 pub enum BYPASSW {
     #[doc = "Oscillator is not bypassed."]
-    OSCILLATOR_IS_NOT_BY,
+    DISABLED,
     #[doc = "Bypass enabled. PLL input (sys_osc_clk) is fed directly from the XTALIN pin bypassing the oscillator. Use this mode when using an external clock source instead of the crystal oscillator."]
-    BYPASS_ENABLED_PLL_,
+    ENABLED,
 }
 impl BYPASSW {
     #[allow(missing_docs)]
@@ -149,8 +149,8 @@ impl BYPASSW {
     #[inline]
     pub fn _bits(&self) -> bool {
         match *self {
-            BYPASSW::OSCILLATOR_IS_NOT_BY => false,
-            BYPASSW::BYPASS_ENABLED_PLL_ => true,
+            BYPASSW::DISABLED => false,
+            BYPASSW::ENABLED => true,
         }
     }
 }
@@ -168,13 +168,13 @@ impl<'a> _BYPASSW<'a> {
     }
     #[doc = "Oscillator is not bypassed."]
     #[inline]
-    pub fn oscillator_is_not_by(self) -> &'a mut W {
-        self.variant(BYPASSW::OSCILLATOR_IS_NOT_BY)
+    pub fn disabled(self) -> &'a mut W {
+        self.variant(BYPASSW::DISABLED)
     }
     #[doc = "Bypass enabled. PLL input (sys_osc_clk) is fed directly from the XTALIN pin bypassing the oscillator. Use this mode when using an external clock source instead of the crystal oscillator."]
     #[inline]
-    pub fn bypass_enabled_pll_(self) -> &'a mut W {
-        self.variant(BYPASSW::BYPASS_ENABLED_PLL_)
+    pub fn enabled(self) -> &'a mut W {
+        self.variant(BYPASSW::ENABLED)
     }
     #[doc = r" Sets the field bit"]
     pub fn set_bit(self) -> &'a mut W {

--- a/lpc11uxx/src/syscon/syspllclksel.rs
+++ b/lpc11uxx/src/syscon/syspllclksel.rs
@@ -48,7 +48,7 @@ pub enum SELR {
     #[doc = "IRC"]
     IRC,
     #[doc = "Crystal Oscillator (SYSOSC)"]
-    CRYSTAL_OSCILLATOR_,
+    CRYSTAL_OSCILLATOR,
 }
 impl SELR {
     #[doc = r" Value of the field as raw bits"]
@@ -56,7 +56,7 @@ impl SELR {
     pub fn bits(&self) -> u8 {
         match *self {
             SELR::IRC => 0,
-            SELR::CRYSTAL_OSCILLATOR_ => 1,
+            SELR::CRYSTAL_OSCILLATOR => 1,
         }
     }
     #[allow(missing_docs)]
@@ -65,7 +65,7 @@ impl SELR {
     pub fn _from(value: u8) -> SELR {
         match value {
             0 => SELR::IRC,
-            1 => SELR::CRYSTAL_OSCILLATOR_,
+            1 => SELR::CRYSTAL_OSCILLATOR,
             _ => unreachable!(),
         }
     }
@@ -74,10 +74,10 @@ impl SELR {
     pub fn is_irc(&self) -> bool {
         *self == SELR::IRC
     }
-    #[doc = "Checks if the value of the field is `CRYSTAL_OSCILLATOR_`"]
+    #[doc = "Checks if the value of the field is `CRYSTAL_OSCILLATOR`"]
     #[inline]
-    pub fn is_crystal_oscillator_(&self) -> bool {
-        *self == SELR::CRYSTAL_OSCILLATOR_
+    pub fn is_crystal_oscillator(&self) -> bool {
+        *self == SELR::CRYSTAL_OSCILLATOR
     }
 }
 #[doc = "Values that can be written to the field `SEL`"]
@@ -85,7 +85,7 @@ pub enum SELW {
     #[doc = "IRC"]
     IRC,
     #[doc = "Crystal Oscillator (SYSOSC)"]
-    CRYSTAL_OSCILLATOR_,
+    CRYSTAL_OSCILLATOR,
 }
 impl SELW {
     #[allow(missing_docs)]
@@ -94,7 +94,7 @@ impl SELW {
     pub fn _bits(&self) -> u8 {
         match *self {
             SELW::IRC => 0,
-            SELW::CRYSTAL_OSCILLATOR_ => 1,
+            SELW::CRYSTAL_OSCILLATOR => 1,
         }
     }
 }
@@ -115,8 +115,8 @@ impl<'a> _SELW<'a> {
     }
     #[doc = "Crystal Oscillator (SYSOSC)"]
     #[inline]
-    pub fn crystal_oscillator_(self) -> &'a mut W {
-        self.variant(SELW::CRYSTAL_OSCILLATOR_)
+    pub fn crystal_oscillator(self) -> &'a mut W {
+        self.variant(SELW::CRYSTAL_OSCILLATOR)
     }
     #[doc = r" Writes raw bits to the field"]
     #[inline]

--- a/lpc11uxx/src/syscon/sysrststat.rs
+++ b/lpc11uxx/src/syscon/sysrststat.rs
@@ -140,9 +140,9 @@ impl EXTRSTR {
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum WDTR {
     #[doc = "No WDT reset detected"]
-    NO_WDT_RESET_DETECTE,
+    NO_RESET,
     #[doc = "WDT reset detected. Writing a one clears this reset."]
-    WDT_RESET_DETECTED_,
+    RESET_CLEAR,
 }
 impl WDTR {
     #[doc = r" Returns `true` if the bit is clear (0)"]
@@ -159,8 +159,8 @@ impl WDTR {
     #[inline]
     pub fn bit(&self) -> bool {
         match *self {
-            WDTR::NO_WDT_RESET_DETECTE => false,
-            WDTR::WDT_RESET_DETECTED_ => true,
+            WDTR::NO_RESET => false,
+            WDTR::RESET_CLEAR => true,
         }
     }
     #[allow(missing_docs)]
@@ -168,28 +168,28 @@ impl WDTR {
     #[inline]
     pub fn _from(value: bool) -> WDTR {
         match value {
-            false => WDTR::NO_WDT_RESET_DETECTE,
-            true => WDTR::WDT_RESET_DETECTED_,
+            false => WDTR::NO_RESET,
+            true => WDTR::RESET_CLEAR,
         }
     }
-    #[doc = "Checks if the value of the field is `NO_WDT_RESET_DETECTE`"]
+    #[doc = "Checks if the value of the field is `NO_RESET`"]
     #[inline]
-    pub fn is_no_wdt_reset_detecte(&self) -> bool {
-        *self == WDTR::NO_WDT_RESET_DETECTE
+    pub fn is_no_reset(&self) -> bool {
+        *self == WDTR::NO_RESET
     }
-    #[doc = "Checks if the value of the field is `WDT_RESET_DETECTED_`"]
+    #[doc = "Checks if the value of the field is `RESET_CLEAR`"]
     #[inline]
-    pub fn is_wdt_reset_detected_(&self) -> bool {
-        *self == WDTR::WDT_RESET_DETECTED_
+    pub fn is_reset_clear(&self) -> bool {
+        *self == WDTR::RESET_CLEAR
     }
 }
 #[doc = "Possible values of the field `BOD`"]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum BODR {
     #[doc = "No BOD reset detected"]
-    NO_BOD_RESET_DETECTE,
+    NO_RESET,
     #[doc = "BOD reset detected. Writing a one clears this reset."]
-    BOD_RESET_DETECTED_,
+    RESET_CLEAR,
 }
 impl BODR {
     #[doc = r" Returns `true` if the bit is clear (0)"]
@@ -206,8 +206,8 @@ impl BODR {
     #[inline]
     pub fn bit(&self) -> bool {
         match *self {
-            BODR::NO_BOD_RESET_DETECTE => false,
-            BODR::BOD_RESET_DETECTED_ => true,
+            BODR::NO_RESET => false,
+            BODR::RESET_CLEAR => true,
         }
     }
     #[allow(missing_docs)]
@@ -215,19 +215,19 @@ impl BODR {
     #[inline]
     pub fn _from(value: bool) -> BODR {
         match value {
-            false => BODR::NO_BOD_RESET_DETECTE,
-            true => BODR::BOD_RESET_DETECTED_,
+            false => BODR::NO_RESET,
+            true => BODR::RESET_CLEAR,
         }
     }
-    #[doc = "Checks if the value of the field is `NO_BOD_RESET_DETECTE`"]
+    #[doc = "Checks if the value of the field is `NO_RESET`"]
     #[inline]
-    pub fn is_no_bod_reset_detecte(&self) -> bool {
-        *self == BODR::NO_BOD_RESET_DETECTE
+    pub fn is_no_reset(&self) -> bool {
+        *self == BODR::NO_RESET
     }
-    #[doc = "Checks if the value of the field is `BOD_RESET_DETECTED_`"]
+    #[doc = "Checks if the value of the field is `RESET_CLEAR`"]
     #[inline]
-    pub fn is_bod_reset_detected_(&self) -> bool {
-        *self == BODR::BOD_RESET_DETECTED_
+    pub fn is_reset_clear(&self) -> bool {
+        *self == BODR::RESET_CLEAR
     }
 }
 #[doc = "Possible values of the field `SYSRST`"]
@@ -396,9 +396,9 @@ impl<'a> _EXTRSTW<'a> {
 #[doc = "Values that can be written to the field `WDT`"]
 pub enum WDTW {
     #[doc = "No WDT reset detected"]
-    NO_WDT_RESET_DETECTE,
+    NO_RESET,
     #[doc = "WDT reset detected. Writing a one clears this reset."]
-    WDT_RESET_DETECTED_,
+    RESET_CLEAR,
 }
 impl WDTW {
     #[allow(missing_docs)]
@@ -406,8 +406,8 @@ impl WDTW {
     #[inline]
     pub fn _bits(&self) -> bool {
         match *self {
-            WDTW::NO_WDT_RESET_DETECTE => false,
-            WDTW::WDT_RESET_DETECTED_ => true,
+            WDTW::NO_RESET => false,
+            WDTW::RESET_CLEAR => true,
         }
     }
 }
@@ -425,13 +425,13 @@ impl<'a> _WDTW<'a> {
     }
     #[doc = "No WDT reset detected"]
     #[inline]
-    pub fn no_wdt_reset_detecte(self) -> &'a mut W {
-        self.variant(WDTW::NO_WDT_RESET_DETECTE)
+    pub fn no_reset(self) -> &'a mut W {
+        self.variant(WDTW::NO_RESET)
     }
     #[doc = "WDT reset detected. Writing a one clears this reset."]
     #[inline]
-    pub fn wdt_reset_detected_(self) -> &'a mut W {
-        self.variant(WDTW::WDT_RESET_DETECTED_)
+    pub fn reset_clear(self) -> &'a mut W {
+        self.variant(WDTW::RESET_CLEAR)
     }
     #[doc = r" Sets the field bit"]
     pub fn set_bit(self) -> &'a mut W {
@@ -454,9 +454,9 @@ impl<'a> _WDTW<'a> {
 #[doc = "Values that can be written to the field `BOD`"]
 pub enum BODW {
     #[doc = "No BOD reset detected"]
-    NO_BOD_RESET_DETECTE,
+    NO_RESET,
     #[doc = "BOD reset detected. Writing a one clears this reset."]
-    BOD_RESET_DETECTED_,
+    RESET_CLEAR,
 }
 impl BODW {
     #[allow(missing_docs)]
@@ -464,8 +464,8 @@ impl BODW {
     #[inline]
     pub fn _bits(&self) -> bool {
         match *self {
-            BODW::NO_BOD_RESET_DETECTE => false,
-            BODW::BOD_RESET_DETECTED_ => true,
+            BODW::NO_RESET => false,
+            BODW::RESET_CLEAR => true,
         }
     }
 }
@@ -483,13 +483,13 @@ impl<'a> _BODW<'a> {
     }
     #[doc = "No BOD reset detected"]
     #[inline]
-    pub fn no_bod_reset_detecte(self) -> &'a mut W {
-        self.variant(BODW::NO_BOD_RESET_DETECTE)
+    pub fn no_reset(self) -> &'a mut W {
+        self.variant(BODW::NO_RESET)
     }
     #[doc = "BOD reset detected. Writing a one clears this reset."]
     #[inline]
-    pub fn bod_reset_detected_(self) -> &'a mut W {
-        self.variant(BODW::BOD_RESET_DETECTED_)
+    pub fn reset_clear(self) -> &'a mut W {
+        self.variant(BODW::RESET_CLEAR)
     }
     #[doc = r" Sets the field bit"]
     pub fn set_bit(self) -> &'a mut W {

--- a/lpc11uxx/src/syscon/usbclkctrl.rs
+++ b/lpc11uxx/src/syscon/usbclkctrl.rs
@@ -46,9 +46,9 @@ impl super::USBCLKCTRL {
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum AP_CLKR {
     #[doc = "Under hardware control."]
-    UNDER_HARDWARE_CONTR,
+    UNDER_HARDWARE_CONTROL,
     #[doc = "Forced HIGH."]
-    FORCED_HIGH_,
+    FORCED_HIGH,
 }
 impl AP_CLKR {
     #[doc = r" Returns `true` if the bit is clear (0)"]
@@ -65,8 +65,8 @@ impl AP_CLKR {
     #[inline]
     pub fn bit(&self) -> bool {
         match *self {
-            AP_CLKR::UNDER_HARDWARE_CONTR => false,
-            AP_CLKR::FORCED_HIGH_ => true,
+            AP_CLKR::UNDER_HARDWARE_CONTROL => false,
+            AP_CLKR::FORCED_HIGH => true,
         }
     }
     #[allow(missing_docs)]
@@ -74,28 +74,28 @@ impl AP_CLKR {
     #[inline]
     pub fn _from(value: bool) -> AP_CLKR {
         match value {
-            false => AP_CLKR::UNDER_HARDWARE_CONTR,
-            true => AP_CLKR::FORCED_HIGH_,
+            false => AP_CLKR::UNDER_HARDWARE_CONTROL,
+            true => AP_CLKR::FORCED_HIGH,
         }
     }
-    #[doc = "Checks if the value of the field is `UNDER_HARDWARE_CONTR`"]
+    #[doc = "Checks if the value of the field is `UNDER_HARDWARE_CONTROL`"]
     #[inline]
-    pub fn is_under_hardware_contr(&self) -> bool {
-        *self == AP_CLKR::UNDER_HARDWARE_CONTR
+    pub fn is_under_hardware_control(&self) -> bool {
+        *self == AP_CLKR::UNDER_HARDWARE_CONTROL
     }
-    #[doc = "Checks if the value of the field is `FORCED_HIGH_`"]
+    #[doc = "Checks if the value of the field is `FORCED_HIGH`"]
     #[inline]
-    pub fn is_forced_high_(&self) -> bool {
-        *self == AP_CLKR::FORCED_HIGH_
+    pub fn is_forced_high(&self) -> bool {
+        *self == AP_CLKR::FORCED_HIGH
     }
 }
 #[doc = "Possible values of the field `POL_CLK`"]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum POL_CLKR {
     #[doc = "Falling edge of the USB need_clock triggers the USB wake-up (default)."]
-    FALLING_EDGE_OF_THE_,
+    FALLING_EDGE,
     #[doc = "Rising edge of the USB need_clock triggers the USB wake-up."]
-    RISING_EDGE_OF_THE_U,
+    RISING_EDGE,
 }
 impl POL_CLKR {
     #[doc = r" Returns `true` if the bit is clear (0)"]
@@ -112,8 +112,8 @@ impl POL_CLKR {
     #[inline]
     pub fn bit(&self) -> bool {
         match *self {
-            POL_CLKR::FALLING_EDGE_OF_THE_ => false,
-            POL_CLKR::RISING_EDGE_OF_THE_U => true,
+            POL_CLKR::FALLING_EDGE => false,
+            POL_CLKR::RISING_EDGE => true,
         }
     }
     #[allow(missing_docs)]
@@ -121,27 +121,27 @@ impl POL_CLKR {
     #[inline]
     pub fn _from(value: bool) -> POL_CLKR {
         match value {
-            false => POL_CLKR::FALLING_EDGE_OF_THE_,
-            true => POL_CLKR::RISING_EDGE_OF_THE_U,
+            false => POL_CLKR::FALLING_EDGE,
+            true => POL_CLKR::RISING_EDGE,
         }
     }
-    #[doc = "Checks if the value of the field is `FALLING_EDGE_OF_THE_`"]
+    #[doc = "Checks if the value of the field is `FALLING_EDGE`"]
     #[inline]
-    pub fn is_falling_edge_of_the_(&self) -> bool {
-        *self == POL_CLKR::FALLING_EDGE_OF_THE_
+    pub fn is_falling_edge(&self) -> bool {
+        *self == POL_CLKR::FALLING_EDGE
     }
-    #[doc = "Checks if the value of the field is `RISING_EDGE_OF_THE_U`"]
+    #[doc = "Checks if the value of the field is `RISING_EDGE`"]
     #[inline]
-    pub fn is_rising_edge_of_the_u(&self) -> bool {
-        *self == POL_CLKR::RISING_EDGE_OF_THE_U
+    pub fn is_rising_edge(&self) -> bool {
+        *self == POL_CLKR::RISING_EDGE
     }
 }
 #[doc = "Values that can be written to the field `AP_CLK`"]
 pub enum AP_CLKW {
     #[doc = "Under hardware control."]
-    UNDER_HARDWARE_CONTR,
+    UNDER_HARDWARE_CONTROL,
     #[doc = "Forced HIGH."]
-    FORCED_HIGH_,
+    FORCED_HIGH,
 }
 impl AP_CLKW {
     #[allow(missing_docs)]
@@ -149,8 +149,8 @@ impl AP_CLKW {
     #[inline]
     pub fn _bits(&self) -> bool {
         match *self {
-            AP_CLKW::UNDER_HARDWARE_CONTR => false,
-            AP_CLKW::FORCED_HIGH_ => true,
+            AP_CLKW::UNDER_HARDWARE_CONTROL => false,
+            AP_CLKW::FORCED_HIGH => true,
         }
     }
 }
@@ -168,13 +168,13 @@ impl<'a> _AP_CLKW<'a> {
     }
     #[doc = "Under hardware control."]
     #[inline]
-    pub fn under_hardware_contr(self) -> &'a mut W {
-        self.variant(AP_CLKW::UNDER_HARDWARE_CONTR)
+    pub fn under_hardware_control(self) -> &'a mut W {
+        self.variant(AP_CLKW::UNDER_HARDWARE_CONTROL)
     }
     #[doc = "Forced HIGH."]
     #[inline]
-    pub fn forced_high_(self) -> &'a mut W {
-        self.variant(AP_CLKW::FORCED_HIGH_)
+    pub fn forced_high(self) -> &'a mut W {
+        self.variant(AP_CLKW::FORCED_HIGH)
     }
     #[doc = r" Sets the field bit"]
     pub fn set_bit(self) -> &'a mut W {
@@ -197,9 +197,9 @@ impl<'a> _AP_CLKW<'a> {
 #[doc = "Values that can be written to the field `POL_CLK`"]
 pub enum POL_CLKW {
     #[doc = "Falling edge of the USB need_clock triggers the USB wake-up (default)."]
-    FALLING_EDGE_OF_THE_,
+    FALLING_EDGE,
     #[doc = "Rising edge of the USB need_clock triggers the USB wake-up."]
-    RISING_EDGE_OF_THE_U,
+    RISING_EDGE,
 }
 impl POL_CLKW {
     #[allow(missing_docs)]
@@ -207,8 +207,8 @@ impl POL_CLKW {
     #[inline]
     pub fn _bits(&self) -> bool {
         match *self {
-            POL_CLKW::FALLING_EDGE_OF_THE_ => false,
-            POL_CLKW::RISING_EDGE_OF_THE_U => true,
+            POL_CLKW::FALLING_EDGE => false,
+            POL_CLKW::RISING_EDGE => true,
         }
     }
 }
@@ -226,13 +226,13 @@ impl<'a> _POL_CLKW<'a> {
     }
     #[doc = "Falling edge of the USB need_clock triggers the USB wake-up (default)."]
     #[inline]
-    pub fn falling_edge_of_the_(self) -> &'a mut W {
-        self.variant(POL_CLKW::FALLING_EDGE_OF_THE_)
+    pub fn falling_edge(self) -> &'a mut W {
+        self.variant(POL_CLKW::FALLING_EDGE)
     }
     #[doc = "Rising edge of the USB need_clock triggers the USB wake-up."]
     #[inline]
-    pub fn rising_edge_of_the_u(self) -> &'a mut W {
-        self.variant(POL_CLKW::RISING_EDGE_OF_THE_U)
+    pub fn rising_edge(self) -> &'a mut W {
+        self.variant(POL_CLKW::RISING_EDGE)
     }
     #[doc = r" Sets the field bit"]
     pub fn set_bit(self) -> &'a mut W {

--- a/lpc11uxx/src/usart/acr.rs
+++ b/lpc11uxx/src/usart/acr.rs
@@ -93,9 +93,9 @@ impl STARTR {
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum MODER {
     #[doc = "Mode 0."]
-    MODE_0_,
+    MODE0,
     #[doc = "Mode 1."]
-    MODE_1_,
+    MODE1,
 }
 impl MODER {
     #[doc = r" Returns `true` if the bit is clear (0)"]
@@ -112,8 +112,8 @@ impl MODER {
     #[inline]
     pub fn bit(&self) -> bool {
         match *self {
-            MODER::MODE_0_ => false,
-            MODER::MODE_1_ => true,
+            MODER::MODE0 => false,
+            MODER::MODE1 => true,
         }
     }
     #[allow(missing_docs)]
@@ -121,19 +121,19 @@ impl MODER {
     #[inline]
     pub fn _from(value: bool) -> MODER {
         match value {
-            false => MODER::MODE_0_,
-            true => MODER::MODE_1_,
+            false => MODER::MODE0,
+            true => MODER::MODE1,
         }
     }
-    #[doc = "Checks if the value of the field is `MODE_0_`"]
+    #[doc = "Checks if the value of the field is `MODE0`"]
     #[inline]
-    pub fn is_mode_0_(&self) -> bool {
-        *self == MODER::MODE_0_
+    pub fn is_mode0(&self) -> bool {
+        *self == MODER::MODE0
     }
-    #[doc = "Checks if the value of the field is `MODE_1_`"]
+    #[doc = "Checks if the value of the field is `MODE1`"]
     #[inline]
-    pub fn is_mode_1_(&self) -> bool {
-        *self == MODER::MODE_1_
+    pub fn is_mode1(&self) -> bool {
+        *self == MODER::MODE1
     }
 }
 #[doc = "Possible values of the field `AUTORESTART`"]
@@ -338,9 +338,9 @@ impl<'a> _STARTW<'a> {
 #[doc = "Values that can be written to the field `MODE`"]
 pub enum MODEW {
     #[doc = "Mode 0."]
-    MODE_0_,
+    MODE0,
     #[doc = "Mode 1."]
-    MODE_1_,
+    MODE1,
 }
 impl MODEW {
     #[allow(missing_docs)]
@@ -348,8 +348,8 @@ impl MODEW {
     #[inline]
     pub fn _bits(&self) -> bool {
         match *self {
-            MODEW::MODE_0_ => false,
-            MODEW::MODE_1_ => true,
+            MODEW::MODE0 => false,
+            MODEW::MODE1 => true,
         }
     }
 }
@@ -367,13 +367,13 @@ impl<'a> _MODEW<'a> {
     }
     #[doc = "Mode 0."]
     #[inline]
-    pub fn mode_0_(self) -> &'a mut W {
-        self.variant(MODEW::MODE_0_)
+    pub fn mode0(self) -> &'a mut W {
+        self.variant(MODEW::MODE0)
     }
     #[doc = "Mode 1."]
     #[inline]
-    pub fn mode_1_(self) -> &'a mut W {
-        self.variant(MODEW::MODE_1_)
+    pub fn mode1(self) -> &'a mut W {
+        self.variant(MODEW::MODE1)
     }
     #[doc = r" Sets the field bit"]
     pub fn set_bit(self) -> &'a mut W {

--- a/lpc11uxx/src/usart/fcr.rs
+++ b/lpc11uxx/src/usart/fcr.rs
@@ -191,13 +191,13 @@ impl<'a> _TXFIFORESW<'a> {
 #[doc = "Values that can be written to the field `RXTL`"]
 pub enum RXTLW {
     #[doc = "Trigger level 0 (1 character or 0x01)."]
-    TRIGGER_LEVEL_0_1_C,
+    LEVEL0,
     #[doc = "Trigger level 1 (4 characters or 0x04)."]
-    TRIGGER_LEVEL_1_4_C,
+    LEVEL1,
     #[doc = "Trigger level 2 (8 characters or 0x08)."]
-    TRIGGER_LEVEL_2_8_C,
+    LEVEL2,
     #[doc = "Trigger level 3 (14 characters or 0x0E)."]
-    TRIGGER_LEVEL_3_14_,
+    LEVEL3,
 }
 impl RXTLW {
     #[allow(missing_docs)]
@@ -205,10 +205,10 @@ impl RXTLW {
     #[inline]
     pub fn _bits(&self) -> u8 {
         match *self {
-            RXTLW::TRIGGER_LEVEL_0_1_C => 0,
-            RXTLW::TRIGGER_LEVEL_1_4_C => 1,
-            RXTLW::TRIGGER_LEVEL_2_8_C => 2,
-            RXTLW::TRIGGER_LEVEL_3_14_ => 3,
+            RXTLW::LEVEL0 => 0,
+            RXTLW::LEVEL1 => 1,
+            RXTLW::LEVEL2 => 2,
+            RXTLW::LEVEL3 => 3,
         }
     }
 }
@@ -226,23 +226,23 @@ impl<'a> _RXTLW<'a> {
     }
     #[doc = "Trigger level 0 (1 character or 0x01)."]
     #[inline]
-    pub fn trigger_level_0_1_c(self) -> &'a mut W {
-        self.variant(RXTLW::TRIGGER_LEVEL_0_1_C)
+    pub fn level0(self) -> &'a mut W {
+        self.variant(RXTLW::LEVEL0)
     }
     #[doc = "Trigger level 1 (4 characters or 0x04)."]
     #[inline]
-    pub fn trigger_level_1_4_c(self) -> &'a mut W {
-        self.variant(RXTLW::TRIGGER_LEVEL_1_4_C)
+    pub fn level1(self) -> &'a mut W {
+        self.variant(RXTLW::LEVEL1)
     }
     #[doc = "Trigger level 2 (8 characters or 0x08)."]
     #[inline]
-    pub fn trigger_level_2_8_c(self) -> &'a mut W {
-        self.variant(RXTLW::TRIGGER_LEVEL_2_8_C)
+    pub fn level2(self) -> &'a mut W {
+        self.variant(RXTLW::LEVEL2)
     }
     #[doc = "Trigger level 3 (14 characters or 0x0E)."]
     #[inline]
-    pub fn trigger_level_3_14_(self) -> &'a mut W {
-        self.variant(RXTLW::TRIGGER_LEVEL_3_14_)
+    pub fn level3(self) -> &'a mut W {
+        self.variant(RXTLW::LEVEL3)
     }
     #[doc = r" Writes raw bits to the field"]
     #[inline]

--- a/lpc11uxx/src/usart/hden.rs
+++ b/lpc11uxx/src/usart/hden.rs
@@ -46,9 +46,9 @@ impl super::HDEN {
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum HDENR {
     #[doc = "Disable half-duplex mode."]
-    DISABLE_HALF_DUPLEX_,
+    DISABLED,
     #[doc = "Enable half-duplex mode."]
-    ENABLE_HALF_DUPLEX_M,
+    ENABLED,
 }
 impl HDENR {
     #[doc = r" Returns `true` if the bit is clear (0)"]
@@ -65,8 +65,8 @@ impl HDENR {
     #[inline]
     pub fn bit(&self) -> bool {
         match *self {
-            HDENR::DISABLE_HALF_DUPLEX_ => false,
-            HDENR::ENABLE_HALF_DUPLEX_M => true,
+            HDENR::DISABLED => false,
+            HDENR::ENABLED => true,
         }
     }
     #[allow(missing_docs)]
@@ -74,27 +74,27 @@ impl HDENR {
     #[inline]
     pub fn _from(value: bool) -> HDENR {
         match value {
-            false => HDENR::DISABLE_HALF_DUPLEX_,
-            true => HDENR::ENABLE_HALF_DUPLEX_M,
+            false => HDENR::DISABLED,
+            true => HDENR::ENABLED,
         }
     }
-    #[doc = "Checks if the value of the field is `DISABLE_HALF_DUPLEX_`"]
+    #[doc = "Checks if the value of the field is `DISABLED`"]
     #[inline]
-    pub fn is_disable_half_duplex_(&self) -> bool {
-        *self == HDENR::DISABLE_HALF_DUPLEX_
+    pub fn is_disabled(&self) -> bool {
+        *self == HDENR::DISABLED
     }
-    #[doc = "Checks if the value of the field is `ENABLE_HALF_DUPLEX_M`"]
+    #[doc = "Checks if the value of the field is `ENABLED`"]
     #[inline]
-    pub fn is_enable_half_duplex_m(&self) -> bool {
-        *self == HDENR::ENABLE_HALF_DUPLEX_M
+    pub fn is_enabled(&self) -> bool {
+        *self == HDENR::ENABLED
     }
 }
 #[doc = "Values that can be written to the field `HDEN`"]
 pub enum HDENW {
     #[doc = "Disable half-duplex mode."]
-    DISABLE_HALF_DUPLEX_,
+    DISABLED,
     #[doc = "Enable half-duplex mode."]
-    ENABLE_HALF_DUPLEX_M,
+    ENABLED,
 }
 impl HDENW {
     #[allow(missing_docs)]
@@ -102,8 +102,8 @@ impl HDENW {
     #[inline]
     pub fn _bits(&self) -> bool {
         match *self {
-            HDENW::DISABLE_HALF_DUPLEX_ => false,
-            HDENW::ENABLE_HALF_DUPLEX_M => true,
+            HDENW::DISABLED => false,
+            HDENW::ENABLED => true,
         }
     }
 }
@@ -121,13 +121,13 @@ impl<'a> _HDENW<'a> {
     }
     #[doc = "Disable half-duplex mode."]
     #[inline]
-    pub fn disable_half_duplex_(self) -> &'a mut W {
-        self.variant(HDENW::DISABLE_HALF_DUPLEX_)
+    pub fn disabled(self) -> &'a mut W {
+        self.variant(HDENW::DISABLED)
     }
     #[doc = "Enable half-duplex mode."]
     #[inline]
-    pub fn enable_half_duplex_m(self) -> &'a mut W {
-        self.variant(HDENW::ENABLE_HALF_DUPLEX_M)
+    pub fn enabled(self) -> &'a mut W {
+        self.variant(HDENW::ENABLED)
     }
     #[doc = r" Sets the field bit"]
     pub fn set_bit(self) -> &'a mut W {

--- a/lpc11uxx/src/usart/icr.rs
+++ b/lpc11uxx/src/usart/icr.rs
@@ -46,9 +46,9 @@ impl super::ICR {
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum IRDAENR {
     #[doc = "IrDA mode is disabled, USARTn acts as a standard USART."]
-    IRDA_MODE_IS_DISABLE,
+    DISABLED,
     #[doc = "IrDA mode is enabled."]
-    IRDA_MODE_IS_ENABLED,
+    ENABLED,
 }
 impl IRDAENR {
     #[doc = r" Returns `true` if the bit is clear (0)"]
@@ -65,8 +65,8 @@ impl IRDAENR {
     #[inline]
     pub fn bit(&self) -> bool {
         match *self {
-            IRDAENR::IRDA_MODE_IS_DISABLE => false,
-            IRDAENR::IRDA_MODE_IS_ENABLED => true,
+            IRDAENR::DISABLED => false,
+            IRDAENR::ENABLED => true,
         }
     }
     #[allow(missing_docs)]
@@ -74,19 +74,19 @@ impl IRDAENR {
     #[inline]
     pub fn _from(value: bool) -> IRDAENR {
         match value {
-            false => IRDAENR::IRDA_MODE_IS_DISABLE,
-            true => IRDAENR::IRDA_MODE_IS_ENABLED,
+            false => IRDAENR::DISABLED,
+            true => IRDAENR::ENABLED,
         }
     }
-    #[doc = "Checks if the value of the field is `IRDA_MODE_IS_DISABLE`"]
+    #[doc = "Checks if the value of the field is `DISABLED`"]
     #[inline]
-    pub fn is_irda_mode_is_disable(&self) -> bool {
-        *self == IRDAENR::IRDA_MODE_IS_DISABLE
+    pub fn is_disabled(&self) -> bool {
+        *self == IRDAENR::DISABLED
     }
-    #[doc = "Checks if the value of the field is `IRDA_MODE_IS_ENABLED`"]
+    #[doc = "Checks if the value of the field is `ENABLED`"]
     #[inline]
-    pub fn is_irda_mode_is_enabled(&self) -> bool {
-        *self == IRDAENR::IRDA_MODE_IS_ENABLED
+    pub fn is_enabled(&self) -> bool {
+        *self == IRDAENR::ENABLED
     }
 }
 #[doc = "Possible values of the field `IRDAINV`"]
@@ -278,9 +278,9 @@ impl PULSEDIVR {
 #[doc = "Values that can be written to the field `IRDAEN`"]
 pub enum IRDAENW {
     #[doc = "IrDA mode is disabled, USARTn acts as a standard USART."]
-    IRDA_MODE_IS_DISABLE,
+    DISABLED,
     #[doc = "IrDA mode is enabled."]
-    IRDA_MODE_IS_ENABLED,
+    ENABLED,
 }
 impl IRDAENW {
     #[allow(missing_docs)]
@@ -288,8 +288,8 @@ impl IRDAENW {
     #[inline]
     pub fn _bits(&self) -> bool {
         match *self {
-            IRDAENW::IRDA_MODE_IS_DISABLE => false,
-            IRDAENW::IRDA_MODE_IS_ENABLED => true,
+            IRDAENW::DISABLED => false,
+            IRDAENW::ENABLED => true,
         }
     }
 }
@@ -307,13 +307,13 @@ impl<'a> _IRDAENW<'a> {
     }
     #[doc = "IrDA mode is disabled, USARTn acts as a standard USART."]
     #[inline]
-    pub fn irda_mode_is_disable(self) -> &'a mut W {
-        self.variant(IRDAENW::IRDA_MODE_IS_DISABLE)
+    pub fn disabled(self) -> &'a mut W {
+        self.variant(IRDAENW::DISABLED)
     }
     #[doc = "IrDA mode is enabled."]
     #[inline]
-    pub fn irda_mode_is_enabled(self) -> &'a mut W {
-        self.variant(IRDAENW::IRDA_MODE_IS_ENABLED)
+    pub fn enabled(self) -> &'a mut W {
+        self.variant(IRDAENW::ENABLED)
     }
     #[doc = r" Sets the field bit"]
     pub fn set_bit(self) -> &'a mut W {

--- a/lpc11uxx/src/usart/ier.rs
+++ b/lpc11uxx/src/usart/ier.rs
@@ -234,9 +234,9 @@ impl MSINTENR {
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum ABEOINTENR {
     #[doc = "Disable end of auto-baud Interrupt."]
-    DISABLE_END_OF_AUTO_,
+    DISABLED,
     #[doc = "Enable end of auto-baud Interrupt."]
-    ENABLE_END_OF_AUTO_B,
+    ENABLED,
 }
 impl ABEOINTENR {
     #[doc = r" Returns `true` if the bit is clear (0)"]
@@ -253,8 +253,8 @@ impl ABEOINTENR {
     #[inline]
     pub fn bit(&self) -> bool {
         match *self {
-            ABEOINTENR::DISABLE_END_OF_AUTO_ => false,
-            ABEOINTENR::ENABLE_END_OF_AUTO_B => true,
+            ABEOINTENR::DISABLED => false,
+            ABEOINTENR::ENABLED => true,
         }
     }
     #[allow(missing_docs)]
@@ -262,28 +262,28 @@ impl ABEOINTENR {
     #[inline]
     pub fn _from(value: bool) -> ABEOINTENR {
         match value {
-            false => ABEOINTENR::DISABLE_END_OF_AUTO_,
-            true => ABEOINTENR::ENABLE_END_OF_AUTO_B,
+            false => ABEOINTENR::DISABLED,
+            true => ABEOINTENR::ENABLED,
         }
     }
-    #[doc = "Checks if the value of the field is `DISABLE_END_OF_AUTO_`"]
+    #[doc = "Checks if the value of the field is `DISABLED`"]
     #[inline]
-    pub fn is_disable_end_of_auto_(&self) -> bool {
-        *self == ABEOINTENR::DISABLE_END_OF_AUTO_
+    pub fn is_disabled(&self) -> bool {
+        *self == ABEOINTENR::DISABLED
     }
-    #[doc = "Checks if the value of the field is `ENABLE_END_OF_AUTO_B`"]
+    #[doc = "Checks if the value of the field is `ENABLED`"]
     #[inline]
-    pub fn is_enable_end_of_auto_b(&self) -> bool {
-        *self == ABEOINTENR::ENABLE_END_OF_AUTO_B
+    pub fn is_enabled(&self) -> bool {
+        *self == ABEOINTENR::ENABLED
     }
 }
 #[doc = "Possible values of the field `ABTOINTEN`"]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum ABTOINTENR {
     #[doc = "Disable auto-baud time-out Interrupt."]
-    DISABLE_AUTO_BAUD_TI,
+    DISABLED,
     #[doc = "Enable auto-baud time-out Interrupt."]
-    ENABLE_AUTO_BAUD_TIM,
+    ENABLED,
 }
 impl ABTOINTENR {
     #[doc = r" Returns `true` if the bit is clear (0)"]
@@ -300,8 +300,8 @@ impl ABTOINTENR {
     #[inline]
     pub fn bit(&self) -> bool {
         match *self {
-            ABTOINTENR::DISABLE_AUTO_BAUD_TI => false,
-            ABTOINTENR::ENABLE_AUTO_BAUD_TIM => true,
+            ABTOINTENR::DISABLED => false,
+            ABTOINTENR::ENABLED => true,
         }
     }
     #[allow(missing_docs)]
@@ -309,19 +309,19 @@ impl ABTOINTENR {
     #[inline]
     pub fn _from(value: bool) -> ABTOINTENR {
         match value {
-            false => ABTOINTENR::DISABLE_AUTO_BAUD_TI,
-            true => ABTOINTENR::ENABLE_AUTO_BAUD_TIM,
+            false => ABTOINTENR::DISABLED,
+            true => ABTOINTENR::ENABLED,
         }
     }
-    #[doc = "Checks if the value of the field is `DISABLE_AUTO_BAUD_TI`"]
+    #[doc = "Checks if the value of the field is `DISABLED`"]
     #[inline]
-    pub fn is_disable_auto_baud_ti(&self) -> bool {
-        *self == ABTOINTENR::DISABLE_AUTO_BAUD_TI
+    pub fn is_disabled(&self) -> bool {
+        *self == ABTOINTENR::DISABLED
     }
-    #[doc = "Checks if the value of the field is `ENABLE_AUTO_BAUD_TIM`"]
+    #[doc = "Checks if the value of the field is `ENABLED`"]
     #[inline]
-    pub fn is_enable_auto_baud_tim(&self) -> bool {
-        *self == ABTOINTENR::ENABLE_AUTO_BAUD_TIM
+    pub fn is_enabled(&self) -> bool {
+        *self == ABTOINTENR::ENABLED
     }
 }
 #[doc = "Values that can be written to the field `RBRINTEN`"]
@@ -559,9 +559,9 @@ impl<'a> _MSINTENW<'a> {
 #[doc = "Values that can be written to the field `ABEOINTEN`"]
 pub enum ABEOINTENW {
     #[doc = "Disable end of auto-baud Interrupt."]
-    DISABLE_END_OF_AUTO_,
+    DISABLED,
     #[doc = "Enable end of auto-baud Interrupt."]
-    ENABLE_END_OF_AUTO_B,
+    ENABLED,
 }
 impl ABEOINTENW {
     #[allow(missing_docs)]
@@ -569,8 +569,8 @@ impl ABEOINTENW {
     #[inline]
     pub fn _bits(&self) -> bool {
         match *self {
-            ABEOINTENW::DISABLE_END_OF_AUTO_ => false,
-            ABEOINTENW::ENABLE_END_OF_AUTO_B => true,
+            ABEOINTENW::DISABLED => false,
+            ABEOINTENW::ENABLED => true,
         }
     }
 }
@@ -588,13 +588,13 @@ impl<'a> _ABEOINTENW<'a> {
     }
     #[doc = "Disable end of auto-baud Interrupt."]
     #[inline]
-    pub fn disable_end_of_auto_(self) -> &'a mut W {
-        self.variant(ABEOINTENW::DISABLE_END_OF_AUTO_)
+    pub fn disabled(self) -> &'a mut W {
+        self.variant(ABEOINTENW::DISABLED)
     }
     #[doc = "Enable end of auto-baud Interrupt."]
     #[inline]
-    pub fn enable_end_of_auto_b(self) -> &'a mut W {
-        self.variant(ABEOINTENW::ENABLE_END_OF_AUTO_B)
+    pub fn enabled(self) -> &'a mut W {
+        self.variant(ABEOINTENW::ENABLED)
     }
     #[doc = r" Sets the field bit"]
     pub fn set_bit(self) -> &'a mut W {
@@ -617,9 +617,9 @@ impl<'a> _ABEOINTENW<'a> {
 #[doc = "Values that can be written to the field `ABTOINTEN`"]
 pub enum ABTOINTENW {
     #[doc = "Disable auto-baud time-out Interrupt."]
-    DISABLE_AUTO_BAUD_TI,
+    DISABLED,
     #[doc = "Enable auto-baud time-out Interrupt."]
-    ENABLE_AUTO_BAUD_TIM,
+    ENABLED,
 }
 impl ABTOINTENW {
     #[allow(missing_docs)]
@@ -627,8 +627,8 @@ impl ABTOINTENW {
     #[inline]
     pub fn _bits(&self) -> bool {
         match *self {
-            ABTOINTENW::DISABLE_AUTO_BAUD_TI => false,
-            ABTOINTENW::ENABLE_AUTO_BAUD_TIM => true,
+            ABTOINTENW::DISABLED => false,
+            ABTOINTENW::ENABLED => true,
         }
     }
 }
@@ -646,13 +646,13 @@ impl<'a> _ABTOINTENW<'a> {
     }
     #[doc = "Disable auto-baud time-out Interrupt."]
     #[inline]
-    pub fn disable_auto_baud_ti(self) -> &'a mut W {
-        self.variant(ABTOINTENW::DISABLE_AUTO_BAUD_TI)
+    pub fn disabled(self) -> &'a mut W {
+        self.variant(ABTOINTENW::DISABLED)
     }
     #[doc = "Enable auto-baud time-out Interrupt."]
     #[inline]
-    pub fn enable_auto_baud_tim(self) -> &'a mut W {
-        self.variant(ABTOINTENW::ENABLE_AUTO_BAUD_TIM)
+    pub fn enabled(self) -> &'a mut W {
+        self.variant(ABTOINTENW::ENABLED)
     }
     #[doc = r" Sets the field bit"]
     pub fn set_bit(self) -> &'a mut W {

--- a/lpc11uxx/src/usart/iir.rs
+++ b/lpc11uxx/src/usart/iir.rs
@@ -15,9 +15,9 @@ impl super::IIR {
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum INTSTATUSR {
     #[doc = "At least one interrupt is pending."]
-    AT_LEAST_ONE_INTERRU,
+    PENDING,
     #[doc = "No interrupt is pending."]
-    NO_INTERRUPT_IS_PEND,
+    NONE,
 }
 impl INTSTATUSR {
     #[doc = r" Returns `true` if the bit is clear (0)"]
@@ -34,8 +34,8 @@ impl INTSTATUSR {
     #[inline]
     pub fn bit(&self) -> bool {
         match *self {
-            INTSTATUSR::AT_LEAST_ONE_INTERRU => false,
-            INTSTATUSR::NO_INTERRUPT_IS_PEND => true,
+            INTSTATUSR::PENDING => false,
+            INTSTATUSR::NONE => true,
         }
     }
     #[allow(missing_docs)]
@@ -43,34 +43,34 @@ impl INTSTATUSR {
     #[inline]
     pub fn _from(value: bool) -> INTSTATUSR {
         match value {
-            false => INTSTATUSR::AT_LEAST_ONE_INTERRU,
-            true => INTSTATUSR::NO_INTERRUPT_IS_PEND,
+            false => INTSTATUSR::PENDING,
+            true => INTSTATUSR::NONE,
         }
     }
-    #[doc = "Checks if the value of the field is `AT_LEAST_ONE_INTERRU`"]
+    #[doc = "Checks if the value of the field is `PENDING`"]
     #[inline]
-    pub fn is_at_least_one_interru(&self) -> bool {
-        *self == INTSTATUSR::AT_LEAST_ONE_INTERRU
+    pub fn is_pending(&self) -> bool {
+        *self == INTSTATUSR::PENDING
     }
-    #[doc = "Checks if the value of the field is `NO_INTERRUPT_IS_PEND`"]
+    #[doc = "Checks if the value of the field is `NONE`"]
     #[inline]
-    pub fn is_no_interrupt_is_pend(&self) -> bool {
-        *self == INTSTATUSR::NO_INTERRUPT_IS_PEND
+    pub fn is_none(&self) -> bool {
+        *self == INTSTATUSR::NONE
     }
 }
 #[doc = "Possible values of the field `INTID`"]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum INTIDR {
     #[doc = "1   - Receive Line Status (RLS)."]
-    _1_RECEIVE_LINE_S,
+    RECEIVE_LINE_STATUS,
     #[doc = "2a - Receive Data Available (RDA)."]
-    _2A_RECEIVE_DATA_AV,
+    RECEIVE_DATA_AVAILABLE,
     #[doc = "2b - Character Time-out Indicator (CTI)."]
-    _2B_CHARACTER_TIME_,
+    CHARACTER_TIMEOUT_INDICATOR,
     #[doc = "3   - THRE Interrupt."]
-    _3_THRE_INTERRUPT,
+    THRE_INTERRUPT,
     #[doc = "4   - Modem status"]
-    _4_MODEM_STATUS,
+    MODEM_STATUS,
     #[doc = r" Reserved"]
     _Reserved(u8),
 }
@@ -79,11 +79,11 @@ impl INTIDR {
     #[inline]
     pub fn bits(&self) -> u8 {
         match *self {
-            INTIDR::_1_RECEIVE_LINE_S => 3,
-            INTIDR::_2A_RECEIVE_DATA_AV => 2,
-            INTIDR::_2B_CHARACTER_TIME_ => 6,
-            INTIDR::_3_THRE_INTERRUPT => 1,
-            INTIDR::_4_MODEM_STATUS => 0,
+            INTIDR::RECEIVE_LINE_STATUS => 3,
+            INTIDR::RECEIVE_DATA_AVAILABLE => 2,
+            INTIDR::CHARACTER_TIMEOUT_INDICATOR => 6,
+            INTIDR::THRE_INTERRUPT => 1,
+            INTIDR::MODEM_STATUS => 0,
             INTIDR::_Reserved(bits) => bits,
         }
     }
@@ -92,38 +92,38 @@ impl INTIDR {
     #[inline]
     pub fn _from(value: u8) -> INTIDR {
         match value {
-            3 => INTIDR::_1_RECEIVE_LINE_S,
-            2 => INTIDR::_2A_RECEIVE_DATA_AV,
-            6 => INTIDR::_2B_CHARACTER_TIME_,
-            1 => INTIDR::_3_THRE_INTERRUPT,
-            0 => INTIDR::_4_MODEM_STATUS,
+            3 => INTIDR::RECEIVE_LINE_STATUS,
+            2 => INTIDR::RECEIVE_DATA_AVAILABLE,
+            6 => INTIDR::CHARACTER_TIMEOUT_INDICATOR,
+            1 => INTIDR::THRE_INTERRUPT,
+            0 => INTIDR::MODEM_STATUS,
             i => INTIDR::_Reserved(i),
         }
     }
-    #[doc = "Checks if the value of the field is `_1_RECEIVE_LINE_S`"]
+    #[doc = "Checks if the value of the field is `RECEIVE_LINE_STATUS`"]
     #[inline]
-    pub fn is_1_receive_line_s(&self) -> bool {
-        *self == INTIDR::_1_RECEIVE_LINE_S
+    pub fn is_receive_line_status(&self) -> bool {
+        *self == INTIDR::RECEIVE_LINE_STATUS
     }
-    #[doc = "Checks if the value of the field is `_2A_RECEIVE_DATA_AV`"]
+    #[doc = "Checks if the value of the field is `RECEIVE_DATA_AVAILABLE`"]
     #[inline]
-    pub fn is_2a_receive_data_av(&self) -> bool {
-        *self == INTIDR::_2A_RECEIVE_DATA_AV
+    pub fn is_receive_data_available(&self) -> bool {
+        *self == INTIDR::RECEIVE_DATA_AVAILABLE
     }
-    #[doc = "Checks if the value of the field is `_2B_CHARACTER_TIME_`"]
+    #[doc = "Checks if the value of the field is `CHARACTER_TIMEOUT_INDICATOR`"]
     #[inline]
-    pub fn is_2b_character_time_(&self) -> bool {
-        *self == INTIDR::_2B_CHARACTER_TIME_
+    pub fn is_character_timeout_indicator(&self) -> bool {
+        *self == INTIDR::CHARACTER_TIMEOUT_INDICATOR
     }
-    #[doc = "Checks if the value of the field is `_3_THRE_INTERRUPT`"]
+    #[doc = "Checks if the value of the field is `THRE_INTERRUPT`"]
     #[inline]
-    pub fn is_3_thre_interrupt(&self) -> bool {
-        *self == INTIDR::_3_THRE_INTERRUPT
+    pub fn is_thre_interrupt(&self) -> bool {
+        *self == INTIDR::THRE_INTERRUPT
     }
-    #[doc = "Checks if the value of the field is `_4_MODEM_STATUS`"]
+    #[doc = "Checks if the value of the field is `MODEM_STATUS`"]
     #[inline]
-    pub fn is_4_modem_status(&self) -> bool {
-        *self == INTIDR::_4_MODEM_STATUS
+    pub fn is_modem_status(&self) -> bool {
+        *self == INTIDR::MODEM_STATUS
     }
 }
 #[doc = r" Value of the field"]

--- a/lpc11uxx/src/usart/lcr.rs
+++ b/lpc11uxx/src/usart/lcr.rs
@@ -102,9 +102,9 @@ impl WLSR {
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum SBSR {
     #[doc = "1 stop bit."]
-    _1_STOP_BIT_,
+    _1_STOP_BIT,
     #[doc = "2 stop bits (1.5 if LCR\\[1:0\\]=00)."]
-    _2_STOP_BITS_1_5_IF_,
+    _2_STOP_BITS_1_5_IF,
 }
 impl SBSR {
     #[doc = r" Returns `true` if the bit is clear (0)"]
@@ -121,8 +121,8 @@ impl SBSR {
     #[inline]
     pub fn bit(&self) -> bool {
         match *self {
-            SBSR::_1_STOP_BIT_ => false,
-            SBSR::_2_STOP_BITS_1_5_IF_ => true,
+            SBSR::_1_STOP_BIT => false,
+            SBSR::_2_STOP_BITS_1_5_IF => true,
         }
     }
     #[allow(missing_docs)]
@@ -130,28 +130,28 @@ impl SBSR {
     #[inline]
     pub fn _from(value: bool) -> SBSR {
         match value {
-            false => SBSR::_1_STOP_BIT_,
-            true => SBSR::_2_STOP_BITS_1_5_IF_,
+            false => SBSR::_1_STOP_BIT,
+            true => SBSR::_2_STOP_BITS_1_5_IF,
         }
     }
-    #[doc = "Checks if the value of the field is `_1_STOP_BIT_`"]
+    #[doc = "Checks if the value of the field is `_1_STOP_BIT`"]
     #[inline]
-    pub fn is_1_stop_bit_(&self) -> bool {
-        *self == SBSR::_1_STOP_BIT_
+    pub fn is_1_stop_bit(&self) -> bool {
+        *self == SBSR::_1_STOP_BIT
     }
-    #[doc = "Checks if the value of the field is `_2_STOP_BITS_1_5_IF_`"]
+    #[doc = "Checks if the value of the field is `_2_STOP_BITS_1_5_IF`"]
     #[inline]
-    pub fn is_2_stop_bits_1_5_if_(&self) -> bool {
-        *self == SBSR::_2_STOP_BITS_1_5_IF_
+    pub fn is_2_stop_bits_1_5_if(&self) -> bool {
+        *self == SBSR::_2_STOP_BITS_1_5_IF
     }
 }
 #[doc = "Possible values of the field `PE`"]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum PER {
     #[doc = "Disable parity generation and checking."]
-    DISABLE_PARITY_GENER,
+    DISABLED,
     #[doc = "Enable parity generation and checking."]
-    ENABLE_PARITY_GENERA,
+    ENABLED,
 }
 impl PER {
     #[doc = r" Returns `true` if the bit is clear (0)"]
@@ -168,8 +168,8 @@ impl PER {
     #[inline]
     pub fn bit(&self) -> bool {
         match *self {
-            PER::DISABLE_PARITY_GENER => false,
-            PER::ENABLE_PARITY_GENERA => true,
+            PER::DISABLED => false,
+            PER::ENABLED => true,
         }
     }
     #[allow(missing_docs)]
@@ -177,42 +177,42 @@ impl PER {
     #[inline]
     pub fn _from(value: bool) -> PER {
         match value {
-            false => PER::DISABLE_PARITY_GENER,
-            true => PER::ENABLE_PARITY_GENERA,
+            false => PER::DISABLED,
+            true => PER::ENABLED,
         }
     }
-    #[doc = "Checks if the value of the field is `DISABLE_PARITY_GENER`"]
+    #[doc = "Checks if the value of the field is `DISABLED`"]
     #[inline]
-    pub fn is_disable_parity_gener(&self) -> bool {
-        *self == PER::DISABLE_PARITY_GENER
+    pub fn is_disabled(&self) -> bool {
+        *self == PER::DISABLED
     }
-    #[doc = "Checks if the value of the field is `ENABLE_PARITY_GENERA`"]
+    #[doc = "Checks if the value of the field is `ENABLED`"]
     #[inline]
-    pub fn is_enable_parity_genera(&self) -> bool {
-        *self == PER::ENABLE_PARITY_GENERA
+    pub fn is_enabled(&self) -> bool {
+        *self == PER::ENABLED
     }
 }
 #[doc = "Possible values of the field `PS`"]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum PSR {
     #[doc = "Odd parity. Number of 1s in the transmitted character and the attached parity bit will be odd."]
-    ODD_PARITY_NUMBER_O,
+    ODD,
     #[doc = "Even Parity. Number of 1s in the transmitted character and the attached parity bit will be even."]
-    EVEN_PARITY_NUMBER_,
+    EVEN,
     #[doc = "Forced 1 stick parity."]
-    FORCED_1_STICK_PARIT,
+    FORCED_1_STICK,
     #[doc = "Forced 0 stick parity."]
-    FORCED_0_STICK_PARIT,
+    FORCED_0_STICK,
 }
 impl PSR {
     #[doc = r" Value of the field as raw bits"]
     #[inline]
     pub fn bits(&self) -> u8 {
         match *self {
-            PSR::ODD_PARITY_NUMBER_O => 0,
-            PSR::EVEN_PARITY_NUMBER_ => 1,
-            PSR::FORCED_1_STICK_PARIT => 2,
-            PSR::FORCED_0_STICK_PARIT => 3,
+            PSR::ODD => 0,
+            PSR::EVEN => 1,
+            PSR::FORCED_1_STICK => 2,
+            PSR::FORCED_0_STICK => 3,
         }
     }
     #[allow(missing_docs)]
@@ -220,32 +220,32 @@ impl PSR {
     #[inline]
     pub fn _from(value: u8) -> PSR {
         match value {
-            0 => PSR::ODD_PARITY_NUMBER_O,
-            1 => PSR::EVEN_PARITY_NUMBER_,
-            2 => PSR::FORCED_1_STICK_PARIT,
-            3 => PSR::FORCED_0_STICK_PARIT,
+            0 => PSR::ODD,
+            1 => PSR::EVEN,
+            2 => PSR::FORCED_1_STICK,
+            3 => PSR::FORCED_0_STICK,
             _ => unreachable!(),
         }
     }
-    #[doc = "Checks if the value of the field is `ODD_PARITY_NUMBER_O`"]
+    #[doc = "Checks if the value of the field is `ODD`"]
     #[inline]
-    pub fn is_odd_parity_number_o(&self) -> bool {
-        *self == PSR::ODD_PARITY_NUMBER_O
+    pub fn is_odd(&self) -> bool {
+        *self == PSR::ODD
     }
-    #[doc = "Checks if the value of the field is `EVEN_PARITY_NUMBER_`"]
+    #[doc = "Checks if the value of the field is `EVEN`"]
     #[inline]
-    pub fn is_even_parity_number_(&self) -> bool {
-        *self == PSR::EVEN_PARITY_NUMBER_
+    pub fn is_even(&self) -> bool {
+        *self == PSR::EVEN
     }
-    #[doc = "Checks if the value of the field is `FORCED_1_STICK_PARIT`"]
+    #[doc = "Checks if the value of the field is `FORCED_1_STICK`"]
     #[inline]
-    pub fn is_forced_1_stick_parit(&self) -> bool {
-        *self == PSR::FORCED_1_STICK_PARIT
+    pub fn is_forced_1_stick(&self) -> bool {
+        *self == PSR::FORCED_1_STICK
     }
-    #[doc = "Checks if the value of the field is `FORCED_0_STICK_PARIT`"]
+    #[doc = "Checks if the value of the field is `FORCED_0_STICK`"]
     #[inline]
-    pub fn is_forced_0_stick_parit(&self) -> bool {
-        *self == PSR::FORCED_0_STICK_PARIT
+    pub fn is_forced_0_stick(&self) -> bool {
+        *self == PSR::FORCED_0_STICK
     }
 }
 #[doc = "Possible values of the field `BC`"]
@@ -411,9 +411,9 @@ impl<'a> _WLSW<'a> {
 #[doc = "Values that can be written to the field `SBS`"]
 pub enum SBSW {
     #[doc = "1 stop bit."]
-    _1_STOP_BIT_,
+    _1_STOP_BIT,
     #[doc = "2 stop bits (1.5 if LCR\\[1:0\\]=00)."]
-    _2_STOP_BITS_1_5_IF_,
+    _2_STOP_BITS_1_5_IF,
 }
 impl SBSW {
     #[allow(missing_docs)]
@@ -421,8 +421,8 @@ impl SBSW {
     #[inline]
     pub fn _bits(&self) -> bool {
         match *self {
-            SBSW::_1_STOP_BIT_ => false,
-            SBSW::_2_STOP_BITS_1_5_IF_ => true,
+            SBSW::_1_STOP_BIT => false,
+            SBSW::_2_STOP_BITS_1_5_IF => true,
         }
     }
 }
@@ -440,13 +440,13 @@ impl<'a> _SBSW<'a> {
     }
     #[doc = "1 stop bit."]
     #[inline]
-    pub fn _1_stop_bit_(self) -> &'a mut W {
-        self.variant(SBSW::_1_STOP_BIT_)
+    pub fn _1_stop_bit(self) -> &'a mut W {
+        self.variant(SBSW::_1_STOP_BIT)
     }
     #[doc = "2 stop bits (1.5 if LCR\\[1:0\\]=00)."]
     #[inline]
-    pub fn _2_stop_bits_1_5_if_(self) -> &'a mut W {
-        self.variant(SBSW::_2_STOP_BITS_1_5_IF_)
+    pub fn _2_stop_bits_1_5_if(self) -> &'a mut W {
+        self.variant(SBSW::_2_STOP_BITS_1_5_IF)
     }
     #[doc = r" Sets the field bit"]
     pub fn set_bit(self) -> &'a mut W {
@@ -469,9 +469,9 @@ impl<'a> _SBSW<'a> {
 #[doc = "Values that can be written to the field `PE`"]
 pub enum PEW {
     #[doc = "Disable parity generation and checking."]
-    DISABLE_PARITY_GENER,
+    DISABLED,
     #[doc = "Enable parity generation and checking."]
-    ENABLE_PARITY_GENERA,
+    ENABLED,
 }
 impl PEW {
     #[allow(missing_docs)]
@@ -479,8 +479,8 @@ impl PEW {
     #[inline]
     pub fn _bits(&self) -> bool {
         match *self {
-            PEW::DISABLE_PARITY_GENER => false,
-            PEW::ENABLE_PARITY_GENERA => true,
+            PEW::DISABLED => false,
+            PEW::ENABLED => true,
         }
     }
 }
@@ -498,13 +498,13 @@ impl<'a> _PEW<'a> {
     }
     #[doc = "Disable parity generation and checking."]
     #[inline]
-    pub fn disable_parity_gener(self) -> &'a mut W {
-        self.variant(PEW::DISABLE_PARITY_GENER)
+    pub fn disabled(self) -> &'a mut W {
+        self.variant(PEW::DISABLED)
     }
     #[doc = "Enable parity generation and checking."]
     #[inline]
-    pub fn enable_parity_genera(self) -> &'a mut W {
-        self.variant(PEW::ENABLE_PARITY_GENERA)
+    pub fn enabled(self) -> &'a mut W {
+        self.variant(PEW::ENABLED)
     }
     #[doc = r" Sets the field bit"]
     pub fn set_bit(self) -> &'a mut W {
@@ -527,13 +527,13 @@ impl<'a> _PEW<'a> {
 #[doc = "Values that can be written to the field `PS`"]
 pub enum PSW {
     #[doc = "Odd parity. Number of 1s in the transmitted character and the attached parity bit will be odd."]
-    ODD_PARITY_NUMBER_O,
+    ODD,
     #[doc = "Even Parity. Number of 1s in the transmitted character and the attached parity bit will be even."]
-    EVEN_PARITY_NUMBER_,
+    EVEN,
     #[doc = "Forced 1 stick parity."]
-    FORCED_1_STICK_PARIT,
+    FORCED_1_STICK,
     #[doc = "Forced 0 stick parity."]
-    FORCED_0_STICK_PARIT,
+    FORCED_0_STICK,
 }
 impl PSW {
     #[allow(missing_docs)]
@@ -541,10 +541,10 @@ impl PSW {
     #[inline]
     pub fn _bits(&self) -> u8 {
         match *self {
-            PSW::ODD_PARITY_NUMBER_O => 0,
-            PSW::EVEN_PARITY_NUMBER_ => 1,
-            PSW::FORCED_1_STICK_PARIT => 2,
-            PSW::FORCED_0_STICK_PARIT => 3,
+            PSW::ODD => 0,
+            PSW::EVEN => 1,
+            PSW::FORCED_1_STICK => 2,
+            PSW::FORCED_0_STICK => 3,
         }
     }
 }
@@ -562,23 +562,23 @@ impl<'a> _PSW<'a> {
     }
     #[doc = "Odd parity. Number of 1s in the transmitted character and the attached parity bit will be odd."]
     #[inline]
-    pub fn odd_parity_number_o(self) -> &'a mut W {
-        self.variant(PSW::ODD_PARITY_NUMBER_O)
+    pub fn odd(self) -> &'a mut W {
+        self.variant(PSW::ODD)
     }
     #[doc = "Even Parity. Number of 1s in the transmitted character and the attached parity bit will be even."]
     #[inline]
-    pub fn even_parity_number_(self) -> &'a mut W {
-        self.variant(PSW::EVEN_PARITY_NUMBER_)
+    pub fn even(self) -> &'a mut W {
+        self.variant(PSW::EVEN)
     }
     #[doc = "Forced 1 stick parity."]
     #[inline]
-    pub fn forced_1_stick_parit(self) -> &'a mut W {
-        self.variant(PSW::FORCED_1_STICK_PARIT)
+    pub fn forced_1_stick(self) -> &'a mut W {
+        self.variant(PSW::FORCED_1_STICK)
     }
     #[doc = "Forced 0 stick parity."]
     #[inline]
-    pub fn forced_0_stick_parit(self) -> &'a mut W {
-        self.variant(PSW::FORCED_0_STICK_PARIT)
+    pub fn forced_0_stick(self) -> &'a mut W {
+        self.variant(PSW::FORCED_0_STICK)
     }
     #[doc = r" Writes raw bits to the field"]
     #[inline]

--- a/lpc11uxx/src/usart/lsr.rs
+++ b/lpc11uxx/src/usart/lsr.rs
@@ -15,9 +15,9 @@ impl super::LSR {
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum RDRR {
     #[doc = "RBR is empty."]
-    RBR_IS_EMPTY_,
+    EMPTY,
     #[doc = "RBR contains valid data."]
-    RBR_CONTAINS_VALID_D,
+    VALID,
 }
 impl RDRR {
     #[doc = r" Returns `true` if the bit is clear (0)"]
@@ -34,8 +34,8 @@ impl RDRR {
     #[inline]
     pub fn bit(&self) -> bool {
         match *self {
-            RDRR::RBR_IS_EMPTY_ => false,
-            RDRR::RBR_CONTAINS_VALID_D => true,
+            RDRR::EMPTY => false,
+            RDRR::VALID => true,
         }
     }
     #[allow(missing_docs)]
@@ -43,19 +43,19 @@ impl RDRR {
     #[inline]
     pub fn _from(value: bool) -> RDRR {
         match value {
-            false => RDRR::RBR_IS_EMPTY_,
-            true => RDRR::RBR_CONTAINS_VALID_D,
+            false => RDRR::EMPTY,
+            true => RDRR::VALID,
         }
     }
-    #[doc = "Checks if the value of the field is `RBR_IS_EMPTY_`"]
+    #[doc = "Checks if the value of the field is `EMPTY`"]
     #[inline]
-    pub fn is_rbr_is_empty_(&self) -> bool {
-        *self == RDRR::RBR_IS_EMPTY_
+    pub fn is_empty(&self) -> bool {
+        *self == RDRR::EMPTY
     }
-    #[doc = "Checks if the value of the field is `RBR_CONTAINS_VALID_D`"]
+    #[doc = "Checks if the value of the field is `VALID`"]
     #[inline]
-    pub fn is_rbr_contains_valid_d(&self) -> bool {
-        *self == RDRR::RBR_CONTAINS_VALID_D
+    pub fn is_valid(&self) -> bool {
+        *self == RDRR::VALID
     }
 }
 #[doc = "Possible values of the field `OE`"]
@@ -250,9 +250,9 @@ impl BIR {
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum THRER {
     #[doc = "THR contains valid data."]
-    THR_CONTAINS_VALID_D,
+    VALID,
     #[doc = "THR is empty."]
-    THR_IS_EMPTY_,
+    EMPTY,
 }
 impl THRER {
     #[doc = r" Returns `true` if the bit is clear (0)"]
@@ -269,8 +269,8 @@ impl THRER {
     #[inline]
     pub fn bit(&self) -> bool {
         match *self {
-            THRER::THR_CONTAINS_VALID_D => false,
-            THRER::THR_IS_EMPTY_ => true,
+            THRER::VALID => false,
+            THRER::EMPTY => true,
         }
     }
     #[allow(missing_docs)]
@@ -278,26 +278,26 @@ impl THRER {
     #[inline]
     pub fn _from(value: bool) -> THRER {
         match value {
-            false => THRER::THR_CONTAINS_VALID_D,
-            true => THRER::THR_IS_EMPTY_,
+            false => THRER::VALID,
+            true => THRER::EMPTY,
         }
     }
-    #[doc = "Checks if the value of the field is `THR_CONTAINS_VALID_D`"]
+    #[doc = "Checks if the value of the field is `VALID`"]
     #[inline]
-    pub fn is_thr_contains_valid_d(&self) -> bool {
-        *self == THRER::THR_CONTAINS_VALID_D
+    pub fn is_valid(&self) -> bool {
+        *self == THRER::VALID
     }
-    #[doc = "Checks if the value of the field is `THR_IS_EMPTY_`"]
+    #[doc = "Checks if the value of the field is `EMPTY`"]
     #[inline]
-    pub fn is_thr_is_empty_(&self) -> bool {
-        *self == THRER::THR_IS_EMPTY_
+    pub fn is_empty(&self) -> bool {
+        *self == THRER::EMPTY
     }
 }
 #[doc = "Possible values of the field `TEMT`"]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum TEMTR {
     #[doc = "THR and/or the TSR contains valid data."]
-    VALID_D,
+    VALID,
     #[doc = "THR and the TSR are empty."]
     EMPTY,
 }
@@ -316,7 +316,7 @@ impl TEMTR {
     #[inline]
     pub fn bit(&self) -> bool {
         match *self {
-            TEMTR::VALID_D => false,
+            TEMTR::VALID => false,
             TEMTR::EMPTY => true,
         }
     }
@@ -325,14 +325,14 @@ impl TEMTR {
     #[inline]
     pub fn _from(value: bool) -> TEMTR {
         match value {
-            false => TEMTR::VALID_D,
+            false => TEMTR::VALID,
             true => TEMTR::EMPTY,
         }
     }
-    #[doc = "Checks if the value of the field is `VALID_D`"]
+    #[doc = "Checks if the value of the field is `VALID`"]
     #[inline]
-    pub fn is_valid_d(&self) -> bool {
-        *self == TEMTR::VALID_D
+    pub fn is_valid(&self) -> bool {
+        *self == TEMTR::VALID
     }
     #[doc = "Checks if the value of the field is `EMPTY`"]
     #[inline]

--- a/lpc11uxx/src/usart/rs485ctrl.rs
+++ b/lpc11uxx/src/usart/rs485ctrl.rs
@@ -93,9 +93,9 @@ impl NMMENR {
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum RXDISR {
     #[doc = "The receiver is enabled."]
-    THE_RECEIVER_IS_ENAB,
+    ENABLED,
     #[doc = "The receiver is disabled."]
-    THE_RECEIVER_IS_DISA,
+    DISABLED,
 }
 impl RXDISR {
     #[doc = r" Returns `true` if the bit is clear (0)"]
@@ -112,8 +112,8 @@ impl RXDISR {
     #[inline]
     pub fn bit(&self) -> bool {
         match *self {
-            RXDISR::THE_RECEIVER_IS_ENAB => false,
-            RXDISR::THE_RECEIVER_IS_DISA => true,
+            RXDISR::ENABLED => false,
+            RXDISR::DISABLED => true,
         }
     }
     #[allow(missing_docs)]
@@ -121,28 +121,28 @@ impl RXDISR {
     #[inline]
     pub fn _from(value: bool) -> RXDISR {
         match value {
-            false => RXDISR::THE_RECEIVER_IS_ENAB,
-            true => RXDISR::THE_RECEIVER_IS_DISA,
+            false => RXDISR::ENABLED,
+            true => RXDISR::DISABLED,
         }
     }
-    #[doc = "Checks if the value of the field is `THE_RECEIVER_IS_ENAB`"]
+    #[doc = "Checks if the value of the field is `ENABLED`"]
     #[inline]
-    pub fn is_the_receiver_is_enab(&self) -> bool {
-        *self == RXDISR::THE_RECEIVER_IS_ENAB
+    pub fn is_enabled(&self) -> bool {
+        *self == RXDISR::ENABLED
     }
-    #[doc = "Checks if the value of the field is `THE_RECEIVER_IS_DISA`"]
+    #[doc = "Checks if the value of the field is `DISABLED`"]
     #[inline]
-    pub fn is_the_receiver_is_disa(&self) -> bool {
-        *self == RXDISR::THE_RECEIVER_IS_DISA
+    pub fn is_disabled(&self) -> bool {
+        *self == RXDISR::DISABLED
     }
 }
 #[doc = "Possible values of the field `AADEN`"]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum AADENR {
     #[doc = "Auto Address Detect (AAD) is disabled."]
-    AUTO_ADDRESS_DETECT_DISABLE,
+    DISABLED,
     #[doc = "Auto Address Detect (AAD) is enabled."]
-    AUTO_ADDRESS_DETECT_ENABLE,
+    ENABLED,
 }
 impl AADENR {
     #[doc = r" Returns `true` if the bit is clear (0)"]
@@ -159,8 +159,8 @@ impl AADENR {
     #[inline]
     pub fn bit(&self) -> bool {
         match *self {
-            AADENR::AUTO_ADDRESS_DETECT_DISABLE => false,
-            AADENR::AUTO_ADDRESS_DETECT_ENABLE => true,
+            AADENR::DISABLED => false,
+            AADENR::ENABLED => true,
         }
     }
     #[allow(missing_docs)]
@@ -168,19 +168,19 @@ impl AADENR {
     #[inline]
     pub fn _from(value: bool) -> AADENR {
         match value {
-            false => AADENR::AUTO_ADDRESS_DETECT_DISABLE,
-            true => AADENR::AUTO_ADDRESS_DETECT_ENABLE,
+            false => AADENR::DISABLED,
+            true => AADENR::ENABLED,
         }
     }
-    #[doc = "Checks if the value of the field is `AUTO_ADDRESS_DETECT_DISABLE`"]
+    #[doc = "Checks if the value of the field is `DISABLED`"]
     #[inline]
-    pub fn is_auto_address_detect_disable(&self) -> bool {
-        *self == AADENR::AUTO_ADDRESS_DETECT_DISABLE
+    pub fn is_disabled(&self) -> bool {
+        *self == AADENR::DISABLED
     }
-    #[doc = "Checks if the value of the field is `AUTO_ADDRESS_DETECT_ENABLE`"]
+    #[doc = "Checks if the value of the field is `ENABLED`"]
     #[inline]
-    pub fn is_auto_address_detect_enable(&self) -> bool {
-        *self == AADENR::AUTO_ADDRESS_DETECT_ENABLE
+    pub fn is_enabled(&self) -> bool {
+        *self == AADENR::ENABLED
     }
 }
 #[doc = "Possible values of the field `SEL`"]
@@ -385,9 +385,9 @@ impl<'a> _NMMENW<'a> {
 #[doc = "Values that can be written to the field `RXDIS`"]
 pub enum RXDISW {
     #[doc = "The receiver is enabled."]
-    THE_RECEIVER_IS_ENAB,
+    ENABLED,
     #[doc = "The receiver is disabled."]
-    THE_RECEIVER_IS_DISA,
+    DISABLED,
 }
 impl RXDISW {
     #[allow(missing_docs)]
@@ -395,8 +395,8 @@ impl RXDISW {
     #[inline]
     pub fn _bits(&self) -> bool {
         match *self {
-            RXDISW::THE_RECEIVER_IS_ENAB => false,
-            RXDISW::THE_RECEIVER_IS_DISA => true,
+            RXDISW::ENABLED => false,
+            RXDISW::DISABLED => true,
         }
     }
 }
@@ -414,13 +414,13 @@ impl<'a> _RXDISW<'a> {
     }
     #[doc = "The receiver is enabled."]
     #[inline]
-    pub fn the_receiver_is_enab(self) -> &'a mut W {
-        self.variant(RXDISW::THE_RECEIVER_IS_ENAB)
+    pub fn enabled(self) -> &'a mut W {
+        self.variant(RXDISW::ENABLED)
     }
     #[doc = "The receiver is disabled."]
     #[inline]
-    pub fn the_receiver_is_disa(self) -> &'a mut W {
-        self.variant(RXDISW::THE_RECEIVER_IS_DISA)
+    pub fn disabled(self) -> &'a mut W {
+        self.variant(RXDISW::DISABLED)
     }
     #[doc = r" Sets the field bit"]
     pub fn set_bit(self) -> &'a mut W {
@@ -443,9 +443,9 @@ impl<'a> _RXDISW<'a> {
 #[doc = "Values that can be written to the field `AADEN`"]
 pub enum AADENW {
     #[doc = "Auto Address Detect (AAD) is disabled."]
-    AUTO_ADDRESS_DETECT_DISABLE,
+    DISABLED,
     #[doc = "Auto Address Detect (AAD) is enabled."]
-    AUTO_ADDRESS_DETECT_ENABLE,
+    ENABLED,
 }
 impl AADENW {
     #[allow(missing_docs)]
@@ -453,8 +453,8 @@ impl AADENW {
     #[inline]
     pub fn _bits(&self) -> bool {
         match *self {
-            AADENW::AUTO_ADDRESS_DETECT_DISABLE => false,
-            AADENW::AUTO_ADDRESS_DETECT_ENABLE => true,
+            AADENW::DISABLED => false,
+            AADENW::ENABLED => true,
         }
     }
 }
@@ -472,13 +472,13 @@ impl<'a> _AADENW<'a> {
     }
     #[doc = "Auto Address Detect (AAD) is disabled."]
     #[inline]
-    pub fn auto_address_detect_disable(self) -> &'a mut W {
-        self.variant(AADENW::AUTO_ADDRESS_DETECT_DISABLE)
+    pub fn disabled(self) -> &'a mut W {
+        self.variant(AADENW::DISABLED)
     }
     #[doc = "Auto Address Detect (AAD) is enabled."]
     #[inline]
-    pub fn auto_address_detect_enable(self) -> &'a mut W {
-        self.variant(AADENW::AUTO_ADDRESS_DETECT_ENABLE)
+    pub fn enabled(self) -> &'a mut W {
+        self.variant(AADENW::ENABLED)
     }
     #[doc = r" Sets the field bit"]
     pub fn set_bit(self) -> &'a mut W {

--- a/lpc11uxx/src/usart/syncctrl.rs
+++ b/lpc11uxx/src/usart/syncctrl.rs
@@ -281,9 +281,9 @@ impl CSCENR {
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum SSDISR {
     #[doc = "Send start and stop bits as in other modes."]
-    SEND_START_AND_STOP_,
+    SEND_START_STOP,
     #[doc = "Do not send start/stop bits."]
-    DO_NOT_SEND_STARTSTOP,
+    DONT_SEND_START_STOP,
 }
 impl SSDISR {
     #[doc = r" Returns `true` if the bit is clear (0)"]
@@ -300,8 +300,8 @@ impl SSDISR {
     #[inline]
     pub fn bit(&self) -> bool {
         match *self {
-            SSDISR::SEND_START_AND_STOP_ => false,
-            SSDISR::DO_NOT_SEND_STARTSTOP => true,
+            SSDISR::SEND_START_STOP => false,
+            SSDISR::DONT_SEND_START_STOP => true,
         }
     }
     #[allow(missing_docs)]
@@ -309,28 +309,28 @@ impl SSDISR {
     #[inline]
     pub fn _from(value: bool) -> SSDISR {
         match value {
-            false => SSDISR::SEND_START_AND_STOP_,
-            true => SSDISR::DO_NOT_SEND_STARTSTOP,
+            false => SSDISR::SEND_START_STOP,
+            true => SSDISR::DONT_SEND_START_STOP,
         }
     }
-    #[doc = "Checks if the value of the field is `SEND_START_AND_STOP_`"]
+    #[doc = "Checks if the value of the field is `SEND_START_STOP`"]
     #[inline]
-    pub fn is_send_start_and_stop_(&self) -> bool {
-        *self == SSDISR::SEND_START_AND_STOP_
+    pub fn is_send_start_stop(&self) -> bool {
+        *self == SSDISR::SEND_START_STOP
     }
-    #[doc = "Checks if the value of the field is `DO_NOT_SEND_STARTSTOP`"]
+    #[doc = "Checks if the value of the field is `DONT_SEND_START_STOP`"]
     #[inline]
-    pub fn is_do_not_send_startstop(&self) -> bool {
-        *self == SSDISR::DO_NOT_SEND_STARTSTOP
+    pub fn is_dont_send_start_stop(&self) -> bool {
+        *self == SSDISR::DONT_SEND_START_STOP
     }
 }
 #[doc = "Possible values of the field `CCCLR`"]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum CCCLRR {
     #[doc = "CSCEN is under software control."]
-    CSCEN_IS_UNDER_SOFTW,
+    SOFTWARE,
     #[doc = "Hardware clears CSCEN after each character is received."]
-    HARDWARE_CLEARS_CSCE,
+    HARDWARE,
 }
 impl CCCLRR {
     #[doc = r" Returns `true` if the bit is clear (0)"]
@@ -347,8 +347,8 @@ impl CCCLRR {
     #[inline]
     pub fn bit(&self) -> bool {
         match *self {
-            CCCLRR::CSCEN_IS_UNDER_SOFTW => false,
-            CCCLRR::HARDWARE_CLEARS_CSCE => true,
+            CCCLRR::SOFTWARE => false,
+            CCCLRR::HARDWARE => true,
         }
     }
     #[allow(missing_docs)]
@@ -356,19 +356,19 @@ impl CCCLRR {
     #[inline]
     pub fn _from(value: bool) -> CCCLRR {
         match value {
-            false => CCCLRR::CSCEN_IS_UNDER_SOFTW,
-            true => CCCLRR::HARDWARE_CLEARS_CSCE,
+            false => CCCLRR::SOFTWARE,
+            true => CCCLRR::HARDWARE,
         }
     }
-    #[doc = "Checks if the value of the field is `CSCEN_IS_UNDER_SOFTW`"]
+    #[doc = "Checks if the value of the field is `SOFTWARE`"]
     #[inline]
-    pub fn is_cscen_is_under_softw(&self) -> bool {
-        *self == CCCLRR::CSCEN_IS_UNDER_SOFTW
+    pub fn is_software(&self) -> bool {
+        *self == CCCLRR::SOFTWARE
     }
-    #[doc = "Checks if the value of the field is `HARDWARE_CLEARS_CSCE`"]
+    #[doc = "Checks if the value of the field is `HARDWARE`"]
     #[inline]
-    pub fn is_hardware_clears_csce(&self) -> bool {
-        *self == CCCLRR::HARDWARE_CLEARS_CSCE
+    pub fn is_hardware(&self) -> bool {
+        *self == CCCLRR::HARDWARE
     }
 }
 #[doc = "Values that can be written to the field `SYNC`"]
@@ -664,9 +664,9 @@ impl<'a> _CSCENW<'a> {
 #[doc = "Values that can be written to the field `SSDIS`"]
 pub enum SSDISW {
     #[doc = "Send start and stop bits as in other modes."]
-    SEND_START_AND_STOP_,
+    SEND_START_STOP,
     #[doc = "Do not send start/stop bits."]
-    DO_NOT_SEND_STARTSTOP,
+    DONT_SEND_START_STOP,
 }
 impl SSDISW {
     #[allow(missing_docs)]
@@ -674,8 +674,8 @@ impl SSDISW {
     #[inline]
     pub fn _bits(&self) -> bool {
         match *self {
-            SSDISW::SEND_START_AND_STOP_ => false,
-            SSDISW::DO_NOT_SEND_STARTSTOP => true,
+            SSDISW::SEND_START_STOP => false,
+            SSDISW::DONT_SEND_START_STOP => true,
         }
     }
 }
@@ -693,13 +693,13 @@ impl<'a> _SSDISW<'a> {
     }
     #[doc = "Send start and stop bits as in other modes."]
     #[inline]
-    pub fn send_start_and_stop_(self) -> &'a mut W {
-        self.variant(SSDISW::SEND_START_AND_STOP_)
+    pub fn send_start_stop(self) -> &'a mut W {
+        self.variant(SSDISW::SEND_START_STOP)
     }
     #[doc = "Do not send start/stop bits."]
     #[inline]
-    pub fn do_not_send_startstop(self) -> &'a mut W {
-        self.variant(SSDISW::DO_NOT_SEND_STARTSTOP)
+    pub fn dont_send_start_stop(self) -> &'a mut W {
+        self.variant(SSDISW::DONT_SEND_START_STOP)
     }
     #[doc = r" Sets the field bit"]
     pub fn set_bit(self) -> &'a mut W {
@@ -722,9 +722,9 @@ impl<'a> _SSDISW<'a> {
 #[doc = "Values that can be written to the field `CCCLR`"]
 pub enum CCCLRW {
     #[doc = "CSCEN is under software control."]
-    CSCEN_IS_UNDER_SOFTW,
+    SOFTWARE,
     #[doc = "Hardware clears CSCEN after each character is received."]
-    HARDWARE_CLEARS_CSCE,
+    HARDWARE,
 }
 impl CCCLRW {
     #[allow(missing_docs)]
@@ -732,8 +732,8 @@ impl CCCLRW {
     #[inline]
     pub fn _bits(&self) -> bool {
         match *self {
-            CCCLRW::CSCEN_IS_UNDER_SOFTW => false,
-            CCCLRW::HARDWARE_CLEARS_CSCE => true,
+            CCCLRW::SOFTWARE => false,
+            CCCLRW::HARDWARE => true,
         }
     }
 }
@@ -751,13 +751,13 @@ impl<'a> _CCCLRW<'a> {
     }
     #[doc = "CSCEN is under software control."]
     #[inline]
-    pub fn cscen_is_under_softw(self) -> &'a mut W {
-        self.variant(CCCLRW::CSCEN_IS_UNDER_SOFTW)
+    pub fn software(self) -> &'a mut W {
+        self.variant(CCCLRW::SOFTWARE)
     }
     #[doc = "Hardware clears CSCEN after each character is received."]
     #[inline]
-    pub fn hardware_clears_csce(self) -> &'a mut W {
-        self.variant(CCCLRW::HARDWARE_CLEARS_CSCE)
+    pub fn hardware(self) -> &'a mut W {
+        self.variant(CCCLRW::HARDWARE)
     }
     #[doc = r" Sets the field bit"]
     pub fn set_bit(self) -> &'a mut W {

--- a/lpc11uxx/src/usb/devcmdstat.rs
+++ b/lpc11uxx/src/usb/devcmdstat.rs
@@ -146,9 +146,9 @@ impl PLL_ONR {
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum LPM_SUPR {
     #[doc = "LPM not supported."]
-    LPM_NOT_SUPPORTED_,
+    NOT_SUPPORTED,
     #[doc = "LPM supported."]
-    LPM_SUPPORTED_,
+    SUPPORTED,
 }
 impl LPM_SUPR {
     #[doc = r" Returns `true` if the bit is clear (0)"]
@@ -165,8 +165,8 @@ impl LPM_SUPR {
     #[inline]
     pub fn bit(&self) -> bool {
         match *self {
-            LPM_SUPR::LPM_NOT_SUPPORTED_ => false,
-            LPM_SUPR::LPM_SUPPORTED_ => true,
+            LPM_SUPR::NOT_SUPPORTED => false,
+            LPM_SUPR::SUPPORTED => true,
         }
     }
     #[allow(missing_docs)]
@@ -174,19 +174,19 @@ impl LPM_SUPR {
     #[inline]
     pub fn _from(value: bool) -> LPM_SUPR {
         match value {
-            false => LPM_SUPR::LPM_NOT_SUPPORTED_,
-            true => LPM_SUPR::LPM_SUPPORTED_,
+            false => LPM_SUPR::NOT_SUPPORTED,
+            true => LPM_SUPR::SUPPORTED,
         }
     }
-    #[doc = "Checks if the value of the field is `LPM_NOT_SUPPORTED_`"]
+    #[doc = "Checks if the value of the field is `NOT_SUPPORTED`"]
     #[inline]
-    pub fn is_lpm_not_supported_(&self) -> bool {
-        *self == LPM_SUPR::LPM_NOT_SUPPORTED_
+    pub fn is_not_supported(&self) -> bool {
+        *self == LPM_SUPR::NOT_SUPPORTED
     }
-    #[doc = "Checks if the value of the field is `LPM_SUPPORTED_`"]
+    #[doc = "Checks if the value of the field is `SUPPORTED`"]
     #[inline]
-    pub fn is_lpm_supported_(&self) -> bool {
-        *self == LPM_SUPR::LPM_SUPPORTED_
+    pub fn is_supported(&self) -> bool {
+        *self == LPM_SUPR::SUPPORTED
     }
 }
 #[doc = "Possible values of the field `INTONNAK_AO`"]
@@ -667,9 +667,9 @@ impl<'a> _PLL_ONW<'a> {
 #[doc = "Values that can be written to the field `LPM_SUP`"]
 pub enum LPM_SUPW {
     #[doc = "LPM not supported."]
-    LPM_NOT_SUPPORTED_,
+    NOT_SUPPORTED,
     #[doc = "LPM supported."]
-    LPM_SUPPORTED_,
+    SUPPORTED,
 }
 impl LPM_SUPW {
     #[allow(missing_docs)]
@@ -677,8 +677,8 @@ impl LPM_SUPW {
     #[inline]
     pub fn _bits(&self) -> bool {
         match *self {
-            LPM_SUPW::LPM_NOT_SUPPORTED_ => false,
-            LPM_SUPW::LPM_SUPPORTED_ => true,
+            LPM_SUPW::NOT_SUPPORTED => false,
+            LPM_SUPW::SUPPORTED => true,
         }
     }
 }
@@ -696,13 +696,13 @@ impl<'a> _LPM_SUPW<'a> {
     }
     #[doc = "LPM not supported."]
     #[inline]
-    pub fn lpm_not_supported_(self) -> &'a mut W {
-        self.variant(LPM_SUPW::LPM_NOT_SUPPORTED_)
+    pub fn not_supported(self) -> &'a mut W {
+        self.variant(LPM_SUPW::NOT_SUPPORTED)
     }
     #[doc = "LPM supported."]
     #[inline]
-    pub fn lpm_supported_(self) -> &'a mut W {
-        self.variant(LPM_SUPW::LPM_SUPPORTED_)
+    pub fn supported(self) -> &'a mut W {
+        self.variant(LPM_SUPW::SUPPORTED)
     }
     #[doc = r" Sets the field bit"]
     pub fn set_bit(self) -> &'a mut W {

--- a/lpc11uxx/src/wwdt/clksel.rs
+++ b/lpc11uxx/src/wwdt/clksel.rs
@@ -48,7 +48,7 @@ pub enum CLKSELR {
     #[doc = "IRC"]
     IRC,
     #[doc = "Watchdog oscillator (WDOSC)"]
-    WATCHDOG_OSCILLATOR_,
+    WATCHDOG_OSCILLATOR,
 }
 impl CLKSELR {
     #[doc = r" Returns `true` if the bit is clear (0)"]
@@ -66,7 +66,7 @@ impl CLKSELR {
     pub fn bit(&self) -> bool {
         match *self {
             CLKSELR::IRC => false,
-            CLKSELR::WATCHDOG_OSCILLATOR_ => true,
+            CLKSELR::WATCHDOG_OSCILLATOR => true,
         }
     }
     #[allow(missing_docs)]
@@ -75,7 +75,7 @@ impl CLKSELR {
     pub fn _from(value: bool) -> CLKSELR {
         match value {
             false => CLKSELR::IRC,
-            true => CLKSELR::WATCHDOG_OSCILLATOR_,
+            true => CLKSELR::WATCHDOG_OSCILLATOR,
         }
     }
     #[doc = "Checks if the value of the field is `IRC`"]
@@ -83,10 +83,10 @@ impl CLKSELR {
     pub fn is_irc(&self) -> bool {
         *self == CLKSELR::IRC
     }
-    #[doc = "Checks if the value of the field is `WATCHDOG_OSCILLATOR_`"]
+    #[doc = "Checks if the value of the field is `WATCHDOG_OSCILLATOR`"]
     #[inline]
-    pub fn is_watchdog_oscillator_(&self) -> bool {
-        *self == CLKSELR::WATCHDOG_OSCILLATOR_
+    pub fn is_watchdog_oscillator(&self) -> bool {
+        *self == CLKSELR::WATCHDOG_OSCILLATOR
     }
 }
 #[doc = r" Value of the field"]
@@ -115,7 +115,7 @@ pub enum CLKSELW {
     #[doc = "IRC"]
     IRC,
     #[doc = "Watchdog oscillator (WDOSC)"]
-    WATCHDOG_OSCILLATOR_,
+    WATCHDOG_OSCILLATOR,
 }
 impl CLKSELW {
     #[allow(missing_docs)]
@@ -124,7 +124,7 @@ impl CLKSELW {
     pub fn _bits(&self) -> bool {
         match *self {
             CLKSELW::IRC => false,
-            CLKSELW::WATCHDOG_OSCILLATOR_ => true,
+            CLKSELW::WATCHDOG_OSCILLATOR => true,
         }
     }
 }
@@ -147,8 +147,8 @@ impl<'a> _CLKSELW<'a> {
     }
     #[doc = "Watchdog oscillator (WDOSC)"]
     #[inline]
-    pub fn watchdog_oscillator_(self) -> &'a mut W {
-        self.variant(CLKSELW::WATCHDOG_OSCILLATOR_)
+    pub fn watchdog_oscillator(self) -> &'a mut W {
+        self.variant(CLKSELW::WATCHDOG_OSCILLATOR)
     }
     #[doc = r" Sets the field bit"]
     pub fn set_bit(self) -> &'a mut W {


### PR DESCRIPTION
Lots of manual work, but should make the user experience much better.

(The NXP SVD files are obviously autogenerated from the description or some internal data, I don't think there's much we can do to automate this work.)