### PR TITLE
Update reference to Braun Robotics

### DIFF
--- a/lpc82x/README.md
+++ b/lpc82x/README.md
@@ -57,7 +57,7 @@ This project is open source software, licensed under the terms of the [Zero Clau
 See [LICENSE] for full details.
 
 
-**Supported by [Braun Robotics]**
+**Supported by [Braun Embedded]**
 
 
 [Rust]: https://www.rust-lang.org/
@@ -76,4 +76,4 @@ See [LICENSE] for full details.
 [rustfmt]: https://crates.io/crates/rustfmt
 [Zero Clause BSD License]: https://opensource.org/licenses/FPL-1.0.0
 [LICENSE]: https://github.com/lpc-rs/lpc-pac/blob/master/lpc82x/LICENSE
-[Braun Robotics]: https://braun-robotics.com/
+[Braun Embedded]: https://braun-embedded.com/


### PR DESCRIPTION
This reference originally appeared in my lpc82x-pac repository, and has been kept when everything moved here. The reference has become outdated, due to a recent rename.

@lpc-rs/all I'd like to run this by you, since we never talked about where lpc-rs stands regarding commercial support and advertising for commercial entities, which this basically is.

My position is, that it should be okay to keep references like this in crates that originated somewhere else and where moved to the organization. We might want to have a broader discussion about the topic at some point.