### PR TITLE
Release new versions of LPC8xx PACs

### DIFF
--- a/lpc82x/CHANGELOG.md
+++ b/lpc82x/CHANGELOG.md
@@ -1,3 +1,12 @@
+## 0.8.1 (2021-09-23)
+
+- Allow using cortex-m-rt 0.6 or 0.7 ([#60])
+- Re-generate with svd2rust 0.19 ([#61])
+
+[#60]: https://github.com/lpc-rs/lpc-pac/pull/60
+[#61]: https://github.com/lpc-rs/lpc-pac/pull/61
+
+
 ## 0.8.0 (2021-04-24)
 
 - Upgrade to 2018 edition

--- a/lpc82x/Cargo.toml
+++ b/lpc82x/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name    = "lpc82x-pac"
-version = "0.8.0"
+version = "0.8.1"
 authors = ["Hanno Braun <hanno@braun-embedded.com>"]
 edition = "2018"
 

--- a/lpc845/CHANGELOG.md
+++ b/lpc845/CHANGELOG.md
@@ -1,3 +1,12 @@
+## 0.4.1 (2021-09-23)
+
+- Allow using cortex-m-rt 0.6 or 0.7 ([#60])
+- Re-generate with svd2rust 0.19 ([#61])
+
+[#60]: https://github.com/lpc-rs/lpc-pac/pull/60
+[#61]: https://github.com/lpc-rs/lpc-pac/pull/61
+
+
 ## 0.4.0 (2021-04-24)
 
 - Upgrade to 2018 edition

--- a/lpc845/Cargo.toml
+++ b/lpc845/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name    = "lpc845-pac"
-version = "0.4.0"
+version = "0.4.1"
 authors = ["David Sawatzke <d-lpc@sawatzke.dev>"]
 edition = "2018"
 


### PR DESCRIPTION
None of the change seems to have been breaking (all of the svd2rust 0.19 changes were trivial), so these are just point releases.

Requirements for getting this done:
- @david-sawatzke:
  - [x] Review/approve this pull request.
- @hannobraun:
  - [x] Update dates for new versions in the changelogs.
  - [x] Publish new versions.
  - [x] Merge this pull request.