### PR TITLE
Make generate.sh work when called from subdir

### DIFF
--- a/generate.sh
+++ b/generate.sh
@@ -17,6 +17,9 @@ PACS=(
     lpc176x5x
 )
 
+# everything is relativ to the generate script
+cd $(dirname $0)
+
 
 ### Helper functions
 


### PR DESCRIPTION
generate.sh assumes it is called from the directory it is in. By just
changing to that directory we allow to call it from a subdirectory with
`../generate.sh`.