### PR TITLE
lpc546xx: fix CRC engine to add 8b and 16b access to data write

### DIFF
--- a/.github/workflows/mmaps_pr.yaml
+++ b/.github/workflows/mmaps_pr.yaml
@@ -52,11 +52,13 @@ jobs:
           COMMIT=$(git rev-parse --short HEAD)
           BRANCH=pr-${{ github.event.number }}-$COMMIT
           echo "BRANCH=$BRANCH" >> $GITHUB_ENV
+          
           # Use the PR's YAML files to rebuild mmaps
           cd ../master
-          rm -rf devices
-          mv ../pr/devices .
+          rm -rf devices peripherals
+          mv ../pr/devices ../pr/peripherals .
           make -j2 mmaps
+
           # Use the new mmaps to make a commit in the mmaps repo
           mv mmaps/* ../mmaps/
           cd ../mmaps

--- a/devices/lpc54605.yaml
+++ b/devices/lpc54605.yaml
@@ -2,3 +2,4 @@ _svd: ../svd/lpc54605.svd
 
 _include:
   - ./common_patches/fix_usart_access_STAT_accesses.yaml
+  - ../peripherals/crc/crc_engine.yaml

--- a/devices/lpc54606.yaml
+++ b/devices/lpc54606.yaml
@@ -2,3 +2,4 @@ _svd: ../svd/lpc54606.svd
 
 _include:
   - ./common_patches/fix_usart_access_STAT_accesses.yaml
+  - ../peripherals/crc/crc_engine.yaml

--- a/devices/lpc54607.yaml
+++ b/devices/lpc54607.yaml
@@ -2,3 +2,4 @@ _svd: ../svd/lpc54607.svd
 
 _include:
   - ./common_patches/fix_usart_access_STAT_accesses.yaml
+  - ../peripherals/crc/crc_engine.yaml

--- a/devices/lpc54608.yaml
+++ b/devices/lpc54608.yaml
@@ -2,3 +2,4 @@ _svd: ../svd/lpc54608.svd
 
 _include:
   - ./common_patches/fix_usart_access_STAT_accesses.yaml
+  - ../peripherals/crc/crc_engine.yaml

--- a/devices/lpc54616.yaml
+++ b/devices/lpc54616.yaml
@@ -2,3 +2,4 @@ _svd: ../svd/lpc54616.svd
 
 _include:
   - ./common_patches/fix_usart_access_STAT_accesses.yaml
+  - ../peripherals/crc/crc_engine.yaml

--- a/devices/lpc54618.yaml
+++ b/devices/lpc54618.yaml
@@ -2,3 +2,4 @@ _svd: ../svd/lpc54618.svd
 
 _include:
   - ./common_patches/fix_usart_access_STAT_accesses.yaml
+  - ../peripherals/crc/crc_engine.yaml

--- a/devices/lpc54628.yaml
+++ b/devices/lpc54628.yaml
@@ -2,3 +2,4 @@ _svd: ../svd/lpc54628.svd
 
 _include:
   - ./common_patches/fix_usart_access_STAT_accesses.yaml
+  - ../peripherals/crc/crc_engine.yaml

--- a/peripherals/crc/crc_engine.yaml
+++ b/peripherals/crc/crc_engine.yaml
@@ -1,0 +1,82 @@
+CRC_ENGINE:
+  _modify:
+    MODE:
+      description: "CRC mode"
+      addressOffset: 0x0
+      access: read-write
+      resetValue: 0x0
+      fields:
+        CRC_POLY: 
+          description: "CRC polynomial"
+          bitOffset: 0
+          bitWidth: 2
+          CRC_32: [0b10, CRC-32 polynomial]
+          CRC_16: [0b01, CRC-16 polynomial]
+          CRC_CCITT: [0b00, CRC-CCITT polynomial]
+
+        BIT_RVS_DATA:
+          description: "Data bit order"
+          bitOffset: 2
+          bitWidth: 1
+          REVERSE: [0b1, Reverse data bits per byte]
+          NORMAL: [0b0, no reverse for data]
+
+        CMPL_DATA:
+          description: "Data complement"
+          bitOffset: 3
+          bitWidth: 1
+          COMPLEMENT: [0b1, "1's complement for data bits"]
+          NORMAL: [0b0, "no complement for data bits"]
+
+        BIT_RVS_SUM:
+          description: "Sum bit order"
+          bitOffset: 4
+          bitWidth: 1
+          REVERSE: [0b1, Reverse sum bits per byte]
+          NORMAL: [0b0, no reverse for sum]
+
+        CMPL_SUM:
+          description: "Sum complement"
+          bitOffset: 5
+          bitWidth: 1
+          COMPLEMENT: [0b1, "1's complement for sum bits"]
+          NORMAL: [0b0, "no complement for sum bits"]
+
+    SEED:
+      description: "CRC seed"
+      addressOffset: 0x4
+      access: read-write
+      resetValue: 0x0000FFFF
+      fields:
+        CRC_SEED:
+          description: "A write access to this register will load CRC seed value to CRC_SUM register with selected bit order and 1’s complement pre-processes.. Remark: A write access to this register will overrule the CRC calculation in progresses."
+          bitOffset: 0
+          bitWidth: 32
+
+    SUM:
+      name: SUM
+      alternateGroup: ""
+      description: "The most recent CRC sum can be read through this register with selected bit order and 1’s complement post-processes."
+      addressOffset: 0x8
+      access: read-only
+      resetValue: 0x0000FFFF
+
+    WR_DATA:
+      name: DATA
+      alternateGroup: ""
+      description: "Data written to this register will be taken to perform CRC calculation with selected bit order and 1’s complement pre-process. Any write size 8, 16 or 32-bit are allowed and accept back-to-back transactions."
+      addressOffset: 0x8
+      access: write-only
+      fields:
+        DATA8:
+          description: "8 bit access"
+          bitOffset: 0
+          bitWidth: 8
+        DATA16:
+          description: "16 bit access"
+          bitOffset: 0
+          bitWidth: 16
+        DATA32:
+          description: "32 bit access"
+          bitOffset: 0
+          bitWidth: 32 


### PR DESCRIPTION
the previous register only had a 32 bit access, messing up byte access for CRC.