### PR TITLE
Allow PACs to depend on cortex-m-rt v0.7

### DIFF
--- a/lpc11uxx/Cargo.toml
+++ b/lpc11uxx/Cargo.toml
@@ -20,7 +20,7 @@ vcell = "0.1"
 
 [dependencies.cortex-m-rt]
 optional = true
-version = "0.6"
+version = ">=0.6, <0.8"
 
 [features]
 rt = ["cortex-m-rt/device"]

--- a/lpc54606/Cargo.toml
+++ b/lpc54606/Cargo.toml
@@ -19,7 +19,7 @@ travis-ci = { repository = "lpc-rs/lpc-pac" }
 
 [dependencies]
 cortex-m    = "0.7.2"
-cortex-m-rt = { version = "0.6.12", optional = true }
+cortex-m-rt = { version = ">=0.6, <0.8", optional = true }
 vcell       = "0.1.2"
 
 

--- a/lpc54608/Cargo.toml
+++ b/lpc54608/Cargo.toml
@@ -18,7 +18,7 @@ cortex-m = "0.7.0"
 
 [dependencies.cortex-m-rt]
 optional = true
-version = "0.6.11"
+version = ">=0.6, <0.8"
 
 
 [features]

--- a/lpc82x/Cargo.toml
+++ b/lpc82x/Cargo.toml
@@ -19,7 +19,7 @@ travis-ci   = { repository = "lpc-rs/lpc-pac" }
 
 [dependencies]
 cortex-m    = "0.7.2"
-cortex-m-rt = { version = "0.6.10", optional = true }
+cortex-m-rt = { version = ">=0.6, <0.8", optional = true }
 vcell       = "0.1.2"
 
 

--- a/lpc845/Cargo.toml
+++ b/lpc845/Cargo.toml
@@ -19,7 +19,7 @@ travis-ci   = { repository = "lpc-rs/lpc-pac" }
 
 [dependencies]
 cortex-m    = "0.7.2"
-cortex-m-rt = { version = "0.6.10", optional = true }
+cortex-m-rt = { version = ">=0.6, <0.8", optional = true }
 vcell       = "0.1.2"
 
 


### PR DESCRIPTION
As far as I can tell, the [breaking changes][1] don't affect the PACs,
and indeed, they build with both versions. This will allow downstream
dependencies to upgrade their own dependency on cortex-m-rt, without
causing disruption for those who don't want to.

[1]: https://github.com/rust-embedded/cortex-m-rt/blob/master/CHANGELOG.md#v070