### PR TITLE
Release `lpc845-pac` version 0.3.0

### DIFF
--- a/lpc845/CHANGELOG.md
+++ b/lpc845/CHANGELOG.md
@@ -1,3 +1,13 @@
+<a name="v0.3.0"></a>
+## v0.3.0 (2019-11-06)
+
+- Fix register value name in WKT.CTRL ([#43])
+- Fix access to STAT register in USART peripheral ([#44])
+
+[#43]: https://github.com/lpc-rs/lpc-pac/pull/43
+[#44]: https://github.com/lpc-rs/lpc-pac/pull/44
+
+
 <a name="v0.2.0"></a>
 ## v0.2.0 (2019-10-11)
 

--- a/lpc845/Cargo.toml
+++ b/lpc845/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name    = "lpc845-pac"
 version = "0.2.0"
-authors = ["David Sawatke <d-lpc@sawatzke.dev>"]
+authors = ["David Sawatzke <d-lpc@sawatzke.dev>"]
 
 description   = "Low-level register mappings for the NXP LPC845 series of ARM Cortex-M0+ microcontrollers"
 documentation = "https://docs.rs/lpc845-pac"

--- a/lpc845/Cargo.toml
+++ b/lpc845/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name    = "lpc845-pac"
-version = "0.2.0"
+version = "0.3.0"
 authors = ["David Sawatzke <d-lpc@sawatzke.dev>"]
 
 description   = "Low-level register mappings for the NXP LPC845 series of ARM Cortex-M0+ microcontrollers"

--- a/lpc845/README.md
+++ b/lpc845/README.md
@@ -39,13 +39,6 @@ Another problem that we inherit from the SVD file is that some register and fiel
 
 At this point, there is no guarantee of API stability. This means that we reserve the right to make changes to the API, that might break existing programs when they upgrade.
 
-## Update Procedure
-
-The repository contains an [update script], that can be used to re-generate the source code. This script updates all required tools ([svd2rust] and [rustfmt]), copies the SVD file, applies various patches to it, and then re-generates the code.
-
-The patches that are applied to the SVD file are relatively minimal, and are just intended to fix various problems with the file that otherwise would prevent code generation, or would lead to incorrect code being generated.
-
-
 ## License
 
 This project is open source software, licensed under the terms of the [Zero Clause BSD License][Zero Clause BSD License] (0BSD, for short). This basically means you can do anything with the software, without any restrictions, but you can't hold the authors liable for problems.


### PR DESCRIPTION
I'm currently working on porting the USART module in `lpc8xx-hal` to LPC845, and that requires the recent fix to the STAT register.

@david-sawatzke Please let me know what you think. If you're happy with the changes in this pull request, I'll publish the release.